### PR TITLE
NEPT-775: Invalidate the cache by default rule - 2.4

### DIFF
--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -96,6 +96,11 @@
         <exclude-pattern>src/Phing</exclude-pattern>
     </rule>
 
+    <!-- Next Europa PiwikRuleEntityUIController do not follow Drupal function name conventions. -->
+    <rule ref="Drupal.NamingConventions.ValidFunctionName.ScopeNotCamelCaps">
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_varnish/includes/cache_purge_rule.ui.inc</exclude-pattern>
+    </rule>
+
     <!-- Comments in exported fields are missing a period at the end. -->
     <!-- Todo: Remove this when https://www.drupal.org/node/2568161 is fixed. -->
     <rule ref="Drupal.Commenting.InlineComment.InvalidEndChar">

--- a/profiles/common/modules/custom/nexteuropa_varnish/README.md
+++ b/profiles/common/modules/custom/nexteuropa_varnish/README.md
@@ -33,6 +33,21 @@ and click on the 'Validate' button.
 Nexteuropa Varnish provides a 'Administer frontend cache purge rules'
 permission which allows to create and maintain 'purge rules'.
 
+## Default content purge rule
+Nexteuropa Varnish provides the default content type purge rule.
+The rule will send a request to invalidate the Varnish cache every time
+the content publication status changes (published/unpublished).
+
+The configuration page path:
+
+You can disable the default rule on the configuration page
+`admin/config/system/nexteuropa-varnish`.
+To do that uncheck the **"Enable the default purge rule"** checkbox and
+hit the **"Save configuration"** button.
+
+When the default rule is disabled you can add a custom rule for a given
+content type path in the 'Purge rules' configuration.
+
 ## Custom entity - 'Purge rule'
 Nexteuropa Varnish provides an additional custom entity type:
 - Purge rule - machine name: `nexteuropa_varnish_cache_purge_rule`
@@ -42,7 +57,7 @@ for sending customized HTTP requests to the Varnish server in order to
 invalidate specific frontend cache items.
 
 To add and maintain purge rules go to the following url:
-`admin/config/frontend_cache_purge_rules`
+`admin/config/system/nexteuropa-varnish/purge_rules`.
 
 ## How to add and maintain 'Purge rule'
 To add new cache purge rule you can expand the **Configuration -> Cache purge rules** menu
@@ -53,7 +68,8 @@ In the first step you need to choose a content type for which the new rule will 
 After picking the content type the next step is to choose the purge target.
 
 The 'Paths of the node the action is performed on' option will perform a purge
-on any path that belongs to the specifiec content type.
+on any path that belongs to the specific content type.
+This option is not available while the default purge rule is enabled.
 
 The 'A specific list of paths' option allows to define a set of paths
 that are going to be purged.

--- a/profiles/common/modules/custom/nexteuropa_varnish/includes/cache_purge_rule.ui.inc
+++ b/profiles/common/modules/custom/nexteuropa_varnish/includes/cache_purge_rule.ui.inc
@@ -64,4 +64,15 @@ class CachePurgeRuleEntityUIController extends EntityDefaultUIController {
     return $render;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function hook_menu() {
+    $items = parent::hook_menu();
+    $items[$this->path]['title'] = t('Purge rules');
+    $items[$this->path]['type'] = MENU_LOCAL_TASK;
+
+    return $items;
+  }
+
 }

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.admin.inc
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.admin.inc
@@ -4,116 +4,53 @@
  * Callbacks used by the administration area.
  */
 
-use Drupal\nexteuropa_varnish\PurgeRuleType;
-
 /**
  * Generates the cache purge rule editing form.
  */
-function nexteuropa_varnish_cache_purge_rule_form($form, &$form_state, $purge_rule, $op = 'edit', $entity_type = NULL) {
-  $form['content_type'] = array(
-    '#title' => t('Content Type'),
-    '#type' => 'select',
-    '#empty_option' => '',
-    '#options' => node_type_get_names(),
-    '#default_value' => isset($purge_rule->content_type) ? $purge_rule->content_type : '',
-    '#required' => TRUE,
+function nexteuropa_varnish_admin_settings_form($form, $form_state) {
+  $form['settings'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Settings'),
   );
 
-  $type_default_value = isset($purge_rule->is_new) ? PurgeRuleType::PATHS : (string) $purge_rule->type();
-
-  $form['rule_type'] = array(
-    '#title' => t('What should be purged'),
-    '#type' => 'radios',
-    '#options' => array(
-      PurgeRuleType::NODE => t('Paths of the node the action is performed on'),
-      PurgeRuleType::PATHS => t('A specific list of paths'),
-    ),
-    '#limit_validation_errors' => array(),
-    '#default_value' => $type_default_value,
-    '#required' => TRUE,
-    '#ajax' => array(
-      'callback' => 'nexteuropa_varnish_cache_purge_rule_type_selection',
-      'wrapper' => 'specifics-for-cache-purge-type',
-    ),
+  $form['settings']['nexteuropa_varnish_default_purge_rule'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable the default purge rule'),
+    '#description' => t('Activates the default purge rule for all content types.
+      The rule invalidates the Varnish cache entries whenever content changes
+      are having an impact on the published/unpublished state.'),
+    '#default_value' => variable_get('nexteuropa_varnish_default_purge_rule', FALSE),
   );
 
-  // This fieldset just serves as a container for the part of the form
-  // that gets rebuilt.
-  $form['specifics'] = array(
-    '#type' => 'item',
-    '#prefix' => '<div id="specifics-for-cache-purge-type">',
-    '#suffix' => '</div>',
-  );
+  return system_settings_form($form);
+}
 
-  $current_rule_type = isset($form_state['values']['rule_type']) ? $form_state['values']['rule_type'] : $type_default_value;
-
-  if ($current_rule_type === PurgeRuleType::PATHS) {
-    $form['specifics']['paths'] = array(
-      '#title' => t('Paths'),
-      '#type' => 'textarea',
-      '#default_value' => isset($purge_rule->paths) ? $purge_rule->paths : '',
-      '#required' => TRUE,
-      '#description' => _nexteuropa_varnish_paths_description(),
+/**
+ * Implements hook_FORM_ID_form_validate().
+ */
+function nexteuropa_varnish_admin_settings_form_validate($form, &$form_state) {
+  $rule_state = $form_state['values']['nexteuropa_varnish_default_purge_rule'];
+  if ($rule_state && _nexteuropa_varnish_check_node_rules()) {
+    form_set_error(
+      'settings',
+      t('You can not enable the default purge rule while "Purge rules" of type "node" exist.')
     );
   }
-
-  $form['actions'] = array('#type' => 'actions');
-  $form['actions']['submit'] = array(
-    '#type' => 'submit',
-    '#value' => t('Save'),
-    '#weight' => 40,
-  );
-
-  return $form;
 }
 
 /**
- * Ajax callback triggered when the cache purge type is changed.
- */
-function nexteuropa_varnish_cache_purge_rule_type_selection($form, $form_state) {
-  return $form['specifics'];
-}
-
-/**
- * Get the description for the purge paths field.
+ * Checks if rules type of node exist.
  *
- * @return string
- *   Description for the field.
+ * @return bool
+ *   TRUE / FALSE depends on the results of the query.
  */
-function _nexteuropa_varnish_paths_description() {
-  $wildcard_descriptions = array(
-    t('* (asterisk) matches any number of any characters including none'),
-    t('? (question mark) matches any single character'),
-  );
+function _nexteuropa_varnish_check_node_rules() {
+  $query = new EntityFieldQuery();
+  $query
+    ->entityCondition('entity_type', 'nexteuropa_varnish_cache_purge_rule')
+    ->propertyCondition('paths', '');
 
-  $description = '<p>' . t('Paths to purge. One per line. The paths should be relative to the base URL. Use / for the front page.') . '</p>';
+  $result = $query->execute();
 
-  $description .= '<p>' . t('You can use the following wildcard patterns:') . '</p>';
-
-  $wildcard_description = array(
-    '#theme' => 'item_list',
-    '#type' => 'ul',
-    '#items' => $wildcard_descriptions,
-  );
-
-  $description .= drupal_render(
-    $wildcard_description
-  );
-
-  $description .= '<p>' . t('In all cases above, the / (forward slash) will never be matched.') . '</p>';
-
-  return $description;
-}
-
-/**
- * Form API submit callback for the cache purge rule editing form.
- */
-function nexteuropa_varnish_cache_purge_rule_form_submit(&$form, &$form_state) {
-  if ($form_state['values']['rule_type'] !== PurgeRuleType::PATHS) {
-    $form_state['values']['paths'] = '';
-  }
-  $purge_rule = entity_ui_form_submit_build_entity($form, $form_state);
-  entity_save('nexteuropa_varnish_cache_purge_rule', $purge_rule);
-
-  $form_state['redirect'] = 'admin/config/frontend_cache_purge_rules';
+  return isset($result['nexteuropa_varnish_cache_purge_rule']);
 }

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.install
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.install
@@ -99,17 +99,21 @@ function nexteuropa_varnish_install() {
     ->condition('type', 'module')
     ->condition('name', 'nexteuropa_varnish')
     ->execute();
+
+  // Enabling the default purge rule.
+  variable_set('nexteuropa_varnish_default_purge_rule', TRUE);
 }
 
 /**
  * Implements hook_uninstall().
  */
 function nexteuropa_varnish_uninstall() {
-  $vars = [
+  $vars = array(
+    'nexteuropa_varnish_default_purge_rule',
     'nexteuropa_varnish_http_targets',
     'nexteuropa_varnish_tag',
     'nexteuropa_varnish_request_method',
-  ];
+  );
 
   foreach ($vars as $var) {
     variable_del($var);

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -9,6 +9,28 @@ module_load_include('inc', 'nexteuropa_varnish', 'nexteuropa_varnish.helper');
 use Drupal\nexteuropa_varnish\PurgeRuleType;
 
 /**
+ * Implements hook_menu().
+ */
+function nexteuropa_varnish_menu() {
+  $items['admin/config/system/nexteuropa-varnish'] = array(
+    'title' => 'Next Europa Varnish - Configuration',
+    'description' => 'Configuration of the Varnish cache invalidation mechanism.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('nexteuropa_varnish_admin_settings_form'),
+    'access arguments' => array('administer frontend cache purge rules'),
+    'file' => 'nexteuropa_varnish.admin.inc',
+  );
+
+  $items['admin/config/system/nexteuropa-varnish/general'] = array(
+    'title' => 'General settings',
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+    'weight' => -10,
+  );
+
+  return $items;
+}
+
+/**
  * Implements hook_entity_info().
  */
 function nexteuropa_varnish_entity_info() {
@@ -26,9 +48,9 @@ function nexteuropa_varnish_entity_info() {
       'controller class' => 'EntityAPIController',
       'access callback' => 'nexteuropa_varnish_cache_purge_rule_access',
       'admin ui' => array(
-        'path' => 'admin/config/frontend_cache_purge_rules',
+        'path' => 'admin/config/system/nexteuropa-varnish/purge_rules',
         'controller class' => 'CachePurgeRuleEntityUIController',
-        'file' => 'nexteuropa_varnish.admin.inc',
+        'file' => 'nexteuropa_varnish.rules.admin.inc',
       ),
     ),
   );
@@ -164,6 +186,18 @@ function _nexteuropa_varnish_get_paths_to_purge($node) {
     $paths = _nexteuropa_varnish_merge_paths_from_purge_rules($purge_rules, $node);
   }
 
+  // Default purge rule integration point.
+  if (variable_get('nexteuropa_varnish_default_purge_rule', FALSE)) {
+    if (empty($paths) && empty($node->is_new)) {
+      $paths = _nexteuropa_varnish_get_node_paths($node);
+
+    }
+  }
+
+  // Removing duplicates and all entries of the array equal to FALSE.
+  $paths = array_unique($paths);
+  $paths = array_filter($paths);
+
   return $paths;
 }
 
@@ -187,40 +221,11 @@ function _nexteuropa_varnish_merge_paths_from_purge_rules($purge_rules, $node) {
       $purge_paths = $purge_rule->paths();
     }
     else {
-      $purge_paths = array();
-
-      $entity_uri = entity_uri('node', $node);
-
-      if ($entity_uri) {
-        // Get the languages the node is translated into (entity translation).
-        if (module_exists('entity_translation') && entity_translation_enabled('node', $node)) {
-          $handler = entity_translation_get_handler('node', $node);
-
-          $translations = $handler->getTranslations();
-
-          $lang_codes = array_keys($translations->data);
-          $all_languages = entity_translation_languages('node', $node);
-
-          foreach ($lang_codes as $lang_code) {
-            if (isset($all_languages[$lang_code])) {
-              $purge_paths[] = url(
-                $entity_uri['path'],
-                $entity_uri['options'] + array('language' => $all_languages[$lang_code])
-              );
-            }
-          }
-        }
-        else {
-          $purge_paths[] = url($entity_uri['path'], $entity_uri['options']);
-        }
-      }
+      $purge_paths = _nexteuropa_varnish_get_node_paths($node);
     }
 
     $paths = array_merge($paths, $purge_paths);
   }
-
-  $paths = array_unique($paths);
-  $paths = array_filter($paths);
 
   return $paths;
 }
@@ -357,4 +362,43 @@ function _nexteuropa_varnish_base_request_headers() {
   }
 
   return $headers;
+}
+
+/**
+ * Returns paths for the node including translations.
+ *
+ * @param object $node
+ *   Node object.
+ *
+ * @return array
+ *   An array with the paths of the node.
+ */
+function _nexteuropa_varnish_get_node_paths($node) {
+  $paths = array();
+  $entity_uri = entity_uri('node', $node);
+  if ($entity_uri) {
+    // Get the languages the node is translated into (entity translation).
+    if (module_exists('entity_translation') && entity_translation_enabled('node', $node)) {
+      $handler = entity_translation_get_handler('node', $node);
+
+      $translations = $handler->getTranslations();
+
+      $lang_codes = array_keys($translations->data);
+      $all_languages = entity_translation_languages('node', $node);
+
+      foreach ($lang_codes as $lang_code) {
+        if (isset($all_languages[$lang_code])) {
+          $paths[] = url(
+            $entity_uri['path'],
+            $entity_uri['options'] + array('language' => $all_languages[$lang_code])
+          );
+        }
+      }
+    }
+    else {
+      $paths[] = url($entity_uri['path'], $entity_uri['options']);
+    }
+  }
+
+  return $paths;
 }

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.rules.admin.inc
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.rules.admin.inc
@@ -1,0 +1,140 @@
+<?php
+/**
+ * @file
+ * Callbacks used by the administration area.
+ */
+
+use Drupal\nexteuropa_varnish\PurgeRuleType;
+
+/**
+ * Generates the cache purge rule editing form.
+ */
+function nexteuropa_varnish_cache_purge_rule_form($form, &$form_state, $purge_rule, $op = 'edit', $entity_type = NULL) {
+  $form['content_type'] = array(
+    '#title' => t('Content Type'),
+    '#type' => 'select',
+    '#empty_option' => '',
+    '#options' => node_type_get_names(),
+    '#default_value' => isset($purge_rule->content_type) ? $purge_rule->content_type : '',
+    '#required' => TRUE,
+  );
+
+  $type_default_value = isset($purge_rule->is_new) ? PurgeRuleType::PATHS : (string) $purge_rule->type();
+
+  $form['rule_type'] = array(
+    '#title' => t('What should be purged'),
+    '#type' => 'radios',
+    '#options' => _nexteuropa_varnish_get_rule_types(),
+    '#limit_validation_errors' => array(),
+    '#default_value' => $type_default_value,
+    '#required' => TRUE,
+    '#ajax' => array(
+      'callback' => 'nexteuropa_varnish_cache_purge_rule_type_selection',
+      'wrapper' => 'specifics-for-cache-purge-type',
+    ),
+  );
+
+  // This fieldset just serves as a container for the part of the form
+  // that gets rebuilt.
+  $form['specifics'] = array(
+    '#type' => 'item',
+    '#prefix' => '<div id="specifics-for-cache-purge-type">',
+    '#suffix' => '</div>',
+  );
+
+  $current_rule_type = isset($form_state['values']['rule_type']) ? $form_state['values']['rule_type'] : $type_default_value;
+
+  if ($current_rule_type === PurgeRuleType::PATHS) {
+    $form['specifics']['paths'] = array(
+      '#title' => t('Paths'),
+      '#type' => 'textarea',
+      '#default_value' => isset($purge_rule->paths) ? $purge_rule->paths : '',
+      '#required' => TRUE,
+      '#description' => _nexteuropa_varnish_paths_description(),
+    );
+  }
+
+  $form['actions'] = array('#type' => 'actions');
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save'),
+    '#weight' => 40,
+  );
+  $form['actions']['cancel'] = array(
+    '#type' => 'item',
+    '#markup' => l(t('Cancel'), 'admin/config/system/nexteuropa-varnish/purge_rules'),
+    '#weight' => 41,
+  );
+
+  return $form;
+}
+
+/**
+ * Ajax callback triggered when the cache purge type is changed.
+ */
+function nexteuropa_varnish_cache_purge_rule_type_selection($form, $form_state) {
+  return $form['specifics'];
+}
+
+/**
+ * Get the description for the purge paths field.
+ *
+ * @return string
+ *   Description for the field.
+ */
+function _nexteuropa_varnish_paths_description() {
+  $wildcard_descriptions = array(
+    t('* (asterisk) matches any number of any characters including none'),
+    t('? (question mark) matches any single character'),
+  );
+
+  $description = '<p>' . t('Paths to purge. One per line. The paths should be relative to the base URL. Use / for the front page.') . '</p>';
+
+  $description .= '<p>' . t('You can use the following wildcard patterns:') . '</p>';
+
+  $wildcard_description = array(
+    '#theme' => 'item_list',
+    '#type' => 'ul',
+    '#items' => $wildcard_descriptions,
+  );
+
+  $description .= drupal_render(
+    $wildcard_description
+  );
+
+  $description .= '<p>' . t('In all cases above, the / (forward slash) will never be matched.') . '</p>';
+
+  return $description;
+}
+
+/**
+ * Form API submit callback for the cache purge rule editing form.
+ */
+function nexteuropa_varnish_cache_purge_rule_form_submit(&$form, &$form_state) {
+  if ($form_state['values']['rule_type'] !== PurgeRuleType::PATHS) {
+    $form_state['values']['paths'] = '';
+  }
+  $purge_rule = entity_ui_form_submit_build_entity($form, $form_state);
+  entity_save('nexteuropa_varnish_cache_purge_rule', $purge_rule);
+
+  $form_state['redirect'] = 'admin/config/system/nexteuropa-varnish/purge_rules';
+}
+
+/**
+ * Returns the options array with the purge rule types.
+ */
+function _nexteuropa_varnish_get_rule_types() {
+  // Remove option if the default purge rule is enabled to prevent an
+  // overlapping rules. There is no need of the 'NODE' type because default
+  // rule works for all of the content types.
+  if (variable_get('nexteuropa_varnish_default_purge_rule', FALSE)) {
+    return array(
+      PurgeRuleType::PATHS => t('A specific list of paths'),
+    );
+  }
+
+  return array(
+    PurgeRuleType::NODE => t('Paths of the node the action is performed on'),
+    PurgeRuleType::PATHS => t('A specific list of paths'),
+  );
+}

--- a/tests/features/frontend_cache_purge.feature
+++ b/tests/features/frontend_cache_purge.feature
@@ -20,7 +20,7 @@ Feature:
       | page         | /, /all-basic-pages |
       | page         | /more-basic-pages   |
       | article      | /all-articles       |
-    When I go to "/admin/config/frontend_cache_purge_rules"
+    When I go to "/admin/config/system/nexteuropa-varnish/purge_rules"
     Then I see an overview with the following cache purge rules:
       | Content Type | Paths to Purge      |
       | Basic page   | /, /all-basic-pages |
@@ -28,7 +28,7 @@ Feature:
       | Article      | /all-articles       |
 
   Scenario: Add a purge rule.
-    When I go to "/admin/config/frontend_cache_purge_rules"
+    When I go to "/admin/config/system/nexteuropa-varnish/purge_rules"
     And I click "Add cache purge rule"
     And I select "Basic page" from "Content Type"
     And I fill "Paths" with:
@@ -48,7 +48,7 @@ Feature:
       | page         | /, /all-basic-pages |
       | page         | /more-basic-pages   |
       | article      | /all-articles       |
-    When I go to "/admin/config/frontend_cache_purge_rules"
+    When I go to "/admin/config/system/nexteuropa-varnish/purge_rules"
     And I click "delete" next to the 2nd cache purge rule
     And I press the "Confirm" button
     Then I see an overview with the following cache purge rules:
@@ -60,14 +60,15 @@ Feature:
     Given the following cache purge rules:
       | Content Type | Paths to Purge      |
       | page         | /, /all-basic-pages |
-    When I go to "/admin/config/frontend_cache_purge_rules"
+    When I go to "/admin/config/system/nexteuropa-varnish/purge_rules"
     And I click "edit" next to the 1st cache purge rule
     Then the "Content Type" field should contain "page"
     And the radio button "A specific list of paths" is selected
 
   @moderated-content
   Scenario: Create a draft.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type | Paths to Purge      |
       | page         | /, /all-basic-pages |
       | page         | /more-basic-pages   |
@@ -79,7 +80,8 @@ Feature:
 
   @moderated-content
   Scenario: Immediately publish a new page.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type | Paths to Purge      |
       | page         | /, /all-basic-pages |
       | page         | /more-basic-pages   |
@@ -98,7 +100,8 @@ Feature:
 
   @moderated-content
   Scenario: Moderate a page.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type | Paths to Purge      |
       | page         | /, /all-basic-pages |
       | page         | /more-basic-pages   |
@@ -113,7 +116,8 @@ Feature:
 
   @moderated-content
   Scenario: Publish a page with moderation.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type | Paths to Purge      |
       | page         | /, /all-basic-pages |
       | page         | /more-basic-pages   |
@@ -137,7 +141,8 @@ Feature:
 
   @moderated-content
   Scenario: Withdraw a published page.
-    Given I am viewing a multilingual "page" content:
+    Given the default purge rule is disabled
+    And I am viewing a multilingual "page" content:
       | language | title            | body                       |
       | en       | Test purge rules | Page to test unpublication |
     And the following cache purge rules:
@@ -155,7 +160,8 @@ Feature:
 
   @non-moderated-content
   Scenario: Create draft of a an editorial team.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type   | Paths to Purge      |
       | page           | /, /all-basic-pages |
       | page           | /more-basic-pages   |
@@ -169,7 +175,8 @@ Feature:
 
   @non-moderated-content
   Scenario: Immediately publish a new editorial team.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type   | Paths to Purge      |
       | page           | /, /all-basic-pages |
       | page           | /more-basic-pages   |
@@ -183,7 +190,8 @@ Feature:
 
   @non-moderated-content
   Scenario: Publish an existing draft of an editorial team.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type   | Paths to Purge      |
       | page           | /, /all-basic-pages |
       | page           | /more-basic-pages   |
@@ -203,7 +211,8 @@ Feature:
 
   @non-moderated-content
   Scenario: Edit an existing draft of an editorial team.
-    Given I go to "node/add/editorial-team"
+    Given the default purge rule is disabled
+    And I go to "node/add/editorial-team"
     And I fill in "Name" with "NextEuropa Platform Core"
     And I click "Publishing options"
     And I uncheck the box "Published"
@@ -215,7 +224,8 @@ Feature:
 
   @non-moderated-content
   Scenario: Withdraw a published editorial team.
-    Given I go to "node/add/editorial-team"
+    Given the default purge rule is disabled
+    And I go to "node/add/editorial-team"
     And I fill in "Name" with "NextEuropa Platform Core"
     And I press "Save"
     And the following cache purge rules:
@@ -232,7 +242,8 @@ Feature:
       | /all-articles |
 
   Scenario: Purge with wildcard pattern "*".
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type | Paths to Purge |
       | page         | /all-pages/*   |
     When I go to "node/add/page"
@@ -266,7 +277,8 @@ Feature:
       | /all-pages/yet/another-page/inside |
 
   Scenario: Purge with multiple wildcard patterns "*" deeper in the path hierarchy.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type | Paths to Purge |
       | page         | /all-pages/*/* |
     When I go to "node/add/page"
@@ -289,7 +301,8 @@ Feature:
       | /all-pages/yet/another-page/inside_fr |
 
   Scenario: Purge with wildcard pattern "?" to match language suffix.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type | Paths to Purge |
       | page         | /all-pages_??  |
     When I go to "node/add/page"
@@ -316,7 +329,8 @@ Feature:
 
   @purge-rule-type-node
   Scenario: Add a purge rule to clear paths of the node the action is performed on.
-    When I go to "/admin/config/frontend_cache_purge_rules"
+    Given the default purge rule is disabled
+    When I go to "/admin/config/system/nexteuropa-varnish/purge_rules"
     And I click "Add cache purge rule"
     And I select "Basic page" from "Content Type"
     And I select the radio button "Paths of the node the action is performed on"
@@ -327,17 +341,19 @@ Feature:
 
   @purge-rule-type-node
   Scenario: Edit a purge rule.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type | Paths to Purge      |
       | page         |                     |
-    When I go to "/admin/config/frontend_cache_purge_rules"
+    When I go to "/admin/config/system/nexteuropa-varnish/purge_rules"
     And I click "edit" next to the 1st cache purge rule
     Then the "Content Type" field should contain "page"
     And the radio button "Paths of the node the action is performed on" is selected
 
   @moderated-content @purge-rule-type-node
   Scenario: Immediately publish a new page and purge its paths.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type | Paths to Purge |
       | page         |                |
     When I go to "node/add/page"
@@ -352,7 +368,8 @@ Feature:
 
   @moderated-content @purge-rule-type-node
   Scenario: Purge the paths of a basic page when it is withdrawn.
-    Given the following languages are available:
+    Given the default purge rule is disabled
+    And the following languages are available:
       | languages |
       | en        |
       | fr        |
@@ -376,7 +393,8 @@ Feature:
 
   @moderated-content @purge-rule-type-node
   Scenario: Purge the paths of a basic page when it is published via moderation.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type | Paths to Purge |
       | page         |                |
     When I go to "node/add/page"
@@ -396,7 +414,8 @@ Feature:
 
   @non-moderated-content @unilingual-content @purge-rule-type-node
   Scenario: Publish an editorial team.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type   | Paths to Purge      |
       | editorial_team |                     |
     When I go to "node/add/editorial-team"
@@ -408,7 +427,8 @@ Feature:
 
   @non-moderated-content @unilingual-content @purge-rule-type-node
   Scenario: Publish an existing draft of an editorial team.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type   | Paths to Purge |
       | editorial_team |                |
     When I go to "node/add/editorial-team"
@@ -426,7 +446,8 @@ Feature:
 
   @non-moderated-content @unilingual-content @purge-rule-type-node
   Scenario: Change the URL of a published editorial team.
-    Given I go to "node/add/editorial-team"
+    Given the default purge rule is disabled
+    And I go to "node/add/editorial-team"
     And I fill in "Name" with "frontend-cache-purge-editorial-team-change-alias"
     And I press "Save"
     And the following cache purge rules:
@@ -442,7 +463,8 @@ Feature:
 
   @non-moderated-content @unilingual-content @purge-rule-type-node
   Scenario: Edit an existing draft of an editorial team.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type   | Paths to Purge |
       | editorial_team |                |
     And I go to "node/add/editorial-team"
@@ -457,7 +479,8 @@ Feature:
 
   @non-moderated-content @unilingual-content @purge-rule-type-node
   Scenario: Withdraw a published editorial team.
-    Given I go to "node/add/editorial-team"
+    Given the default purge rule is disabled
+    And I go to "node/add/editorial-team"
     And I fill in "Name" with "frontend-cache-purge-withdraw-editorial-team"
     And I press "Save"
     And the following cache purge rules:
@@ -472,7 +495,8 @@ Feature:
       | /content/frontend-cache-purge-withdraw-editorial-team_en |
 
   Scenario: Use basic authentication.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type | Paths to Purge      |
       | page         | /more-basic-pages   |
     When nexteuropa_varnish is configured to authenticate with user "usr" and password "pass"
@@ -485,7 +509,8 @@ Feature:
     Then the web front end cache received a request authenticated with user "usr" and password "pass"
 
   Scenario: Authentication failures are logged.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type | Paths to Purge    |
       | page         | /more-basic-pages |
     When nexteuropa_varnish is configured to authenticate with user "usr" and password "pass"
@@ -499,7 +524,8 @@ Feature:
     Then an error is logged with type "nexteuropa_varnish" and a message matching "Clear operation failed for target http://localhost:[0-9]*: 401 Unauthorized"
 
   Scenario: Paths to purge are logged.
-    Given the following cache purge rules:
+    Given the default purge rule is disabled
+    And the following cache purge rules:
       | Content Type | Paths to Purge         |
       | page         | /more-basic-pages, /   |
       | page         | /even-more-basic-pages |
@@ -528,3 +554,54 @@ Feature:
     Then the web front end cache was not instructed to purge any paths
     And a critical error message is logged with type "nexteuropa_varnish" and a message matching "No path has been sent for clearing because all module settings are not set."
     And no informational message is logged with type "nexteuropa_varnish" and a message matching "Clearing paths: /more-basic-pages, /, /even-more-basic-pages"
+
+  # Scenarios for checking the default purge rule functionality
+
+  @moderated-content @purge-rule-type-node
+  Scenario: Purge the paths of a basic page when it is withdrawn using the default purge rule.
+    Given the following languages are available:
+      | languages |
+      | en        |
+      | fr        |
+      | nl        |
+      | de        |
+    And I am viewing a multilingual "page" content:
+      | language | title                                     | body                    |
+      | en       | frontend-cache-purge-withdrawal           | Page to test withdrawal |
+      | fr       | frontend-cache-purge-withdrawal-in-french | Page to test withdrawal |
+      | nl       | frontend-cache-purge-withdrawal-in-dutch  | Page to test withdrawal |
+    And the web front end cache is ready to receive requests.
+    When I click "Unpublish this revision"
+    And I press the "Unpublish" button
+    Then the web front end cache was instructed to purge the following paths for the application tag "my-website":
+      | Path                                        |
+      | /content/frontend-cache-purge-withdrawal_en |
+      | /content/frontend-cache-purge-withdrawal_fr |
+      | /content/frontend-cache-purge-withdrawal_nl |
+
+  @moderated-content @purge-rule-type-node
+  Scenario: Purge the paths of a basic page when it is published via moderation using the default purge rule.
+    When I go to "node/add/page"
+    And I fill in "Title" with "frontend-cache-purge-publication"
+    And I press "Save"
+    And I click "Moderate"
+    And I select "Published" from "state"
+    And I press the "Apply" button
+    Then the web front end cache was instructed to purge the following paths for the application tag "my-website":
+      | Path                                         |
+      | /content/frontend-cache-purge-publication_en |
+
+  @non-moderated-content @unilingual-content @purge-rule-type-node
+  Scenario: Publish an existing draft of an editorial team using the default purge rule..
+    When I go to "node/add/editorial-team"
+    And I fill in "Name" with "frontend-cache-purge-editorial-team-publish-draft"
+    And I click "Publishing options"
+    And I uncheck the box "Published"
+    And I press "Save"
+    And I click "Edit"
+    And I click "Publishing options"
+    And I check the box "Published"
+    And I press "Save"
+    Then the web front end cache was instructed to purge the following paths for the application tag "my-website":
+      | Path          |
+      | /content/frontend-cache-purge-editorial-team-publish-draft_en |

--- a/tests/src/Context/FrontendCacheContext.php
+++ b/tests/src/Context/FrontendCacheContext.php
@@ -190,6 +190,15 @@ class FrontendCacheContext implements Context {
   }
 
   /**
+   * Disables the default purge rule for content type modifications.
+   *
+   * @Given the default purge rule is disabled
+   */
+  public function theDefaultPurgeRuleIsDisabled() {
+    $this->variables->setVariable('nexteuropa_varnish_default_purge_rule', FALSE);
+  }
+
+  /**
    * Asserts the cache purge rules displayed in the overview.
    *
    * @Then I see an overview with the following cache purge rules:
@@ -262,6 +271,19 @@ class FrontendCacheContext implements Context {
   /**
    * Asserts that the web front end cache received certain purge requests.
    *
+   * @Then the web front end cache is ready to receive requests.
+   */
+  public function theWebFrontEndCacheIsReadyToReceiveRequests() {
+    if ($this->server && $this->server->isStarted()) {
+      // Cleaning the requests recorder during creation of the content.
+      // Useful for testing with the default purge rule enabled.
+      $this->server->clean();
+    }
+  }
+
+  /**
+   * Asserts that the web front end cache received certain purge requests.
+   *
    * @Then the web front end cache was instructed to purge the following paths for the application tag :arg1:
    */
   public function theWebFrontEndCacheWasInstructedToPurgeTheFollowingPathsForTheApplicationTag($arg1, TableNode $table) {
@@ -321,6 +343,9 @@ class FrontendCacheContext implements Context {
    */
   public function stopMockServer() {
     if ($this->server && $this->server->isStarted()) {
+      // Cleaning the mock server state.
+      $this->server->clean();
+      // Stopping the mock server.
       $this->server->stop();
     }
   }


### PR DESCRIPTION
Clone of the PR #1282 to include it into the 2.4 branch
* NEPT-775: The default purge rule functionality
* NEPT-775: Fixing problem with the Behat tests + docs
* NEPT-775: Changing the order of steps in Behat scenarios
* NEPT-775: Changing the order of steps in Behat scenarios + case for new nodes without rules
* NEPT-775: Tweak the new node case
* NEPT-775: Extending default rule usage. Excluding new nodes, including translations.
* NEPT-775: Removing a case for sending purge request on the node creation
* NEPT-775: Stabilizing and implementing the code review suggestions
* NEPT-775: Implementing suggestions from the Code Review
* NEPT-744: Improved comment readability