### PR TITLE
remove travis-ci status label

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://status.continuousphp.com/git-hub/ec-europa/platform-dev?token=4df2e996-5362-486e-b409-84527de6a65b&branch=develop)](https://continuousphp.com/git-hub/ec-europa/platform-dev)
-[![Build Status](https://travis-ci.org/ec-europa/platform-dev.svg?branch=develop)](https://travis-ci.org/ec-europa/platform-dev)
 
 # NextEuropa
 


### PR DESCRIPTION
As travis-ci is not used anymore, keeping the status label is confusing and will not show the real status of the last build.