### PR TITLE
BUGFIX/NEXTEUROPA-12123

### DIFF
--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/filter/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/filter/Config.php
@@ -166,4 +166,43 @@ class Config extends ConfigBase {
     return filter_format_save($format);
   }
 
+  /**
+   * Retrieves a list of roles for a given text format.
+   *
+   * @param string $format_name
+   *    Text format machine name.
+   *
+   * @return array
+   *    An array of role names, keyed by role ID.
+   */
+  public function getFormatRoles($format_name) {
+    $format = $this->getFormat($format_name);
+    return filter_get_roles_by_format($format);
+  }
+
+  /**
+   * Set roles for the specified text format.
+   *
+   * @param string $format_name
+   *    Text format machine name.
+   * @param array $roles
+   *    Roles array keyed by the role ID.
+   *
+   * @return bool
+   *    TRUE / FALSE when filter name is invalid.
+   */
+  public function setFormatRoles($format_name, $roles) {
+    $format = $this->getFormat($format_name);
+    // Save user permissions.
+    if ($permission = filter_permission_name($format)) {
+      foreach ($roles as $rid => $enabled) {
+        user_role_change_permissions($rid, array($permission => $enabled));
+      }
+
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
 }

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -436,14 +436,6 @@ function cce_basic_config_install() {
       'media',
       'break',
     ),
-    'lite' => array(
-      'lite_AcceptAll',
-      'lite_RejectAll',
-      'lite_AcceptOne',
-      'lite_RejectOne',
-      'lite_ToggleShow',
-      'lite_ToggleTracking',
-    ),
     'nexteuropa_token_ckeditor' => array(
       'NextEuropaToken',
     ),
@@ -451,6 +443,57 @@ function cce_basic_config_install() {
   foreach ($plugin_settings as $group => $buttons) {
     multisite_config_service('wysiwyg')->addButtonsToProfile('full_html', $group, $buttons);
   }
+
+  /*
+   * Create WYSIWYG profile for Full HTML text format with Change Tracking.
+   *
+   * Introducing that format will allow users to choose tracking changes
+   * functionality for WYSIWYG fields based on filter type.
+   * Format is based on 'Full HTML' text format and profile.
+   */
+
+  // Preparing filer format required further to build WYSIWYG profile.
+  $fl_html_filters = multisite_config_service('filter')->getFormatFilters('full_html');
+
+  // Transforming array of objects in to array by small trick.
+  $fl_html_filters = json_decode(json_encode($fl_html_filters), TRUE);
+  $full_html_track_format = (object) array(
+    'format' => 'full_html_track',
+    'name' => 'Full HTML + Change tracking',
+    'cache' => '0',
+    'status' => '1',
+    'weight' => '-10',
+    'filters' => $fl_html_filters,
+  );
+  // Filter module function for saving and updating text formats.
+  filter_format_save($full_html_track_format);
+
+  // Create WYSIWYG profile for Full HTML text format with change tracking.
+  // Creation based on Full HTML profile to keep a consistent functionality.
+  $wys_fl_html = multisite_config_service('wysiwyg')->getProfile('full_html');
+  $wys_fl_html_settings = (array) $wys_fl_html->settings;
+  multisite_config_service('wysiwyg')->createProfile(
+    'full_html_track',
+    'ckeditor',
+    $wys_fl_html_settings
+  );
+
+  // Adding LITE plugin change tracking functionality to new profile.
+  // Enable ckeditor_lite WYSIWYG plugin.
+  $lite_plugin_settings = array(
+    'lite_AcceptAll',
+    'lite_RejectAll',
+    'lite_AcceptOne',
+    'lite_RejectOne',
+    'lite_ToggleShow',
+    'lite_ToggleTracking',
+  );
+  multisite_config_service('wysiwyg')->addButtonsToProfile(
+    'full_html_track',
+    'lite',
+    $lite_plugin_settings
+  );
+
 
   // Dynamically set the 'print_pdf_pdf_tool' variable. It cannot be exported
   // in a regular feature since it includes the path to where the Print PDF
@@ -799,6 +842,11 @@ function _cce_basic_config_post_install_user_roles_perms() {
     'search content',
     'use advanced search',
   ));
+
+  // Cloning roles to 'Full HTML + Change tracking' text format. It needs to be
+  // done at least here because sooner it was not possible.
+  $fl_html_roles = multisite_config_service('filter')->getFormatRoles('full_html');
+  multisite_config_service('filter')->setFormatRoles('full_html_track', $fl_html_roles);
 }
 
 /**

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -494,7 +494,6 @@ function cce_basic_config_install() {
     $lite_plugin_settings
   );
 
-
   // Dynamically set the 'print_pdf_pdf_tool' variable. It cannot be exported
   // in a regular feature since it includes the path to where the Print PDF
   // module is installed, which is different depending on the installation

--- a/profiles/common/modules/features/multisite_wysiwyg/includes/multisite_wysiwyg.settings.inc
+++ b/profiles/common/modules/features/multisite_wysiwyg/includes/multisite_wysiwyg.settings.inc
@@ -8,27 +8,29 @@
  * Multisite WYSIWYG settings form.
  */
 function multisite_wysiwyg_settings_form($form, &$form_state) {
+  $settings = variable_get('multisite_wysiwyg', array());
   $profiles = _multisite_wysiwyg_get_profiles();
   $info_table = _multisite_wysiwyg_render_info_table($profiles['info']);
 
-  $form['wysiwyg'] = [
-    '#title' => t('Options'),
+  $form['multisite_wysiwyg'] = [
+    '#title' => t('Change tracking options'),
     '#type' => 'fieldset',
+    '#tree' => TRUE,
   ];
 
-  $form['wysiwyg']['change_tracking'] = [
-    '#title' => t('[Enable/Disable] change tracking for selected WYSIWYG profile'),
-    '#type' => 'fieldset',
-  ];
-
-  $form['wysiwyg']['info'] = [
-    '#title' => t('WYSIWYG change tracking status'),
+  $form['multisite_wysiwyg']['info'] = [
+    '#title' => t('WYSIWYG profiles: change tracking status'),
     '#type' => 'item',
     '#markup' => $info_table,
     '#weight' => -10,
   ];
 
-  $form['wysiwyg']['change_tracking']['action'] = [
+  $form['multisite_wysiwyg']['change_tracking'] = [
+    '#title' => t('[Enable/Disable] change tracking for selected WYSIWYG profile'),
+    '#type' => 'fieldset',
+  ];
+
+  $form['multisite_wysiwyg']['change_tracking']['action'] = [
     '#title' => "Select operation",
     '#type' => 'select',
     '#options' => [
@@ -38,20 +40,34 @@ function multisite_wysiwyg_settings_form($form, &$form_state) {
     '#default_value' => [],
   ];
 
-  $form['wysiwyg']['change_tracking']['profile'] = [
+  $form['multisite_wysiwyg']['change_tracking']['profile'] = [
     '#title' => "Select profile",
     '#type' => 'select',
     '#options' => $profiles['options'],
     '#default_value' => [],
   ];
 
-  $form['wysiwyg']['change_tracking']['submit'] = [
+  $form['multisite_wysiwyg']['change_tracking']['submit'] = [
     '#type' => 'submit',
     '#value' => t('Submit'),
     '#submit' => ['_multisite_wysiwyg_set_change_tracking'],
   ];
 
-  return $form;
+  $form['multisite_wysiwyg']['dis_change_track_on_create'] = [
+    '#title' => t('Disable on create content pages.'),
+    '#type' => 'checkbox',
+    '#description' => 'Disable change tracking on create content pages.',
+    '#default_value' => isset($settings['dis_change_track_on_create']) ? $settings['dis_change_track_on_create'] : '',
+  ];
+
+  $form['multisite_wysiwyg']['en_change_track_on_edit'] = [
+    '#title' => t('Enable tracking on edit content pages.'),
+    '#type' => 'checkbox',
+    '#description' => 'Enable change tracking on edit content pages.',
+    '#default_value' => isset($settings['en_change_track_on_edit']) ? $settings['en_change_track_on_edit'] : '',
+  ];
+
+  return system_settings_form($form);
 }
 
 /**
@@ -66,9 +82,8 @@ function _multisite_wysiwyg_set_change_tracking($form, &$form_state) {
     'lite_ToggleShow',
     'lite_ToggleTracking',
   );
-  $action = $form_state['values']['action'];
-  $profile = $form_state['values']['profile'];
-
+  $action = $form_state['values']['multisite_wysiwyg']['change_tracking']['action'];
+  $profile = $form_state['values']['multisite_wysiwyg']['change_tracking']['profile'];
   switch ($action) {
     case 'enable':
       multisite_config_service('wysiwyg')->addButtonsToProfile(
@@ -99,11 +114,6 @@ function _multisite_wysiwyg_get_profiles() {
   $formats = filter_formats();
   $profiles = wysiwyg_profile_load_all();
 
-  // Removing profile which by default needs to have change tracking enabled.
-  if (isset($profiles['full_html_track'])) {
-    unset($profiles['full_html_track']);
-  }
-
   // Generating array with options array and change tracking status.
   foreach ($profiles as $key => $profile) {
     $wysiwyg_profiles['options'][$key] = $formats[$key]->name;
@@ -117,6 +127,11 @@ function _multisite_wysiwyg_get_profiles() {
         $wysiwyg_profiles['info'][$key]['status'] = FALSE;
       }
     }
+  }
+
+  // Removing profile which by default needs to have change tracking enabled.
+  if (isset($wysiwyg_profiles['options']['full_html_track'])) {
+    unset($wysiwyg_profiles['options']['full_html_track']);
   }
 
   return $wysiwyg_profiles;
@@ -135,13 +150,16 @@ function _multisite_wysiwyg_render_info_table($info) {
   // Setting up table header.
   $header = [
     ['data' => t('Profile')],
-    ['data' => t('Change tracking')],
+    ['data' => t('Status')],
+    ['data' => t('Notes')],
+
   ];
   // Setting up table rows.
-  foreach ($info as $data_row) {
+  foreach ($info as $key => $data_row) {
     $row = [
       $data_row['name'],
       $data_row['status'] ? t('Enabled') : t('Disabled'),
+      ($key == 'full_html_track' ? t('Enabled by default. Can not be disabled.') : ''),
     ];
     $rows[] = $row;
   }

--- a/profiles/common/modules/features/multisite_wysiwyg/includes/multisite_wysiwyg.settings.inc
+++ b/profiles/common/modules/features/multisite_wysiwyg/includes/multisite_wysiwyg.settings.inc
@@ -8,6 +8,9 @@
  * Multisite WYSIWYG settings form.
  */
 function multisite_wysiwyg_settings_form($form, &$form_state) {
+  $profiles = _multisite_wysiwyg_get_profiles();
+  $info_table = _multisite_wysiwyg_render_info_table($profiles['info']);
+
   $form['wysiwyg'] = [
     '#title' => t('Options'),
     '#type' => 'fieldset',
@@ -16,6 +19,13 @@ function multisite_wysiwyg_settings_form($form, &$form_state) {
   $form['wysiwyg']['change_tracking'] = [
     '#title' => t('[Enable/Disable] change tracking for selected WYSIWYG profile'),
     '#type' => 'fieldset',
+  ];
+
+  $form['wysiwyg']['info'] = [
+    '#title' => t('WYSIWYG change tracking status'),
+    '#type' => 'item',
+    '#markup' => $info_table,
+    '#weight' => -10,
   ];
 
   $form['wysiwyg']['change_tracking']['action'] = [
@@ -31,7 +41,7 @@ function multisite_wysiwyg_settings_form($form, &$form_state) {
   $form['wysiwyg']['change_tracking']['profile'] = [
     '#title' => "Select profile",
     '#type' => 'select',
-    '#options' => _multisite_wysiwyg_get_profiles(),
+    '#options' => $profiles['options'],
     '#default_value' => [],
   ];
 
@@ -85,13 +95,68 @@ function _multisite_wysiwyg_set_change_tracking($form, &$form_state) {
  *    An array with WYSIWYG profiles.
  */
 function _multisite_wysiwyg_get_profiles() {
+  $wysiwyg_profiles = [];
   $formats = filter_formats();
   $profiles = wysiwyg_profile_load_all();
-  foreach ($profiles as $key => $profile) {
-    $wysiwyg_profiles[$key] = $formats[$key]->name;
+
+  // Removing profile which by default needs to have change tracking enabled.
+  if (isset($profiles['full_html_track'])) {
+    unset($profiles['full_html_track']);
   }
 
-  unset($wysiwyg_profiles['full_html_track']);
+  // Generating array with options array and change tracking status.
+  foreach ($profiles as $key => $profile) {
+    $wysiwyg_profiles['options'][$key] = $formats[$key]->name;
+    $wysiwyg_profiles['info'][$key]['name'] = $formats[$key]->name;
+    if (isset($profile->settings['buttons']['lite'])) {
+      $tracking_status = count($profile->settings['buttons']['lite']);
+      if ($tracking_status) {
+        $wysiwyg_profiles['info'][$key]['status'] = TRUE;
+      }
+      else {
+        $wysiwyg_profiles['info'][$key]['status'] = FALSE;
+      }
+    }
+  }
 
   return $wysiwyg_profiles;
+}
+
+/**
+ * Helper function renders array with information about profiles.
+ *
+ * @param array $info
+ *    An array with WYSIWYG profile information.
+ *
+ * @return string
+ *    Markup with rendered table.
+ */
+function _multisite_wysiwyg_render_info_table($info) {
+  // Setting up table header.
+  $header = [
+    ['data' => t('Profile')],
+    ['data' => t('Change tracking')],
+  ];
+  // Setting up table rows.
+  foreach ($info as $data_row) {
+    $row = [
+      $data_row['name'],
+      $data_row['status'] ? t('Enabled') : t('Disabled'),
+    ];
+    $rows[] = $row;
+  }
+  // Rendering table.
+  $rendered_table = theme('table',
+    [
+      'header' => $header,
+      'rows' => $rows,
+      'attributes' => ['class' => ['table', 'table-striped']],
+      'caption' => '',
+      'colgroups' => [],
+      'sticky' => FALSE,
+      'empty' => FALSE,
+    ]
+  );
+
+  return $rendered_table;
 }

--- a/profiles/common/modules/features/multisite_wysiwyg/includes/multisite_wysiwyg.settings.inc
+++ b/profiles/common/modules/features/multisite_wysiwyg/includes/multisite_wysiwyg.settings.inc
@@ -25,6 +25,14 @@ function multisite_wysiwyg_settings_form($form, &$form_state) {
     '#weight' => -10,
   ];
 
+  if (!isset($profiles['info']['full_html_track'])) {
+    $form['multisite_wysiwyg']['create_full_html_track'] = [
+      '#type' => 'submit',
+      '#value' => t('Create Full HTML + Change tracking profile'),
+      '#submit' => ['_multisite_wysiwyg_create_full_html_track_profile'],
+    ];
+  }
+
   $form['multisite_wysiwyg']['change_tracking'] = [
     '#title' => t('[Enable/Disable] change tracking for selected WYSIWYG profile'),
     '#type' => 'fieldset',
@@ -177,4 +185,55 @@ function _multisite_wysiwyg_render_info_table($info) {
   );
 
   return $rendered_table;
+}
+
+/**
+ * Helper funtion to create Full HTML + Change tracking WYSIWYG profile.
+ */
+function _multisite_wysiwyg_create_full_html_track_profile() {
+  // Preparing filer format required further to build WYSIWYG profile.
+  $fl_html_filters = multisite_config_service('filter')->getFormatFilters('full_html');
+
+  // Transforming array of objects in to array by small trick.
+  $fl_html_filters = json_decode(json_encode($fl_html_filters), TRUE);
+  $full_html_track_format = (object) array(
+    'format' => 'full_html_track',
+    'name' => 'Full HTML + Change tracking',
+    'cache' => '0',
+    'status' => '1',
+    'weight' => '-10',
+    'filters' => $fl_html_filters,
+  );
+  // Filter module function for saving and updating text formats.
+  filter_format_save($full_html_track_format);
+
+  // Create WYSIWYG profile for Full HTML text format with change tracking.
+  // Creation based on Full HTML profile to keep a consistent functionality.
+  $wys_fl_html = multisite_config_service('wysiwyg')->getProfile('full_html');
+  $wys_fl_html_settings = (array) $wys_fl_html->settings;
+  multisite_config_service('wysiwyg')->createProfile(
+    'full_html_track',
+    'ckeditor',
+    $wys_fl_html_settings
+  );
+
+  // Adding LITE plugin change tracking functionality to new profile.
+  // Enable ckeditor_lite WYSIWYG plugin.
+  $lite_plugin_settings = array(
+    'lite_AcceptAll',
+    'lite_RejectAll',
+    'lite_AcceptOne',
+    'lite_RejectOne',
+    'lite_ToggleShow',
+    'lite_ToggleTracking',
+  );
+  multisite_config_service('wysiwyg')->addButtonsToProfile(
+    'full_html_track',
+    'lite',
+    $lite_plugin_settings
+  );
+
+  // Cloning roles to 'Full HTML + Change tracking' text format.
+  $fl_html_roles = multisite_config_service('filter')->getFormatRoles('full_html');
+  multisite_config_service('filter')->setFormatRoles('full_html_track', $fl_html_roles);
 }

--- a/profiles/common/modules/features/multisite_wysiwyg/includes/multisite_wysiwyg.settings.inc
+++ b/profiles/common/modules/features/multisite_wysiwyg/includes/multisite_wysiwyg.settings.inc
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @file
+ * multisite_wysiwyg.settings.inc
+ */
+
+/**
+ * Multisite WYSIWYG settings form.
+ */
+function multisite_wysiwyg_settings_form($form, &$form_state) {
+  $form['wysiwyg'] = [
+    '#title' => t('Options'),
+    '#type' => 'fieldset',
+  ];
+
+  $form['wysiwyg']['change_tracking'] = [
+    '#title' => t('[Enable/Disable] change tracking for selected WYSIWYG profile'),
+    '#type' => 'fieldset',
+  ];
+
+  $form['wysiwyg']['change_tracking']['action'] = [
+    '#title' => "Select operation",
+    '#type' => 'select',
+    '#options' => [
+      'enable' => t('Enable change tracking'),
+      'disable' => t('Disable change tracking'),
+    ],
+    '#default_value' => [],
+  ];
+
+  $form['wysiwyg']['change_tracking']['profile'] = [
+    '#title' => "Select profile",
+    '#type' => 'select',
+    '#options' => _multisite_wysiwyg_get_profiles(),
+    '#default_value' => [],
+  ];
+
+  $form['wysiwyg']['change_tracking']['submit'] = [
+    '#type' => 'submit',
+    '#value' => t('Submit'),
+    '#submit' => ['_multisite_wysiwyg_set_change_tracking'],
+  ];
+
+  return $form;
+}
+
+/**
+ * Custom form submit function. Enabling and disabling change tracking.
+ */
+function _multisite_wysiwyg_set_change_tracking($form, &$form_state) {
+  $lite_plugin_settings = array(
+    'lite_AcceptAll',
+    'lite_RejectAll',
+    'lite_AcceptOne',
+    'lite_RejectOne',
+    'lite_ToggleShow',
+    'lite_ToggleTracking',
+  );
+  $action = $form_state['values']['action'];
+  $profile = $form_state['values']['profile'];
+
+  switch ($action) {
+    case 'enable':
+      multisite_config_service('wysiwyg')->addButtonsToProfile(
+        $profile,
+        'lite',
+        $lite_plugin_settings
+      );
+      break;
+
+    case 'disable':
+      multisite_config_service('wysiwyg')->removeButtonsFromProfile(
+        $profile,
+        'lite',
+        $lite_plugin_settings
+      );
+      break;
+  }
+}
+
+/**
+ * Helper function for fetching WYSIWYG profiles.
+ *
+ * @return array
+ *    An array with WYSIWYG profiles.
+ */
+function _multisite_wysiwyg_get_profiles() {
+  $formats = filter_formats();
+  $profiles = wysiwyg_profile_load_all();
+  foreach ($profiles as $key => $profile) {
+    $wysiwyg_profiles[$key] = $formats[$key]->name;
+  }
+
+  unset($wysiwyg_profiles['full_html_track']);
+
+  return $wysiwyg_profiles;
+}

--- a/profiles/common/modules/features/multisite_wysiwyg/includes/multisite_wysiwyg.settings.inc
+++ b/profiles/common/modules/features/multisite_wysiwyg/includes/multisite_wysiwyg.settings.inc
@@ -131,9 +131,9 @@ function _multisite_wysiwyg_get_profiles() {
       if ($tracking_status) {
         $wysiwyg_profiles['info'][$key]['status'] = TRUE;
       }
-      else {
-        $wysiwyg_profiles['info'][$key]['status'] = FALSE;
-      }
+    }
+    else {
+      $wysiwyg_profiles['info'][$key]['status'] = FALSE;
     }
   }
 

--- a/profiles/common/modules/features/multisite_wysiwyg/includes/multisite_wysiwyg.settings.inc
+++ b/profiles/common/modules/features/multisite_wysiwyg/includes/multisite_wysiwyg.settings.inc
@@ -126,11 +126,8 @@ function _multisite_wysiwyg_get_profiles() {
   foreach ($profiles as $key => $profile) {
     $wysiwyg_profiles['options'][$key] = $formats[$key]->name;
     $wysiwyg_profiles['info'][$key]['name'] = $formats[$key]->name;
-    if (isset($profile->settings['buttons']['lite'])) {
-      $tracking_status = count($profile->settings['buttons']['lite']);
-      if ($tracking_status) {
-        $wysiwyg_profiles['info'][$key]['status'] = TRUE;
-      }
+    if (isset($profile->settings['buttons']['lite']) && count($profile->settings['buttons']['lite'])) {
+      $wysiwyg_profiles['info'][$key]['status'] = TRUE;
     }
     else {
       $wysiwyg_profiles['info'][$key]['status'] = FALSE;

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.behat.inc
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.behat.inc
@@ -12,7 +12,7 @@ use Drupal\DrupalExtension\Context\RawDrupalContext;
 /**
  * Behat step definitions for the NextEuropa Editorial module.
  */
-class NextEuropaTokenSubContext extends RawDrupalContext implements DrupalSubContextInterface {
+class MultisiteWysiwygSubContext extends RawDrupalContext implements DrupalSubContextInterface {
 
   /**
    * The Drupal driver manager.
@@ -172,6 +172,34 @@ class NextEuropaTokenSubContext extends RawDrupalContext implements DrupalSubCon
     $content = $this->getSession()->evaluateScript("return $instance.getContent()");
     if (strpos($text, $content) === FALSE) {
       throw new \Exception(sprintf('The text "%s" was not found in the "%s" WYSWIYG editor on the page %s', $text, $instance_id, $this->getSession()->getCurrentUrl()));
+    }
+  }
+
+  /**
+   * Checks if given button is not available in WYSIWYG editor toolbar.
+   *
+   * @Then /^I should not see the "([^"]*)" button in the "([^"]*)" WYSIWYG editor$/
+   */
+  public function iShouldNotSeeButtonInToolbar($action, $instance_id) {
+    $instance_id = $this->getWysiwygInstance($instance_id);
+    $toolbar_element = $this->getWysiwygToolbar($instance_id);
+    $button = $toolbar_element->find("xpath", "//a[starts-with(@title, '$action')]");
+    if (!is_null($button)) {
+      throw new \Exception(sprintf('Button "%s" was found on the page %s', $action, $this->getSession()->getCurrentUrl()));
+    }
+  }
+
+  /**
+   * Checks if given button is available in WYSIWYG editor toolbar.
+   *
+   * @Then /^I should see the "([^"]*)" button in the "([^"]*)" WYSIWYG editor$/
+   */
+  public function iShouldSeeButtonInToolbar($action, $instance_id) {
+    $instance_id = $this->getWysiwygInstance($instance_id);
+    $toolbar_element = $this->getWysiwygToolbar($instance_id);
+    $button = $toolbar_element->find("xpath", "//a[starts-with(@title, '$action')]");
+    if (is_null($button)) {
+      throw new \Exception(sprintf('Button "%s" was not found on the page %s', $action, $this->getSession()->getCurrentUrl()));
     }
   }
 

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
@@ -16,7 +16,35 @@ function multisite_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
     // Set custom skin.
     $settings['skin'] = sprintf('%s,' . '%s/%s/%s/', $active_skin, $base_url, $skins_path, $active_skin);
 
-    // Provide additionnal custom settings.
+    // Provide additional custom settings.
     $settings['customConfig'] = base_path() . drupal_get_path('module', 'multisite_wysiwyg') . '/multisite_wysiwyg_config.js';
   }
+}
+
+/**
+ * Implements hook_menu().
+ */
+function multisite_wysiwyg_menu() {
+  $items['admin/config/content/multisite_wysiwyg'] = [
+    'title' => 'Multisite WYSIWYG',
+    'description' => 'Multisite WYSIWYG: Available options',
+    'position' => 'left',
+    'weight' => -100,
+    'page callback' => 'system_admin_menu_block_page',
+    'access arguments' => ['administer site configuration'],
+    'file' => 'system.admin.inc',
+    'file path' => drupal_get_path('module', 'system'),
+  ];
+
+  $items['admin/config/content/multisite_wysiwyg/setup'] = [
+    'title' => 'Settings',
+    'description' => 'Setup page for Multisite WYSIWYG',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => ['multisite_wysiwyg_settings_form'],
+    'access arguments' => ['administer site configuration'],
+    'file' => 'includes/multisite_wysiwyg.settings.inc',
+    'weight' => 1,
+  ];
+
+  return $items;
 }

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
@@ -41,9 +41,9 @@ function multisite_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
   }
 
   // Enable CKEditor Lite change tracking on edit content pages.
-  $create_page = _multisite_wysiwyg_check_page_arg('edit');
+  $edit_page = _multisite_wysiwyg_check_page_arg('edit');
   if ($ms_wysiwyg && isset($ms_wysiwyg['en_change_track_on_edit'])) {
-    if ($ms_wysiwyg['en_change_track_on_edit'] && $create_page) {
+    if ($ms_wysiwyg['en_change_track_on_edit'] && $edit_page) {
       $settings['lite']['isTracking'] = TRUE;
     }
   }

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
@@ -9,6 +9,7 @@
  */
 function multisite_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
   global $base_url;
+  $ms_wysiwyg = variable_get('multisite_wysiwyg', FALSE);
 
   if ($context['profile']->editor == 'ckeditor') {
     $skins_path = drupal_get_path('module', 'multisite_wysiwyg') . '/ckeditor/skins';
@@ -19,6 +20,34 @@ function multisite_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
     // Provide additional custom settings.
     $settings['customConfig'] = base_path() . drupal_get_path('module', 'multisite_wysiwyg') . '/multisite_wysiwyg_config.js';
   }
+
+  // Turn CKEditor Lite tracking off by default.
+  if (module_exists('ckeditor_lite') && $context['profile']->editor == 'ckeditor') {
+    $settings['lite']['isTracking'] = FALSE;
+  }
+
+  // Disable CKEditor Lite change tracking on create content pages.
+  $create_page = _multisite_wysiwyg_check_page_arg('add');
+  if ($ms_wysiwyg && isset($ms_wysiwyg['dis_change_track_on_create'])) {
+    if ($ms_wysiwyg['dis_change_track_on_create'] && $create_page) {
+      $extra_plugins = explode(',', $settings['extraPlugins']);
+      foreach ($extra_plugins as $key => $plugin) {
+        if ($plugin == 'lite') {
+          unset($extra_plugins[$key]);
+        }
+      }
+      $settings['extraPlugins'] = implode(',', $extra_plugins);
+    }
+  }
+
+  // Enable CKEditor Lite change tracking on edit content pages.
+  $create_page = _multisite_wysiwyg_check_page_arg('edit');
+  if ($ms_wysiwyg && isset($ms_wysiwyg['en_change_track_on_edit'])) {
+    if ($ms_wysiwyg['en_change_track_on_edit'] && $create_page) {
+      $settings['lite']['isTracking'] = TRUE;
+    }
+  }
+
 }
 
 /**
@@ -47,4 +76,19 @@ function multisite_wysiwyg_menu() {
   ];
 
   return $items;
+}
+
+/**
+ * Helper function for checking if an element is in internal menu path.
+ *
+ * @param string $element
+ *    Element string.
+ *
+ * @return bool
+ *    TRUE / FALSE.
+ */
+function _multisite_wysiwyg_check_page_arg($element) {
+  $arg = arg();
+
+  return in_array($element, $arg);
 }

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.module
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.module
@@ -43,12 +43,3 @@ function nexteuropa_core_form_taxonomy_overview_terms_submit($form, &$form_state
   }
 }
 
-/**
- * Implements hook_wysiwyg_editor_settings_alter().
- */
-function nexteuropa_core_wysiwyg_editor_settings_alter(&$settings, $context) {
-  // Turn CKEditor Lite tracking off by default.
-  if (module_exists('ckeditor_lite') && $context['profile']->editor == 'ckeditor') {
-    $settings['lite']['isTracking'] = FALSE;
-  }
-}

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.module
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.module
@@ -42,4 +42,3 @@ function nexteuropa_core_form_taxonomy_overview_terms_submit($form, &$form_state
     }
   }
 }
-

--- a/tests/features/multisite_wysiwyg/multisite_wysiwyg_settings_check.feature
+++ b/tests/features/multisite_wysiwyg/multisite_wysiwyg_settings_check.feature
@@ -1,0 +1,39 @@
+@api
+Feature: Testing settings options for the Multisite WYSIWYG module.
+  In order to check if settings for Multisite WYSIWYG are working correctly
+  As an administrator
+  I want to be able to see perform available actions and check their results.
+
+  Background:
+    Given I am logged in as a user with the 'administrator' role
+
+  Scenario: Checking WYSIWYG enabling and disabling change tracking on given WYSIWYG profile
+    When I go to "admin/config/content/multisite_wysiwyg/setup"
+    And I select "Enable change tracking" from "Select operation"
+    And I select "Full HTML" from "Select profile"
+    And I press "Submit"
+    Then I should see "Enabled" in the "Full HTML" row
+    And I select "Disable change tracking" from "Select operation"
+    And I select "Full HTML" from "Select profile"
+    And I press "Submit"
+    Then I should see "Disabled" in the "Full HTML" row
+
+  @javascript
+  Scenario: Checking if WYSIWYG options are applied to CKeditor
+    When I go to "admin/config/content/multisite_wysiwyg/setup"
+    And I select "Enable change tracking" from "Select operation"
+    And I select "Full HTML" from "Select profile"
+    And I press "Submit"
+    Then I should see "Enabled" in the "Full HTML" row
+    And I check the box "edit-multisite-wysiwyg-dis-change-track-on-create"
+    And I check the box "edit-multisite-wysiwyg-en-change-track-on-edit"
+    And I press "Save configuration"
+    And I go to "node/add/page"
+    Then I should not see the "Start tracking changes" button in the "edit-field-ne-body-und-0-value" WYSIWYG editor
+    When I select "Basic HTML" from "Text format"
+    And I fill in "Title" with "This is a page i want to reference"
+    And I fill in "Body" with "Here is the content of the referenced page."
+    And I press "Save"
+    And I click "Edit draft"
+    And I select "Full HTML" from "Text format"
+    Then I should see the "Stop tracking changes" button in the "edit-field-ne-body-en-0-value" WYSIWYG editor


### PR DESCRIPTION
PR includes following elements:
- new text format - Full HTML + Change trackng
- new WYSIWYG profile cloned from Full HTML
- new admin page for the multisite_wysiwyg module
  - enabling/disabling change tracking plugin for create and edit content pages
  - enabling/disabling change tracking plugin for given WYSIWYG profile
  - provides information table regarding status of change tracking plugin for available WYSIWYG profiles

To use on existing sites you need to configure settings on `admin/config/content/multisite_wysiwyg/setup`

For new sites webmaster would be able to select profile with change tracking if needed. To set up behaviour on create/edit content pages you need to configure settings on `admin/config/content/multisite_wysiwyg/setup`
