### PR TITLE
MULTISITE-7373 - Issue #2325549: AJAX doesn't work in jQuery 1.9+

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -220,8 +220,15 @@ projects[freepager][subdir] = "contrib"
 
 projects[fullcalendar][subdir] = "contrib"
 projects[fullcalendar][version] = "2.0"
-projects[fullcalendar][patch][] = patches/fullcalendar-ajax_date_format-2185449-11.patch
+; Issue #2185449: Using AJAX results in errors when scrolling through months
+; https://www.drupal.org/node/2185449
+projects[fullcalendar][patch][] = https://www.drupal.org/files/issues/ajax_date_format-2185449-11.patch
 projects[fullcalendar][patch][] = patches/fullcalendar-views_dom_id_check-1803770-4.patch
+; Issue #2325549: AJAX doesn't work in jQuery 1.9+
+; https://www.drupal.org/node/2325549
+; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-7373
+; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-7237
+projects[fullcalendar][patch][] = https://www.drupal.org/files/issues/2325549-jquery19_ajax.patch
 
 projects[geofield][subdir] = "contrib"
 projects[geofield][version] = "2.3"


### PR DESCRIPTION
Also replaced patches/fullcalendar-ajax_date_format-2185449-11.patch with the drupal org version.