### PR TITLE
NEXTEUROPA-5585: Splash screen: Link to language versions does not work if language uses a custom prefix

### DIFF
--- a/profiles/common/modules/custom/multisite_drupal_language_negociation/multisite_drupal_language_negociation.install
+++ b/profiles/common/modules/custom/multisite_drupal_language_negociation/multisite_drupal_language_negociation.install
@@ -9,17 +9,17 @@
  * Implements hook_requirements().
  */
 function multisite_drupal_language_negociation_requirements() {
+  $requirements = [];
   if (module_exists('nexteuropa_multilingual')) {
     $t = get_t();
     $args = array('%module' => 'NextEuropa Multilingual');
-    return array(
-      'multisite_drupal_language_negociation_module_conflict' => array(
-        'title' => 'Multisite drupal language negociation',
-        'description' => $t('This module is not compatible with %module. Please disable that module first.', $args),
-        'severity' => REQUIREMENT_ERROR,
-      ),
-    );
+    $requirements['multisite_drupal_language_negociation_module_conflict'] = [
+      'title' => 'Multisite drupal language negociation',
+      'description' => $t('This module is not compatible with %module. Please disable that module first.', $args),
+      'severity' => REQUIREMENT_ERROR,
+    ];
   }
+  return $requirements;
 }
 
 /**

--- a/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.install
+++ b/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.install
@@ -8,17 +8,17 @@
   * Implements hook_requirements().
   */
 function nexteuropa_multilingual_requirements() {
+  $requirements = [];
   if (module_exists('multisite_drupal_language_negociation')) {
     $t = get_t();
     $args = array('%module' => 'Multisite Drupal Language Negociation');
-    return array(
-      'nexteuropa_multilingual_module_conflict' => array(
-        'title' => 'NextEuropa Multilingual',
-        'description' => $t('This module is not compatible with %module. Please disable that module first.', $args),
-        'severity' => REQUIREMENT_ERROR,
-      ),
-    );
+    $requirements['nexteuropa_multilingual_module_conflict'] = [
+      'title' => 'NextEuropa Multilingual',
+      'description' => $t('This module is not compatible with %module. Please disable that module first.', $args),
+      'severity' => REQUIREMENT_ERROR,
+    ];
   }
+  return $requirements;
 }
 
 /**

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -140,6 +140,12 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
    * @param TableNode $modules_table
    *   The table listing modules.
    *
+   * @return bool
+   *   Always returns TRUE.
+   *
+   * @throws \Exception
+   *   Thrown when a module does not exist.
+   *
    * @Given the/these module/modules is/are enabled
    */
   public function enableModule(TableNode $modules_table) {
@@ -197,10 +203,10 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   /**
    * Creates a language.
    *
-   * @Given the :language language is available
-   *
    * @param string $langcode
    *   The ISO code of the language to create.
+   *
+   * @Given the :language language is available
    */
   public function createLanguages($langcode) {
     $this->languageCreate((object) ['langcode' => $langcode]);

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -194,4 +194,16 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     }
   }
 
+  /**
+   * Creates a language.
+   *
+   * @Given the :language language is available
+   *
+   * @param string $langcode
+   *   The ISO code of the language to create.
+   */
+  public function createLanguages($langcode) {
+    $this->languageCreate((object) ['langcode' => $langcode]);
+  }
+
 }

--- a/tests/features/splash_screen.feature
+++ b/tests/features/splash_screen.feature
@@ -49,9 +49,6 @@ Feature: Splash Screen features
     And I should see the link "Deutsch"
     And I should not see "Български"
     And I should not see "Français"
-    # Clean up after the fact.
-    # @todo Remove this once NEXTEUROPA-5519 is in.
-    And I run drush "vdel" "splash_screen_blacklist --yes"
 
   Scenario: Being able to change the splash screen title
     Given I am logged in as a user with the 'administrator' role

--- a/tests/features/splash_screen.feature
+++ b/tests/features/splash_screen.feature
@@ -26,16 +26,18 @@ Feature: Splash Screen features
     And I should see the link "Български"
 
   @api
-  Scenario: Links on splash screen pages are correct
+  # Regression test for a bug that broke the Portuguese (pt-pt) link.
+  # See https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-5585
+  Scenario: Test language with a custom prefix
     Given I am logged in as a user with the 'administrator' role
-    When I go to "admin/config/regional/language/edit/fr"
-    And I fill in "edit-prefix" with "fr-prefix"
+    And the "pt-pt" language is available
+    When I go to "admin/config/regional/language/edit/pt-pt"
+    And I fill in "edit-prefix" with "pt"
     And I press the "Save language" button
-    And I go to "/"
-    Then I should see an "body.not-front.page-splash" element
-    And I should see the link "Français"
-    When I click "Français"
-    Then the url should match "(.*)fr-prefix(.*)"
+    When I go to "/"
+    Then I should see the link "Português"
+    When I click "Português"
+    Then the url should match "(.*)_pt"
 
   @api
   Scenario: Administrators can blacklisted languages for the splash screen page

--- a/tests/features/splash_screen.feature
+++ b/tests/features/splash_screen.feature
@@ -1,21 +1,20 @@
+@api
 Feature: Splash Screen features
   In order navigate on the site in my language of preference
   As a citizen of the European Union
   I want to be able to choose my language at my first site connection
-  
+
   Background:
     Given these modules are enabled
-      |modules|
-      |splash_screen|
+      | modules       |
+      | splash_screen |
     And these following languages are available:
       | languages |
       | en        |
       | de        |
       | fr        |
       | bg        |
-    And I run drush "vdel" "splash_screen_blacklist --yes"
 
-  @api
   Scenario: Users can access to splash screen pages
     Given I am an anonymous user
     When I go to "/"
@@ -25,7 +24,6 @@ Feature: Splash Screen features
     And I should see the link "Français"
     And I should see the link "Български"
 
-  @api
   # Regression test for a bug that broke the Portuguese (pt-pt) link.
   # See https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-5585
   Scenario: Test language with a custom prefix
@@ -39,7 +37,6 @@ Feature: Splash Screen features
     When I click "Português"
     Then the url should match "(.*)_pt"
 
-  @api
   Scenario: Administrators can blacklisted languages for the splash screen page
     Given I am logged in as a user with the 'administrator' role
     When I go to "admin/config/regional/splash_screen_settings"
@@ -52,3 +49,6 @@ Feature: Splash Screen features
     And I should see the link "Deutsch"
     And I should not see "Български"
     And I should not see "Français"
+    # Clean up after the fact.
+    # @todo Remove this once NEXTEUROPA-5519 is in.
+    And I run drush "vdel" "splash_screen_blacklist --yes"


### PR DESCRIPTION
https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-5585