### PR TITLE
fix(multilingual): fix error when content has language UND

### DIFF
--- a/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.tokens.inc
+++ b/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.tokens.inc
@@ -31,7 +31,9 @@ function nexteuropa_multilingual_tokens($type, $tokens, array $data = array(), a
         $language_list = language_list();
         $languages = array();
         foreach ($entity_languages as $language) {
-          $languages[] = $language_list[$language]->name;
+          if (isset($language_list[$language]) && isset($language_list[$language]->name)) {
+            $languages[] = $language_list[$language]->name;
+          }
         }
 
         $replacements[$original] = implode(" ", $languages);


### PR DESCRIPTION
The token "**node:entity-translation-languages**" and the variable "**nexteuropa_multilingual_warning_message_languages**" will be removed from code. But maybe they are currently being used in custom code in some subsites.
The removal of the variable should not cause any problem, because it will still exist in the database (**no** hook_update_N with variable_del() is created).
But the removal of the token will make the token not to be replaced. This is not a critical error, but still if possible in the QA process by the maintenance team, some evaluation of the uses of this token in subsites can have place. If considered too risky, we can reconsider the removal of this token.
