### PR TITLE
MULTISITE-7873-geophp-lockdown

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -273,8 +273,10 @@ projects[fullcalendar][patch][] = https://www.drupal.org/files/issues/2325549-jq
 projects[geofield][subdir] = "contrib"
 projects[geofield][version] = "2.3"
 
+projects[geophp][download][branch] = 7.x-1.x
+projects[geophp][download][revision] = 2777c5e
+projects[geophp][download][type] = git
 projects[geophp][subdir] = "contrib"
-projects[geophp][version] = "1.x-dev"
 
 projects[hidden_captcha][subdir] = "contrib"
 projects[hidden_captcha][version] = "1.0"


### PR DESCRIPTION
Requested by customer developers to have a fixed/locked version of geophp 1.x-dev (IT IS A DEV VERSION). This module needs to be glued to a commit.