### PR TITLE
NEXTEUROPA-11356: Adding patch for setting up default timeout for all…

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -37,6 +37,8 @@ projects[apachesolr][patch][] = https://www.drupal.org/files/apachesolr-multiple
 projects[apachesolr][patch][] = https://www.drupal.org/files/issues/apachesolr_search-overwritten_menu_items-2446419.patch
 ;https://www.drupal.org/node/2333447#comment-10826660
 projects[apachesolr][patch][] = https://www.drupal.org/files/issues/apachesolr-missing-tabs-2333447-10-D7.patch
+; Issue NEXTEUROPA-11356 - setting up default timeout value for drupal_http_request function (500 errors investigation).
+projects[apachesolr][patch][] = patches/apachesolr-changing_drupal_http_request_timeout_value.patch
 
 projects[apachesolr_attachments][subdir] = "contrib"
 projects[apachesolr_attachments][version] = "1.4"

--- a/resources/patches/apachesolr-changing_drupal_http_request_timeout_value.patch
+++ b/resources/patches/apachesolr-changing_drupal_http_request_timeout_value.patch
@@ -8,7 +8,7 @@ index e67f483..1bddfe0 100644
  
 +    // @todo: Remove after investigation of 500 errors - NEXTEUROPA-11356.
 +    // Warning 'timeout' is hardcoded for all of HTTP SOLR requests.
-+    $options['timeout'] = 25;
++    $options['timeout'] = 5;
      $result = drupal_http_request($url, $options);
  
      if (!isset($result->code) || $result->code < 0 || isset($result->error)) {

--- a/resources/patches/apachesolr-changing_drupal_http_request_timeout_value.patch
+++ b/resources/patches/apachesolr-changing_drupal_http_request_timeout_value.patch
@@ -1,0 +1,14 @@
+diff --git a/Drupal_Apache_Solr_Service.php b/Drupal_Apache_Solr_Service.php
+index e67f483..1bddfe0 100644
+--- a/Drupal_Apache_Solr_Service.php
++++ b/Drupal_Apache_Solr_Service.php
+@@ -552,6 +552,9 @@ class DrupalApacheSolrService implements DrupalApacheSolrServiceInterface {
+       $options['data'] = NULL;
+     }
+ 
++    // @todo: Remove after investigation of 500 errors - NEXTEUROPA-11356.
++    // Warning 'timeout' is hardcoded for all of HTTP SOLR requests.
++    $options['timeout'] = 25;
+     $result = drupal_http_request($url, $options);
+ 
+     if (!isset($result->code) || $result->code < 0 || isset($result->error)) {


### PR DESCRIPTION
Adding patch. After build no additional tasks are needed to make it work.
This is temporary solution to process with 500 errors investigation.