### PR TITLE
NEXTEUROPA-13955: Add hook_requirement on communities features

### DIFF
--- a/profiles/common/modules/features/communities/communities.install
+++ b/profiles/common/modules/features/communities/communities.install
@@ -5,6 +5,23 @@
  */
 
 /**
+ * Implements hook_requirements().
+ */
+function communities_requirements() {
+  $requirements = [];
+  if (module_exists('nexteuropa_communitites')) {
+    $t = get_t();
+    $args = array('%module' => 'Nexteuropa Communities');
+    $requirements['communities_module_conflict'] = [
+      'title' => 'Communities',
+      'description' => $t('This module is not compatible with %module. Please disable that module first.', $args),
+      'severity' => REQUIREMENT_ERROR,
+    ];
+  }
+  return $requirements;
+}
+
+/**
  * Implements hook_disable().
  */
 function communities_disable() {

--- a/profiles/common/modules/features/communities/communities.install
+++ b/profiles/common/modules/features/communities/communities.install
@@ -9,7 +9,7 @@
  */
 function communities_requirements() {
   $requirements = [];
-  if (module_exists('nexteuropa_communitites')) {
+  if (module_exists('nexteuropa_communities')) {
     $t = get_t();
     $args = array('%module' => 'Nexteuropa Communities');
     $requirements['communities_module_conflict'] = [

--- a/profiles/common/modules/features/nexteuropa_communities/nexteuropa_communities.install
+++ b/profiles/common/modules/features/nexteuropa_communities/nexteuropa_communities.install
@@ -6,6 +6,23 @@
  */
 
 /**
+ * Implements hook_requirements().
+ */
+function nexteuropa_communities_requirements() {
+  $requirements = [];
+  if (module_exists('communities')) {
+    $t = get_t();
+    $args = array('%module' => 'Communities');
+    $requirements['nexteuropa_communities_module_conflict'] = [
+      'title' => 'NextEuropa Communities',
+      'description' => $t('This module is not compatible with %module. Please disable that module first.', $args),
+      'severity' => REQUIREMENT_ERROR,
+    ];
+  }
+  return $requirements;
+}
+
+/**
  * Implements hook_enable().
  */
 function nexteuropa_communities_enable() {


### PR DESCRIPTION
Prevent modules communities and nexteuropa_communities to be enabled
simultaneous
NEXTEUROPA-13955
