### PR TITLE
NEXTEUROPA-9797: Avoid using drupal_exit() in hook_boot() context.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_laco/src/LanguageCoverageService.php
+++ b/profiles/common/modules/custom/nexteuropa_laco/src/LanguageCoverageService.php
@@ -93,7 +93,7 @@ class LanguageCoverageService {
     }
 
     if ($this->hasStatus()) {
-      drupal_exit();
+      exit;
     }
   }
 
@@ -115,7 +115,7 @@ class LanguageCoverageService {
       else {
         $this->setStatus('404 Not found');
       }
-      drupal_exit();
+      exit;
     }
   }
 


### PR DESCRIPTION
https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-9797