### PR TITLE
NEPT-618: Aligning symlinks between standard and community profile

### DIFF
--- a/profiles/multisite_drupal_communities/modules/custom/multisite_drupal_features_set_standard
+++ b/profiles/multisite_drupal_communities/modules/custom/multisite_drupal_features_set_standard
@@ -1,1 +1,0 @@
-../../../common/modules/custom/multisite_drupal_features_set_standard

--- a/profiles/multisite_drupal_communities/modules/custom/nexteuropa_ds_layouts
+++ b/profiles/multisite_drupal_communities/modules/custom/nexteuropa_ds_layouts
@@ -1,0 +1,1 @@
+../../../common/modules/custom/nexteuropa_ds_layouts

--- a/profiles/multisite_drupal_communities/modules/custom/nexteuropa_formatters
+++ b/profiles/multisite_drupal_communities/modules/custom/nexteuropa_formatters
@@ -1,0 +1,1 @@
+../../../common/modules/custom/nexteuropa_formatters

--- a/profiles/multisite_drupal_communities/modules/custom/tmgmt_dgt_html
+++ b/profiles/multisite_drupal_communities/modules/custom/tmgmt_dgt_html
@@ -1,1 +1,0 @@
-../../../common/modules/custom/tmgmt_dgt_html

--- a/profiles/multisite_drupal_communities/modules/custom/tmgmt_poetry
+++ b/profiles/multisite_drupal_communities/modules/custom/tmgmt_poetry
@@ -1,1 +1,0 @@
-../../../common/modules/custom/tmgmt_poetry

--- a/profiles/multisite_drupal_communities/modules/features/multisite_review
+++ b/profiles/multisite_drupal_communities/modules/features/multisite_review
@@ -1,1 +1,0 @@
-../../../common/modules/features/multisite_review

--- a/profiles/multisite_drupal_communities/modules/features/nexteuropa_dgt_connector
+++ b/profiles/multisite_drupal_communities/modules/features/nexteuropa_dgt_connector
@@ -1,0 +1,1 @@
+../../../common/modules/features/nexteuropa_dgt_connector

--- a/profiles/multisite_drupal_communities/modules/features/nexteuropa_event
+++ b/profiles/multisite_drupal_communities/modules/features/nexteuropa_event
@@ -1,0 +1,1 @@
+../../../common/modules/features/nexteuropa_event

--- a/profiles/multisite_drupal_communities/modules/features/nexteuropa_faq
+++ b/profiles/multisite_drupal_communities/modules/features/nexteuropa_faq
@@ -1,0 +1,1 @@
+../../../common/modules/features/nexteuropa_faq

--- a/profiles/multisite_drupal_communities/modules/features/nexteuropa_feature_set
+++ b/profiles/multisite_drupal_communities/modules/features/nexteuropa_feature_set
@@ -1,0 +1,1 @@
+../../../common/modules/features/nexteuropa_feature_set

--- a/profiles/multisite_drupal_communities/modules/features/nexteuropa_geofield
+++ b/profiles/multisite_drupal_communities/modules/features/nexteuropa_geofield
@@ -1,0 +1,1 @@
+../../../common/modules/features/nexteuropa_geofield

--- a/profiles/multisite_drupal_communities/modules/features/nexteuropa_mediagallery
+++ b/profiles/multisite_drupal_communities/modules/features/nexteuropa_mediagallery
@@ -1,0 +1,1 @@
+../../../common/modules/features/nexteuropa_mediagallery

--- a/profiles/multisite_drupal_communities/modules/features/nexteuropa_news
+++ b/profiles/multisite_drupal_communities/modules/features/nexteuropa_news
@@ -1,0 +1,1 @@
+../../../common/modules/features/nexteuropa_news

--- a/profiles/multisite_drupal_communities/modules/features/nexteuropa_trackedchanges
+++ b/profiles/multisite_drupal_communities/modules/features/nexteuropa_trackedchanges
@@ -1,0 +1,1 @@
+../../../common/modules/features/nexteuropa_trackedchanges


### PR DESCRIPTION
During the deployment of the 2.3 release on the test environment, DevOps team encountered on an issue with some missing and broken symlinks which are not aligned between the standard and community profiles.
Test deployment for the release 2.3 was introduced and needed for the NEPT-375.

As this fact is blocking the test of deployment process for the major 2.3 release after discussed with the Community, DevOps and Core team we decided to create this ticket.

To unblock the deployment process DevOps team asked for performing alignment of the symlinks between profiles.

Pull request included in issue needs to have at least one 👍 from the Community Team member.

CC: @Fefaine @jfhovinne @champcy @gervasek  