### PR TITLE
Get a builded 2.0 in github releases as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+composer.lock
+vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ script:
   - mkdir build
   - echo "Build multisite ${PROFILE}"
   - ./vendor/bin/drush --concurrency=10 --no-patch-txt --no-core --nocolor --root=$(pwd)/build --yes --pipe make $(pwd)/${MULTISITE_PROFILE} build
+  - ls build -lha
   - tar cz build > legacy-europa-platform-${PROFILE}-${TRAVIS_TAG}.tar.gz
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,29 @@ script:
   - curl -sS https://getcomposer.org/installer | php
   - ./composer.phar install -o --no-interaction --ansi --no-scripts --no-progress
   - echo "Build multisite ${PROFILE}"
-  - ./vendor/bin/drush --concurrency=10 --root=$(pwd)/build --yes --pipe make $(pwd)/${MULTISITE_PROFILE} build
-  - ls build -lha
+  - ./vendor/bin/drush --concurrency=10 --root=$(pwd)/build --yes --pipe make $(pwd)/profiles/${PROFILE}/build.make build
+  - rm build/*.patch
+  - rm build/{INSTALL.{mysql,pgsql,sqlite},CHANGELOG,UPGRADE}.txt
+  - cp -R "profiles/multisite_drupal_core" "build/profiles"
+  - cp -R "profiles/${PROFILE}" "build/profiles"
+  - cp -R "sites/all/modules/" "build/sites/all"
+  - cp -R "sites/all/themes" "build/sites/all"
+  - cp -R "sites/all/libraries" "build/sites/all"
+  - cp -R "sites/default/files/" "build/sites/default/files/"
+  - find build
   - tar cz build > legacy-europa-platform-${PROFILE}-${TRAVIS_TAG}.tar.gz
 deploy:
   skip_cleanup: true
   provider: releases
   api_key:
     secure: mjJBmbunwTVl6xWVf+Un6aGEX0xKkAPy/wj75R9Uzhiy4UyvA5dULp8IbzavQvgniOYbunvCYYgswNcylUf7cfQlhoNfRcT+E0lvHH+BpHj5QdPdtaQTPzjkaFjcTL3fm1tZV+bPaWuvWjDiqClUnqMlmveH3JfB7BNNi8Ylr1vf64v9GHbDnxN0io2PO9eIQ7GyAuvliWan0l2HwOblp9r2UVQQCo9a/31Yhn7mp8X17OyEAyyB7vva6tswybzBAGCND/GtmMcFfSnWMUyI1opeJe7v04LPPh7HVfT3R/JtXjYUO7kEBKmXca8FptKTnGnB17FJMThiCAogTG1QjtCqe95kAhL2wJp8prpghuNmLYGbfDuFmJIQaA2C67VQCtHRKD2zhKLhW5zbH0YM2rg3A5trGU69hrE7uTYX65dyOldnEeBMZYRI9jeyNgdaWzGdreJaJOwKK/Yu+uAC1bBB9s814XbE72ZNpfTDrRyzMOP5NNwsTfLNipQCYEVLRk6mR8KV9pnnrnNfNr2hfomBRAtI6Q97td9VOREs3nVvTdYkTFQ+SNiWPtTYUmZnX/JxrrwkW4C2yNvubXF0uFZHxW66kQZM8PlMj6EO4rhKguBKPhIEioYOK1tT7IqL/RFH6B6cnWrFvmpCkoXwtWEETu5tky+0UpP0t3F4J+4=
-  file: next-europa-platform-${TRAVIS_TAG}.tar.gz 
+  file: legacy-europa-platform-${PROFILE}-${TRAVIS_TAG}.tar.gz
   on:
     repo: ec-europa/platform-dev
     tags: true
 matrix:
   include:
-    - env: MULTISITE_PROFILE=profiles/multisite_drupal_communities/build.make PROFILE=community
-    - env: MULTISITE_PROFILE=profiles/multisite_drupal_standard/build.make PROFILE=publishing
+    - env: PROFILE=multisite_drupal_communities
+    - env: PROFILE=multisite_drupal_standard
   exclude:
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ script:
   - echo "Build multisite ${PROFILE}"
   - ./vendor/bin/drush --concurrency=10 --no-patch-txt --no-core --nocolor --root=$(pwd)/build --yes --pipe make /home/travis/build/ec-europa/platform-dev/resources/${MULTISITE_PROFILE}.make build
   - tar cz build > legacy-europa-platform-${PROFILE}-${TRAVIS_TAG}.tar.gz
-  - ls -lha
 deploy:
   skip_cleanup: true
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
   - ./composer.phar install -o --no-interaction --ansi --no-scripts --no-progress
   - mkdir build
   - echo "Build multisite ${PROFILE}"
-  - ./vendor/bin/drush --concurrency=10 --no-patch-txt --no-core --nocolor --root=$(pwd)/build --yes --pipe make /home/travis/build/ec-europa/platform-dev/resources/${MULTISITE_PROFILE}.make build
+  - ./vendor/bin/drush --concurrency=10 --no-patch-txt --no-core --nocolor --root=$(pwd)/build --yes --pipe make $(pwd)/${MULTISITE_PROFILE} build
   - tar cz build > legacy-europa-platform-${PROFILE}-${TRAVIS_TAG}.tar.gz
 deploy:
   skip_cleanup: true
@@ -18,5 +18,5 @@ deploy:
     tags: true
 matrix:
   include:
-    - env: MULTISITE_PROFILE=multisite_drupal_communities PROFILE=community
-    - env: MUTLSITE_PROFILE=multisite_drupal_standard PROFILE=publishing
+    - env: MULTISITE_PROFILE=profiles/multisite_drupal_communities/build.make PROFILE=community
+    - env: MUTLSITE_PROFILE=profiles/multisite_drupal_standard/build.make PROFILE=publishing

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
   - ./composer.phar install -o --no-interaction --ansi --no-scripts --no-progress
   - mkdir build
   - echo "Build multisite ${PROFILE}"
-  - ./vendor/bin/drush --concurrency=10 --no-patch-txt --no-core --nocolor --root=$(pwd)/build --yes --pipe make $(pwd)/${MULTISITE_PROFILE} build
+  - ./vendor/bin/drush --concurrency=10 --root=$(pwd)/build --yes --pipe make $(pwd)/${MULTISITE_PROFILE} build
   - ls build -lha
   - tar cz build > legacy-europa-platform-${PROFILE}-${TRAVIS_TAG}.tar.gz
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ script:
   - cp -R "sites/all/themes" "build/sites/all"
   - cp -R "sites/all/libraries" "build/sites/all"
   - cp -R "sites/default/files/" "build/sites/default/files/"
-  - find build
   - tar cz build > legacy-europa-platform-${PROFILE}-${TRAVIS_TAG}.tar.gz
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ php:
   - 5.6
 script:
   - curl -sS https://getcomposer.org/installer | php
-  - ./composer.phar install -o --no-interaction --ansi --no-scripts --no-progress --no-dev
-  - ./bin/phing 'build-multisite-dist' -D'composer.bin'='./composer.phar'
-  - rm composer.phar
-  - tar cz build > next-europa-platform-${TRAVIS_TAG}.tar.gz
+  - ./composer.phar install -o --no-interaction --ansi --no-scripts --no-progress
+  - mkdir build
+  - echo "Build multisite ${PROFILE}"
+  - ./vendor/bin/drush --concurrency=10 --no-patch-txt --no-core --nocolor --root=$(pwd)/build --yes --pipe make /home/travis/build/ec-europa/platform-dev/resources/${MULTISITE_PROFILE}.make build
+  - tar cz build > legacy-europa-platform-${PROFILE}-${TRAVIS_TAG}.tar.gz
   - ls -lha
 deploy:
   skip_cleanup: true
@@ -17,3 +18,7 @@ deploy:
   on:
     repo: ec-europa/platform-dev
     tags: true
+matrix:
+  include:
+    - env: MULTISITE_PROFILE=multisite_drupal_communities PROFILE=community
+    - env: MUTLSITE_PROFILE=multisite_drupal_standard PROFILE=publishing

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,5 @@ matrix:
   include:
     - env: MULTISITE_PROFILE=profiles/multisite_drupal_communities/build.make PROFILE=community
     - env: MUTLSITE_PROFILE=profiles/multisite_drupal_standard/build.make PROFILE=publishing
+  exclude:
+    - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
-php:
-  - 5.6
+php: 5.6
 script:
   - curl -sS https://getcomposer.org/installer | php
   - ./composer.phar install -o --no-interaction --ansi --no-scripts --no-progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: php
+php:
+  - 5.6
+script:
+  - curl -sS https://getcomposer.org/installer | php
+  - ./composer.phar install -o --no-interaction --ansi --no-scripts --no-progress --no-dev
+  - ./bin/phing 'build-multisite-dist' -D'composer.bin'='./composer.phar'
+  - rm composer.phar
+  - tar cz build > next-europa-platform-${TRAVIS_TAG}.tar.gz
+  - ls -lha
+deploy:
+  skip_cleanup: true
+  provider: releases
+  api_key:
+    secure: mjJBmbunwTVl6xWVf+Un6aGEX0xKkAPy/wj75R9Uzhiy4UyvA5dULp8IbzavQvgniOYbunvCYYgswNcylUf7cfQlhoNfRcT+E0lvHH+BpHj5QdPdtaQTPzjkaFjcTL3fm1tZV+bPaWuvWjDiqClUnqMlmveH3JfB7BNNi8Ylr1vf64v9GHbDnxN0io2PO9eIQ7GyAuvliWan0l2HwOblp9r2UVQQCo9a/31Yhn7mp8X17OyEAyyB7vva6tswybzBAGCND/GtmMcFfSnWMUyI1opeJe7v04LPPh7HVfT3R/JtXjYUO7kEBKmXca8FptKTnGnB17FJMThiCAogTG1QjtCqe95kAhL2wJp8prpghuNmLYGbfDuFmJIQaA2C67VQCtHRKD2zhKLhW5zbH0YM2rg3A5trGU69hrE7uTYX65dyOldnEeBMZYRI9jeyNgdaWzGdreJaJOwKK/Yu+uAC1bBB9s814XbE72ZNpfTDrRyzMOP5NNwsTfLNipQCYEVLRk6mR8KV9pnnrnNfNr2hfomBRAtI6Q97td9VOREs3nVvTdYkTFQ+SNiWPtTYUmZnX/JxrrwkW4C2yNvubXF0uFZHxW66kQZM8PlMj6EO4rhKguBKPhIEioYOK1tT7IqL/RFH6B6cnWrFvmpCkoXwtWEETu5tky+0UpP0t3F4J+4=
+  file: next-europa-platform-${TRAVIS_TAG}.tar.gz 
+  on:
+    repo: ec-europa/platform-dev
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ deploy:
 matrix:
   include:
     - env: MULTISITE_PROFILE=profiles/multisite_drupal_communities/build.make PROFILE=community
-    - env: MUTLSITE_PROFILE=profiles/multisite_drupal_standard/build.make PROFILE=publishing
+    - env: MULTISITE_PROFILE=profiles/multisite_drupal_standard/build.make PROFILE=publishing
   exclude:
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php: 5.6
 script:
   - curl -sS https://getcomposer.org/installer | php
   - ./composer.phar install -o --no-interaction --ansi --no-scripts --no-progress
-  - mkdir build
   - echo "Build multisite ${PROFILE}"
   - ./vendor/bin/drush --concurrency=10 --root=$(pwd)/build --yes --pipe make $(pwd)/${MULTISITE_PROFILE} build
   - ls build -lha

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "drush/drush": "dev-master"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "drush/drush": "8.0.*@beta"
+        "drush/drush": "^6"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "drush/drush": "dev-master"
+        "drush/drush": "^7.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "drush/drush": "^7.1"
+        "drush/drush": "8.0.*@beta"
     }
 }

--- a/profiles/drupal-org.make
+++ b/profiles/drupal-org.make
@@ -5,10 +5,10 @@ core = 7.x
 ; Temporary fix until Drupal.org add project tags back
 ; =============
 ;projects[drupal][type] = core
-;projects[drupal][version] = "7.35"
+;projects[drupal][version] = "7.41"
 
 projects[drupal][type] = core
-projects[drupal][version] = 7.35
+projects[drupal][version] = 7.41
 projects[drupal][download][type] = get
 projects[drupal][download][url] = http://ftp.drupal.org/files/projects/drupal-7.35.tar.gz
 

--- a/profiles/drupal-org.make
+++ b/profiles/drupal-org.make
@@ -5,10 +5,10 @@ core = 7.x
 ; Temporary fix until Drupal.org add project tags back
 ; =============
 ;projects[drupal][type] = core
-;projects[drupal][version] = "7.41"
+;projects[drupal][version] = "7.35"
 
 projects[drupal][type] = core
-projects[drupal][version] = 7.41
+projects[drupal][version] = 7.35
 projects[drupal][download][type] = get
 projects[drupal][download][url] = http://ftp.drupal.org/files/projects/drupal-7.41.tar.gz
 

--- a/profiles/drupal-org.make
+++ b/profiles/drupal-org.make
@@ -10,7 +10,7 @@ core = 7.x
 projects[drupal][type] = core
 projects[drupal][version] = 7.41
 projects[drupal][download][type] = get
-projects[drupal][download][url] = http://ftp.drupal.org/files/projects/drupal-7.35.tar.gz
+projects[drupal][download][url] = http://ftp.drupal.org/files/projects/drupal-7.41.tar.gz
 
 ; ====================
 ; Contributed modules

--- a/profiles/drupal-org.make
+++ b/profiles/drupal-org.make
@@ -10,7 +10,7 @@ core = 7.x
 projects[drupal][type] = core
 projects[drupal][version] = 7.35
 projects[drupal][download][type] = get
-projects[drupal][download][url] = http://ftp.drupal.org/files/projects/drupal-7.41.tar.gz
+projects[drupal][download][url] = http://ftp.drupal.org/files/projects/drupal-7.35.tar.gz
 
 ; ====================
 ; Contributed modules


### PR DESCRIPTION
Like :

https://github.com/ec-europa/platform-dev/releases/download/2.0.65/legacy-europa-platform-multisite_drupal_communities-2.0.65-1.tar.gz

https://github.com/ec-europa/platform-dev/releases/download/2.0.65/legacy-europa-platform-multisite_drupal_standard-2.0.65-1.tar.gz

This will also make sure buildable (not really tested) trough travis on pushes / pull-requests.