### PR TITLE
MUTLISITE-7576 Create a views handler

### DIFF
--- a/profiles/common/modules/features/e_library/e_library_og/e_library_og.features.inc
+++ b/profiles/common/modules/features/e_library/e_library_og/e_library_og.features.inc
@@ -18,3 +18,10 @@ function e_library_og_ctools_plugin_api($module = NULL, $api = NULL) {
     return array("version" => "1");
   }
 }
+
+/**
+ * Implements hook_views_api().
+ */
+function e_library_og_views_api($module = NULL, $api = NULL) {
+  return array("api" => "3.0");
+}

--- a/profiles/common/modules/features/e_library/e_library_og/e_library_og.info
+++ b/profiles/common/modules/features/e_library/e_library_og/e_library_og.info
@@ -22,3 +22,7 @@ features[og_features_permission][] = node:community:update any document content
 features[og_features_permission][] = node:community:update own document content
 features[variable][] = pathauto_node_document_pattern
 files[] = tests/e_library_og.test
+files[] = e_library_og.views.inc
+
+; Views plugins
+files[] = views/e_library_og_plugin_argument_default_og_context_session.inc

--- a/profiles/common/modules/features/e_library/e_library_og/e_library_og.views.inc
+++ b/profiles/common/modules/features/e_library/e_library_og/e_library_og.views.inc
@@ -1,0 +1,21 @@
+<?php
+
+
+/**
+ * @file
+ * Provides support for the Views module.
+ */
+
+/**
+ * Implements hook_views_plugins().
+ */
+function e_library_og_views_plugins() {
+  return array(
+    'argument default' => array(
+      'e_library_og_context_session_groups' => array(
+        'title' => t('The user\'s session group context'),
+        'handler' => 'e_library_og_plugin_argument_default_og_context_session',
+      ),
+    ),
+  );
+}

--- a/profiles/common/modules/features/e_library/e_library_og/views/e_library_og_plugin_argument_default_og_context_session.inc
+++ b/profiles/common/modules/features/e_library/e_library_og/views/e_library_og_plugin_argument_default_og_context_session.inc
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Contains the user's session group context argument default plugin.
+ */
+
+/**
+ * The user's session group context argument default handler.
+ */
+class e_library_og_plugin_argument_default_og_context_session extends views_plugin_argument_default {
+
+  /**
+   * Return the user's session group context argument.
+   */
+  function get_argument() {
+    return isset($_SESSION['og_context']['gid']) ? $_SESSION['og_context']['gid'] : NULL;
+  }
+}


### PR DESCRIPTION
Hello@degliwe 

This views handler can be used instead of the pure PHP code in views for e_library feature. 
Someone just need to remove the pure PHP code from the feature and use this handler instead.

In this file (e_library_og.views_alter.inc):
----------------------------------------------------
Deleted these two lines:
$handler->display->display_options['arguments']['gid']['default_argument_type'] = 'php';
$handler->display->display_options['arguments']['gid']['default_argument_options']['code'] = 'return $_SESSION[\'og_context\'][\'gid\'];

Add this line:
$handler->display->display_options['arguments']['gid']['default_argument_type'] = 'e_library_og_plugin_argument_default_og_context_session';

As I told you, I tried it but (drush fd) says e_library_core is overridden...

https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-7576

 