### PR TITLE
Use travis to release builds on github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: php
+php:
+  - 5.6
+script:
+  - curl -sS https://getcomposer.org/installer | php
+  - ./composer.phar install -o --no-interaction --ansi --no-scripts --no-progress --no-dev
+  - ./bin/phing 'build-multisite-dist' -D'composer.bin'='./composer.phar'
+  - rm composer.phar
+  - tar cz build > next-europa-platform-${TRAVIS_TAG}.tar.gz
+  - ls -lha
+deploy:
+  skip_cleanup: true
+  provider: releases
+  api_key:
+    secure: mjJBmbunwTVl6xWVf+Un6aGEX0xKkAPy/wj75R9Uzhiy4UyvA5dULp8IbzavQvgniOYbunvCYYgswNcylUf7cfQlhoNfRcT+E0lvHH+BpHj5QdPdtaQTPzjkaFjcTL3fm1tZV+bPaWuvWjDiqClUnqMlmveH3JfB7BNNi8Ylr1vf64v9GHbDnxN0io2PO9eIQ7GyAuvliWan0l2HwOblp9r2UVQQCo9a/31Yhn7mp8X17OyEAyyB7vva6tswybzBAGCND/GtmMcFfSnWMUyI1opeJe7v04LPPh7HVfT3R/JtXjYUO7kEBKmXca8FptKTnGnB17FJMThiCAogTG1QjtCqe95kAhL2wJp8prpghuNmLYGbfDuFmJIQaA2C67VQCtHRKD2zhKLhW5zbH0YM2rg3A5trGU69hrE7uTYX65dyOldnEeBMZYRI9jeyNgdaWzGdreJaJOwKK/Yu+uAC1bBB9s814XbE72ZNpfTDrRyzMOP5NNwsTfLNipQCYEVLRk6mR8KV9pnnrnNfNr2hfomBRAtI6Q97td9VOREs3nVvTdYkTFQ+SNiWPtTYUmZnX/JxrrwkW4C2yNvubXF0uFZHxW66kQZM8PlMj6EO4rhKguBKPhIEioYOK1tT7IqL/RFH6B6cnWrFvmpCkoXwtWEETu5tky+0UpP0t3F4J+4=
+  file: next-europa-platform-${TRAVIS_TAG}.tar.gz 
+  on:
+    repo: ec-europa/platform-dev
+    tags: true


### PR DESCRIPTION
Once merged to develop, it will generate a package from the build folder when a new tag is pushed ( so after testing by cphp ) and publish it to the github releases page.

eg : https://github.com/ec-europa/platform-dev/releases/download/2.1.6/next-europa-platform-2.1.6.tar.gz

