### PR TITLE
NEXTEUROPA-6837: include language.inc in hook_update

### DIFF
--- a/profiles/common/modules/features/multisite_settings/multisite_settings_core/multisite_settings_core.install
+++ b/profiles/common/modules/features/multisite_settings/multisite_settings_core/multisite_settings_core.install
@@ -97,5 +97,6 @@ function multisite_settings_core_update_7123() {
   // DELETE FROM cache_variable;
   // DELETE FROM cache_bootstrap WHERE cid = 'variables';
   // @endcode
+  include_once DRUPAL_ROOT . '/includes/language.inc';
   language_types_set();
 }


### PR DESCRIPTION
to fix "Fatal error: Call to undefined function language_types_set()"