### PR TITLE
NEPT-64: ec-resp / block.tpl.php - missing tag $attributes.

### DIFF
--- a/profiles/common/themes/ec_resp/templates/blocks/block.tpl.php
+++ b/profiles/common/themes/ec_resp/templates/blocks/block.tpl.php
@@ -4,8 +4,12 @@
  * Default theme implementation to display a block.
  *
  * Available variables:
+ * - $attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
  * - $block->subject: Block title.
  * - $content: Block content.
+ * - $content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
  * - $block->module: Module that generated the block.
  * - $block->delta: An ID for the block, unique within each module.
  * - $block->region: The block region embedding the current block.
@@ -43,7 +47,7 @@
  * @ingroup themeable
  */
 ?>
-<div id="<?php print $block_html_id; ?>" class="<?php print $classes; ?> <?php print ($panel ? 'panel panel-default clearfix' : ''); ?>">
+<div id="<?php print $block_html_id; ?>" class="<?php print $classes; ?> <?php print ($panel ? 'panel panel-default clearfix' : ''); ?>" <?php print $attributes; ?>>
   
 <?php print render($title_prefix); ?>
 <?php if ($title && $block->subject): ?>

--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -49,3 +49,8 @@ projects[drupal][patch][] = https://www.drupal.org/files/issues/1617918-33-d7-do
 ; https://www.drupal.org/node/2697611
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-9874
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal_add_js_sanitize_external-2697611-4.patch
+
+; Document $attributes, $title_attributes, and $content_attributes template variables
+; https://www.drupal.org/node/569362
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-64
+projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-doc-theme-attributes-d7-569362-53.patch


### PR DESCRIPTION
This PR fixes two things:

1. The missing tag `$attributes`,
2. The missing comments in many templates in Drupal. See [#569362](https://www.drupal.org/node/569362). I've uploaded a patch upstream, and included in makefile.

You need to flush cache to get this working properly.

Internal issue link: https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-64