### PR TITLE
NEPT-60: TMGMT: Fix insufficient access check on Views.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -608,6 +608,10 @@ projects[tmgmt][subdir] = contrib
 projects[tmgmt][patch][] = https://www.drupal.org/files/issues/support_for_link_field-2489134-9.patch
 ; @see https://www.drupal.org/node/272245
 projects[tmgmt][patch][] = https://www.drupal.org/files/issues/tmgmt-test_translator_missing-2722455-2.patch
+; NEPT-60
+; @see https://www.drupal.org/node/2812863
+; This patch fix the insufficient access check on Views.
+projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2812863.patch
 
 projects[token][subdir] = "contrib"
 projects[token][version] = "1.6"


### PR DESCRIPTION
Some Views do not provide sufficient access check, which is considered as security risk , as it may allow to expose the view information to the unwanted user.

This PR fix the problem by adding an upstream patch to the makefile.

Link to the drupal.org issue: https://www.drupal.org/node/2812863
JIRA Link: https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-60
