### PR TITLE
Bugfix/multisite 9994

### DIFF
--- a/profiles/common/themes/ec_resp/scripts/ec_resp.js
+++ b/profiles/common/themes/ec_resp/scripts/ec_resp.js
@@ -4,6 +4,23 @@
  */
 
 (function($){
+
+  Drupal.behaviors.ec_resp_anchors = {
+    attach: function(context, settings) {
+      // There are no attributes added to the anchors produced by ckeditor. So I can't think of a nicer way to do this.
+      $("a").each(function(index){
+        if($(this).attr("href") === undefined || $(this).attr("href") == '') {
+          if($(this).attr("id") == $(this).attr("name")) {
+            var header_height = ($('.navbar-collapse').height());
+            $(this).css('position', 'relative');
+            $(this).css('display', 'block');
+            $(this).css('top', -1 *header_height);
+          }
+        }
+      });
+    }
+  };
+
   // Drupal.behaviours
   // https://drupal.org/node/304258
   // http://blog.amazeelabs.com/en/drupal-behaviors-quick-how

--- a/profiles/common/themes/ec_resp/scripts/ec_resp.js
+++ b/profiles/common/themes/ec_resp/scripts/ec_resp.js
@@ -9,12 +9,12 @@
     attach: function(context, settings) {
       // There are no attributes added to the anchors produced by ckeditor. So I can't think of a nicer way to do this.
       $("a").each(function(index){
-        if($(this).attr("href") === undefined || $(this).attr("href") == '') {
-          if($(this).attr("id") == $(this).attr("name")) {
+        if ($(this).attr("href") === undefined || $(this).attr("href") == '') {
+          if ($(this).attr("id") == $(this).attr("name")) {
             var header_height = ($('.navbar-collapse').height());
             $(this).css('position', 'relative');
             $(this).css('display', 'block');
-            $(this).css('top', -1 *header_height);
+            $(this).css('top', -1 * header_height);
           }
         }
       });


### PR DESCRIPTION
This is to fix the problem described in https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-9994

When anchor texts are added into article text the link is not playing nicely. 

Doing it this way doesn't feel ideal, but should work for anchors that already exist on the site. Which don't have any classes attached to them due to the way ckeditor works.
