### PR TITLE
bugfix/MULTISITE-7351 - admin jquery minimum version

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.strongarm.inc
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.strongarm.inc
@@ -193,7 +193,7 @@ function cce_basic_config_strongarm() {
   $strongarm->disabled = FALSE;
   $strongarm->api_version = 1;
   $strongarm->name = 'jquery_update_jquery_admin_version';
-  $strongarm->value = '1.5';
+  $strongarm->value = '1.7';
   $export['jquery_update_jquery_admin_version'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
Right now, the cce_basic_config sets the "Alternate jQuery version for administrative pages" to 1.5. This is not compatible with the "add media" button from CKeditor. It should be at least 1.7