### PR TITLE
MULTISITE-8283-version-fix

### DIFF
--- a/profiles/common/themes/ec_resp/ec_resp.info
+++ b/profiles/common/themes/ec_resp/ec_resp.info
@@ -3,7 +3,7 @@ description = Responsive template with Europa banner
 package = Fpfis_cms_theme
 version = "7.x-2.1"
 core = "7.x"
-php = "5.2.4"
+php = "5.6.9"
 
 stylesheets[all][] = "css/ec_resp.css"
 stylesheets[print][] = "css/print.css"
@@ -34,7 +34,7 @@ settings[shortcut_module_link] = 0
 project = "drupal"
 datestamp = "1294208756"
 
-multisite_version = "2.0"
+multisite_version = "2.1"
 
 ; Define this theme as multisite base theme (used by multisite_dynamic_basetheme)
 multisite = "1"


### PR DESCRIPTION
```php = "5.2.4"```
This defines the minimum PHP version the theme will support but there were reports of not able to install the platform because the code uses new PHP syntax.


The line that produces the error is:
```
$form['search_input_group']['europa_search_submit']['#attributes']['class'] = array_merge(['search_input_group']['europa_search_submit']['#attributes']['class'], array('btn', 'btn-default'));
```