### PR TITLE
Added dependency on multisite_drupal_toolbox

### DIFF
--- a/profiles/common/modules/custom/language_selector_page/language_selector_page.info
+++ b/profiles/common/modules/custom/language_selector_page/language_selector_page.info
@@ -2,5 +2,6 @@ name = Language selector (Page)
 description = Manage language selector at page level.
 core = 7.x
 dependencies[] = entity_translation
+dependencies[] = multisite_drupal_toolbox
 
 datestamp = "1427356701"


### PR DESCRIPTION
This dependency is needed because the starterkit (altered for nems) fails on "install-dev" because of a missing dependency: https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-12350