### PR TITLE
Added PhantomJS restart before each scenario & Phing target to stop unused services

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -24,6 +24,15 @@
     <echo msg="Loading PHP Codesniffer Configuration task." />
     <taskdef name="phpcodesnifferconfiguration" classname="\NextEuropa\Phing\PhpCodeSnifferConfigurationTask" />
 
+    <target name="stop-services">
+        <echo msg="Stopping unused services..." />
+        <exec command="sudo supervisorctl stop selenium_node" passthru="true" checkreturn="true"/>
+        <exec command="sudo supervisorctl stop selenium_hub" passthru="true" checkreturn="true"/>
+        <exec command="sudo supervisorctl stop solr5" passthru="true" checkreturn="true"/>
+        <exec command="sudo supervisorctl stop virtuoso" passthru="true" checkreturn="true"/>
+        <exec command="sudo supervisorctl stop couchbase-server" passthru="true" checkreturn="true"/>
+    </target>
+
     <import file="build.package.xml" />
     <import file="build.test.xml" />
 

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -21,10 +21,11 @@ use Behat\Gherkin\Node\PyStringNode;
 class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext {
 
   /**
+   * Restarts PhantomJS before each scenario to prevent memory leaking and freezing.
+   * 
    * @BeforeScenario
    */
-  public static function restartPhantomJs(BeforeScenarioScope $scope)
-  {
+  public static function restartPhantomJs(BeforeScenarioScope $scope) {
     if (getenv('CONTINUOUSPHP') == 'continuousphp') {
       exec('sudo supervisorctl restart phantomjs');
     }

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -8,6 +8,7 @@
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Element\Element;
 use Behat\Mink\Element\NodeElement;
@@ -21,11 +22,11 @@ use Behat\Gherkin\Node\PyStringNode;
 class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext {
 
   /**
-   * Restarts PhantomJS before each scenario to prevent memory leaking and freezing.
+   * Restarts PhantomJS after each scenario to prevent memory leaking and freezing.
    * 
-   * @BeforeScenario
+   * @AfterScenario
    */
-  public static function restartPhantomJs(BeforeScenarioScope $scope) {
+  public static function restartPhantomJs(AfterScenarioScope $scope) {
     if (getenv('CONTINUOUSPHP') == 'continuousphp') {
       exec('sudo supervisorctl restart phantomjs');
     }

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -21,6 +21,16 @@ use Behat\Gherkin\Node\PyStringNode;
 class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext {
 
   /**
+   * @BeforeScenario
+   */
+  public static function restartPhantomJs(BeforeScenarioScope $scope)
+  {
+    if (getenv('CONTINUOUSPHP') == 'continuousphp') {
+      exec('sudo supervisorctl restart phantomjs');
+    }
+  }
+
+  /**
    * Checks that a 403 Access Denied error occurred.
    *
    * @Then I should get an access denied error

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -22,7 +22,8 @@ use Behat\Gherkin\Node\PyStringNode;
 class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext {
 
   /**
-   * Restarts PhantomJS after each scenario to prevent memory leaking and freezing.
+   * Restarts PhantomJS after each scenario to prevent memory leaking and
+   * freezing.
    * 
    * @AfterScenario
    */


### PR DESCRIPTION
The build timeouts we had in the past, were generated through random freezes of PhantomJS. By adding a BeforeScenario hook in Behat that restarts PhantomJS, the problem should be solved.

Additionally, there is now a Phing target "stop-services" that stops unused services in the container to free additional memory. (After having accepted the PR, this target has to be set as the 1st target in the list of Phing targets in the continuousphp Behat config).

Greetings,
Pascal
