### PR TITLE
NEXTEUROPA-5707: Adding a check for existing 2nd language argument

### DIFF
--- a/profiles/common/modules/custom/language_selector_page/language_selector_page.module
+++ b/profiles/common/modules/custom/language_selector_page/language_selector_page.module
@@ -50,14 +50,13 @@ function language_selector_page_block_content() {
       // Initialize variables.
       $is_available = FALSE;
       $not_available = '';
-      $served = '';
       $other = array();
 
       // Get currently served language.
       $args = func_get_args();
       $entity_type = array_shift($args);
       $entity = array_shift($args);
-      $served_code = entity_translation_get_existing_language($entity_type, $entity);
+      $served_code = (isset($_GET['2nd-language']) ? check_plain($_GET['2nd-language']) : entity_translation_get_existing_language($entity_type, $entity));
       $served = $languages[1][$served_code];
 
       // Check available translations.


### PR DESCRIPTION
When we have 2nd-language GET argument, language_selector_page should respect.

This is when it's not respected:
![not_respected](https://cloud.githubusercontent.com/assets/1923476/9993746/96a683e2-6079-11e5-9ed3-9c17316831d3.png)

And this is after it's respected:
![respected](https://cloud.githubusercontent.com/assets/1923476/9993750/9c995900-6079-11e5-82da-b9ca53075068.png)
