### PR TITLE
Allow subsites to override and add url parameters for EU Login.

### DIFF
--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -381,8 +381,23 @@ function ecas_login_check() {
 
     // Preparing validation URL to retrieve attributes as well :
     $assurance_level = variable_get('ecas_assurance_level', constant('ECAS_DEFAULT_ASSURANCE_LEVEL'));
-    $validate_server_url = 'https://' . FPFIS_ECAS_URL . ':' . FPFIS_ECAS_PORT;
-    $validate_server_url .= FPFIS_ECAS_URI . '/TicketValidationService?assuranceLevel=' . $assurance_level . '&ticketTypes=SERVICE,PROXY&userDetails=true&groups=*';
+    $request_params = variable_get('ecas_request_params', array());
+
+    $url = 'https://' . FPFIS_ECAS_URL . ':' . FPFIS_ECAS_PORT . FPFIS_ECAS_URI . '/TicketValidationService';
+    // To allow individual application to override the default params.
+    // We put the $request_params before the default value.
+    $query = $request_params + array(
+      'ticketTypes' => 'SERVICE,PROXY',
+      'userDetails' => 'true',
+      'groups' => '*',
+      'assuranceLevel' => $assurance_level,
+    );
+
+    $validate_server_url = url($url, array(
+      'query' => $query,
+      'external' => TRUE,
+    ));
+
     phpCAS::setServerServiceValidateURL($validate_server_url);
 
     if ($force_login === ECAS_LOGIN) {


### PR DESCRIPTION
https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-14064

Here an example to allow social media login.
The variable is handled with strongarm:
  $strongarm = new stdClass();
  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
  $strongarm->api_version = 1;
  $strongarm->name = 'ecas_request_params';
  $strongarm->value = array(
    'acceptedStrengths' => 'SOCIAL_NETWORKS',
  );
  $export['ecas_request_params'] = $strongarm;