### PR TITLE
NEXTEUROPA-5610: Specific settings needed to use 2nd-language negotia…

### DIFF
--- a/profiles/common/modules/custom/language_selector_page/language_selector_page.info
+++ b/profiles/common/modules/custom/language_selector_page/language_selector_page.info
@@ -5,5 +5,6 @@ dependencies[] = entity_translation
 dependencies[] = splash_screen
 
 version = "7.x-1.0"
+core = "7.x"
 project = "language_selector_page"
 datestamp = "1427356701"

--- a/profiles/common/modules/custom/language_selector_page/language_selector_page.module
+++ b/profiles/common/modules/custom/language_selector_page/language_selector_page.module
@@ -50,7 +50,6 @@ function language_selector_page_block_content() {
       // Initialize variables.
       $is_available = FALSE;
       $not_available = '';
-      $served = '';
       $other = array();
 
       // Get currently served language.

--- a/profiles/common/modules/custom/language_selector_page/language_selector_page_settings/language_selector_page_settings.features.inc
+++ b/profiles/common/modules/custom/language_selector_page/language_selector_page_settings/language_selector_page_settings.features.inc
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @file
+ * language_selector_page_settings.features.inc
+ */
+
+/**
+ * Implements hook_ctools_plugin_api().
+ */
+function language_selector_page_settings_ctools_plugin_api($module = NULL, $api = NULL) {
+  if ($module == "strongarm" && $api == "strongarm") {
+    return array("version" => "1");
+  }
+}

--- a/profiles/common/modules/custom/language_selector_page/language_selector_page_settings/language_selector_page_settings.info
+++ b/profiles/common/modules/custom/language_selector_page/language_selector_page_settings/language_selector_page_settings.info
@@ -1,0 +1,13 @@
+name = Language Selector Page Settings
+description = Sets '2nd-language' for content language negotiation.
+core = 7.x
+package = Nexteuropa Digital Transformation
+version = 7.x-1.0
+project = language_selector_page_settings
+dependencies[] = ctools
+dependencies[] = strongarm
+features[ctools][] = strongarm:strongarm:1
+features[features_api][] = api:2
+features[variable][] = language_default
+features[variable][] = locale_language_negotiation_session_param
+features[variable][] = locale_language_providers_weight_language_content

--- a/profiles/common/modules/custom/language_selector_page/language_selector_page_settings/language_selector_page_settings.install
+++ b/profiles/common/modules/custom/language_selector_page/language_selector_page_settings/language_selector_page_settings.install
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Implements installation/uninstallation functions.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function language_selector_page_settings_install() {
+}
+
+/**
+ * Implements hook_enable().
+ */
+function language_selector_page_settings_enable() {
+}
+
+/**
+ * Implements hook_disable().
+ */
+function language_selector_page_settings_disable() {
+}
+
+
+/**
+ * Implements hook_uninstall().
+ */
+function language_selector_page_settings_uninstall() {
+  $path = drupal_get_path('module', 'language_selector_page_settings') . '/language_selector_page_settings.info';
+  $info = drupal_parse_info_file($path);
+  drupal_set_message(t('language_selector_page_settings %v feature is uninstalled on your site.', array('%v' => $info['version'])));
+}

--- a/profiles/common/modules/custom/language_selector_page/language_selector_page_settings/language_selector_page_settings.module
+++ b/profiles/common/modules/custom/language_selector_page/language_selector_page_settings/language_selector_page_settings.module
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @file
+ * Code for the Language Selector Page Settings feature.
+ */
+
+include_once 'language_selector_page_settings.features.inc';

--- a/profiles/common/modules/custom/language_selector_page/language_selector_page_settings/language_selector_page_settings.strongarm.inc
+++ b/profiles/common/modules/custom/language_selector_page/language_selector_page_settings/language_selector_page_settings.strongarm.inc
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @file
+ * language_selector_page_settings.strongarm.inc
+ */
+
+/**
+ * Implements hook_strongarm().
+ */
+function language_selector_page_settings_strongarm() {
+  $export = array();
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'language_default';
+  $strongarm->value = (object) array(
+    'language' => 'en',
+    'name' => 'English',
+    'native' => 'English',
+    'direction' => '0',
+    'enabled' => 1,
+    'plurals' => '0',
+    'formula' => '',
+    'domain' => '',
+    'prefix' => 'en',
+    'weight' => -14,
+    'javascript' => '',
+  );
+  $export['language_default'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'locale_language_negotiation_session_param';
+  $strongarm->value = '2nd-language';
+  $export['locale_language_negotiation_session_param'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'locale_language_providers_weight_language_content';
+  $strongarm->value = array(
+    'locale-session' => '-10',
+    'nexteuropa_multilingual_url_suffix' => '-8',
+    'language-default' => '-9',
+    'locale-interface' => '-7',
+    'locale-url' => '-6',
+    'language_cookie' => '-5',
+    'locale-user' => '-4',
+    'locale-browser' => '-3',
+  );
+  $export['locale_language_providers_weight_language_content'] = $strongarm;
+
+  return $export;
+}


### PR DESCRIPTION
The settings are added as a feature in the module, supposedly DT related, as this 2nd-language is still project specific.