### PR TITLE
NEPT-552: fix(maintenance): Move context from nexteuropa_multilingual into tests/src/Context - NEPT-552

### DIFF
--- a/tests/behat.api.yml.dist
+++ b/tests/behat.api.yml.dist
@@ -23,6 +23,7 @@ default:
             mock_server_port: {{ varnish.server.port }}
         - Drupal\nexteuropa\Context\DatabaseLogContext
         - Drupal\nexteuropa\Context\PathautoContext
+        - Drupal\nexteuropa\Context\MultilingualContext
       filters:
         tags: "~@communities&&~@wip&&@api&&~@i18n"
   extensions:

--- a/tests/behat.i18n.yml.dist
+++ b/tests/behat.i18n.yml.dist
@@ -12,6 +12,7 @@ default:
         - Drupal\nexteuropa\Context\TaxonomyContext
         - Drupal\nexteuropa\Context\DatabaseLogContext
         - Drupal\nexteuropa\Context\ViewsContext
+        - Drupal\nexteuropa\Context\MultilingualContext
       filters:
         tags: "~@communities&&~@wip&&@i18n"
   extensions:

--- a/tests/src/Context/MultilingualContext.php
+++ b/tests/src/Context/MultilingualContext.php
@@ -2,8 +2,10 @@
 
 /**
  * @file
- * Contains \NextEuropaMultilingualSubContext.
+ * Contains \Drupal\nexteuropa\Context\MultilingualContext.
  */
+
+namespace Drupal\nexteuropa\Context;
 
 use Drupal\DrupalDriverManager;
 use Drupal\DrupalExtension\Context\DrupalSubContextInterface;
@@ -13,7 +15,7 @@ use Behat\Gherkin\Node\TableNode;
 /**
  * Behat step definitions for the NextEuropa Multilingual module.
  */
-class NextEuropaMultilingualSubContext extends RawDrupalContext implements DrupalSubContextInterface {
+class MultilingualContext extends RawDrupalContext implements DrupalSubContextInterface {
   use \Drupal\nexteuropa\Context\ContextUtil;
   /**
    * Published workbench moderation state.


### PR DESCRIPTION
Move context from nexteuropa_multilingual.behat.inc into tests/src/Context 
This fixes "Trait 'Drupal\nexteuropa\Context\ContextUtil' not found" error in subsites.