### PR TITLE
NEPT-717: Advanced PIWIK rules feature - 2.4

### DIFF
--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -88,6 +88,11 @@
         <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tests/tmgmt_poetry.test</exclude-pattern>
     </rule>
 
+    <!-- Next Europa PiwikRuleEntityUIController do not follow Drupal function name conventions. -->
+    <rule ref="Drupal.NamingConventions.ValidFunctionName.ScopeNotCamelCaps">
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_piwik/src/EntityDefaultUIController/PiwikRuleEntityUIController.php</exclude-pattern>
+    </rule>
+
     <!-- Exclude third party code which is not following Drupal coding standards. -->
     <exclude-pattern>profiles/common/modules/custom/multisite_drupal_toolbox/icons</exclude-pattern>
 

--- a/profiles/common/modules/custom/nexteuropa_piwik/README.md
+++ b/profiles/common/modules/custom/nexteuropa_piwik/README.md
@@ -1,0 +1,82 @@
+Next Europa PIWIK
+=================
+
+This feature provides integration with the Piwik web statistics tracking system.
+
+Installation
+============
+
+Install the module as usual, see http://drupal.org/node/895232 for further information.
+
+Usage
+=====
+Once the module is enabled in a site the general configuration must be defined
+before starting the Piwik integration.
+
+Navigate to `admin/config/system/webtools/piwik` in order to
+enter the Piwik website ID and define other properties like what user
+roles should be tracked.
+
+After the configuration all pages that follow the settings' scope will have
+the required JavaScript added to the HTML footer. You can check this by
+viewing the page source from your browser and looking for the '"utility":"piwik"' tag.
+
+Advanced PIWIK rules
+===================
+The **"Advanced PIWIK rules"** is an additional functionality available in the Next
+Europa PIWIK feature. It allows to create custom rules for setting up
+different site section values.
+To keep backward compatibility the "Advanced PIWIK rules" option is disabled
+by default.
+
+### Table of Contents
+1. [How to enable Advanced PIWIK rules](#how-to-enable)
+2. [Custom PIWIK rule types](#rule-types)
+3. [Overlapping rules](#overlapping-rules)
+4. [How to add a new custom PIWIK rule](#how-to-add-rule)
+
+#### How to enable Advanced PIWIK rules <a name="how-to-enable"></a>
+The feature can be enabled on the PIWIK configuration page which is available
+on the following path: `admin/config/system/webtools/piwik`.
+
+On the configuration page click on the "Advanced PIWIK rules" tab which is located
+at the bottom of the page. 
+On the tab section tick the "Enable advanced PIWIK rules" checkbox and
+after that click on the "Save configuration" button.
+A notification with the following message should be displayed:
+"The PIWIK advanced rules are turned on."
+A new configuration tab "Advanced PIWIK rules" should have become visible.
+Enabling the "Advanced PIWIK rules" option resets the entity cache info
+and rebuilds the menu.
+
+#### Custom PIWIK rule types <a name="rule-types"></a>
+There are two types of PIWIK rules:
+- **Direct path** rules are based on the direct full path of a page
+- **Regexp path** rules are based on a regular expression
+  
+#### Overlapping rules <a name="overlapping-rules"></a>
+If more than one rule applies for a given page, a log entry will be
+created with the information about the overlapping rule IDs.
+
+The "Direct path" rules have a priority over the "Regexp path".
+It means that if two or more rules are applicable for the given page and
+one of them is a "Direct path" rule, that rule will be applied.
+The same rule applies to the language selection. If there is more
+than a one rule, the rule with the specific language will be selected
+instead of the one with an 'all' languages option.
+
+The function that filters the rules does so by returning the first result from
+the stack. This means that rules will be applied in the IDs ascending order.
+
+If there are no rules for a given path the default settings from the
+"General settings" section will be applied.
+
+#### How to add a new custom PIWIK rule <a name="how-to-add-rule"></a>
+To add the custom rule click on the "Advanced PIWIK rules" tab or go to 
+the following path: `admin/config/system/webtools/piwik/advanced_rules`.
+
+Next click on the **"+ Add piwik rule"** link and fill the form by following
+the description tips located beneath the fields.
+When all of the fields are filled you can click save button.
+After submitting the rule you will be redirected to the rule list
+from where you can manage your rules (edit / delete).

--- a/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.admin.inc
+++ b/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.admin.inc
@@ -204,7 +204,23 @@ function nexteuropa_piwik_admin_settings_form($form_state) {
     '#description' => t('If none of the roles are selected, all users will be tracked. If a user has any of the roles checked, that user will be tracked (or excluded, depending on the setting above).'),
   );
 
-  return system_settings_form($form);
+  // Render the advanced PIWIK rules.
+  $form['tracking']['advanced_rules'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Advanced PIWIK rules'),
+  );
+
+  $form['tracking']['advanced_rules']['nexteuropa_piwik_rules_state'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable advanced PIWIK rules'),
+    '#description' => t('Activates the "Advanced PIWIK rules" configuration tab.'),
+    '#default_value' => variable_get('nexteuropa_piwik_rules_state', FALSE),
+  );
+
+  $form = system_settings_form($form);
+  array_unshift($form['#submit'], '_nexteuropa_piwik_rules_state_check');
+
+  return $form;
 }
 
 /**
@@ -328,4 +344,32 @@ function _nexteuropa_piwik_contains_forbidden_token($token_string) {
   );
 
   return preg_match('/' . implode('|', array_map('preg_quote', $token_blacklist)) . '/i', $token_string);
+}
+
+/**
+ * Helper submit function for checking the PIWIK advanced rules state.
+ */
+function _nexteuropa_piwik_rules_state_check($form, &$form_state) {
+  // Checking the state of the advanced rules checkbox.
+  $rule_state = $form_state['values']['nexteuropa_piwik_rules_state'];
+  $rule_state_var = variable_get('nexteuropa_piwik_rules_state', FALSE);
+
+  switch ($rule_state) {
+    case 0:
+      $state = t('off');
+      break;
+
+    case 1:
+      $state = t('on');
+      break;
+  }
+
+  // Presenting the message resetting the entity cache info and rebuilding menu.
+  // Runs only if the advanced PIWIK rules state has changed.
+  if ($rule_state != $rule_state_var) {
+    variable_set('nexteuropa_piwik_rules_state', $rule_state);
+    drupal_set_message(t('The PIWIK advanced rules are turned @state.', array('@state' => $state)));
+    entity_info_cache_clear();
+    menu_rebuild();
+  }
 }

--- a/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.info
+++ b/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.info
@@ -3,3 +3,8 @@ description = Adds Piwik Webtools widget to all your site's pages.
 core = 7.x
 package = NextEuropa
 configure = admin/config/system/webtools/piwik
+
+dependencies[] = entity
+dependencies[] = registry_autoload
+
+registry_autoload[] = PSR-4

--- a/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.install
+++ b/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.install
@@ -92,3 +92,62 @@ function nexteuropa_piwik_enable() {
   // Grant the permissions to PIWIK administrator role.
   user_role_change_permissions($piwik_admin_role->rid, $piwik_admin_permissions);
 }
+
+/**
+ * Returns the schema array.
+ */
+function _nexteuropa_piwik_get_schema_array() {
+  return array(
+    'description' => 'Next Europa PIWIK rules',
+    'fields' => array(
+      'id' => array(
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique PIWIK rule ID.',
+      ),
+      'rule_language' => array(
+        'type' => 'varchar',
+        'length' => 12,
+        'not null' => TRUE,
+        'description' => 'The language for which a given rule applies.',
+      ),
+      'rule_path' => array(
+        'type' => 'text',
+        'description' => 'Path where a given rule applies.',
+      ),
+      'rule_path_type' => array(
+        'type' => 'varchar',
+        'length' => 16,
+        'not null' => TRUE,
+        'description' => 'The rule path type.',
+      ),
+      'rule_section' => array(
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'description' => 'The name of the site section where a given rule applies.',
+      ),
+    ),
+    'primary key' => array('id'),
+  );
+}
+
+/**
+ * Implements hook_schema().
+ */
+function nexteuropa_piwik_schema() {
+  $schema = array();
+  $schema['nexteuropa_piwik_rule'] = _nexteuropa_piwik_get_schema_array();
+
+  return $schema;
+}
+
+/**
+ * Add the table required for the "Advanced PIWIK rules".
+ */
+function nexteuropa_piwik_update_7101() {
+  db_create_table(
+    'nexteuropa_piwik_rule',
+    _nexteuropa_piwik_get_schema_array()
+  );
+}

--- a/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.module
+++ b/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.module
@@ -10,6 +10,8 @@
  * @author: Original Piwik module: Alexander Hass <http://drupal.org/user/85918>
  */
 
+use Drupal\nexteuropa_piwik\Entity\PiwikRule;
+
 /**
  * Define default path exclusion list to remove tracking from admin pages.
  */
@@ -53,14 +55,21 @@ function nexteuropa_piwik_permission() {
  */
 function nexteuropa_piwik_menu() {
   $items['admin/config/system/webtools/piwik'] = array(
-    'title' => 'Piwik',
+    'title' => 'Next Europa Piwik',
     'description' => 'Configure the settings used to generate your NextEuropa Piwik tracking code.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('nexteuropa_piwik_admin_settings_form'),
     'access arguments' => array('administer nexteuropa_piwik'),
-    'type' => MENU_NORMAL_ITEM,
     'file' => 'nexteuropa_piwik.admin.inc',
   );
+
+  if (variable_get('nexteuropa_piwik_rules_state', FALSE)) {
+    $items['admin/config/system/webtools/piwik/general'] = array(
+      'title' => 'General settings',
+      'type' => MENU_DEFAULT_LOCAL_TASK,
+      'weight' => -10,
+    );
+  }
 
   return $items;
 }
@@ -146,6 +155,13 @@ function nexteuropa_piwik_process_html(&$vars) {
     $webtools_piwik_settings['siteSection'] = $site_section;
   }
 
+  // Advanced PIWIK rules integration point.
+  if (variable_get('nexteuropa_piwik_rules_state', FALSE)) {
+    if ($piwik_rule = _nexteuropa_piwik_get_piwik_rule()) {
+      $webtools_piwik_settings['siteSection'] = $piwik_rule->rule_section;
+    }
+  }
+
   $webtools_piwik_settings = strip_tags(json_encode($webtools_piwik_settings));
   // Add application/json tag to the header.
   $element = array(
@@ -157,6 +173,7 @@ function nexteuropa_piwik_process_html(&$vars) {
     '#weight' => '99999',
     '#value' => $webtools_piwik_settings,
   );
+
   $vars['page_bottom'] .= drupal_render($element);
 }
 
@@ -245,4 +262,239 @@ function nexteuropa_piwik_search_get_keys() {
     $return = count($path) == 3 ? $path[2] : $keys;
   }
   return $return;
+}
+
+/**
+ * Implements hook_entity_info().
+ */
+function nexteuropa_piwik_entity_info() {
+  if (variable_get('nexteuropa_piwik_rules_state', FALSE)) {
+    return array(
+      'nexteuropa_piwik_rule' => array(
+        'module' => 'nexteuropa_piwik',
+        'label' => t('PIWIK rule'),
+        'fieldable' => FALSE,
+        'entity keys' => array(
+          'id' => 'id',
+        ),
+        'label callback' => 'nexteuropa_piwik_rule_label',
+        'base table' => 'nexteuropa_piwik_rule',
+        'entity class' => 'Drupal\\nexteuropa_piwik\\Entity\\PiwikRule',
+        'controller class' => 'EntityAPIController',
+        'access callback' => 'nexteuropa_piwik_rule_access',
+        'admin ui' => array(
+          'path' => 'admin/config/system/webtools/piwik/advanced_rules',
+          'controller class' => 'Drupal\\nexteuropa_piwik\\EntityDefaultUIController\\PiwikRuleEntityUIController',
+          'file' => 'nexteuropa_piwik.rule.admin.inc',
+        ),
+      ),
+    );
+  }
+}
+
+/**
+ * Label callback for the Next Europa PIWIK rule entity.
+ *
+ * @param object $piwik_rule
+ *   The Next Europa PIWIK rule.
+ *
+ * @return null|string
+ *   The Next Europa PIWIK rule label.
+ */
+function nexteuropa_piwik_rule_label($piwik_rule) {
+  if (isset($piwik_rule->id)) {
+    return t('Rule ID: [!id]',
+      array(
+        '!id' => $piwik_rule->id,
+        '@rule_language' => $piwik_rule->rule_language,
+        '@rule_section' => $piwik_rule->rule_section,
+      )
+    );
+  }
+
+  return t('Rule ID: [NEW]');
+}
+/**
+ * Access callback for the  rule entity..
+ *
+ * @param string $op
+ *   The operation being performed. One of 'view', 'update', 'create', 'delete'
+ *   or just 'edit' (being the same as 'create' or 'update').
+ * @param object $nexteuropa_piwik_rule
+ *   (optional) A PIWIK rule to check access for. If nothing is given,
+ *   access for all cache purge rules is determined.
+ * @param object $account
+ *   (optional) The user to check for. Leave it to NULL to check for the
+ *   global user.
+ *
+ * @return bool
+ *   Whether access is allowed or not.
+ */
+function nexteuropa_piwik_rule_access($op, $nexteuropa_piwik_rule = NULL, $account = NULL) {
+  return user_access('administer nexteuropa_piwik', $account);
+}
+
+/**
+ * Returns the site section name based on the advanced PIWIK rules.
+ *
+ * @return mixed
+ *   PIWIK rule entity
+ *   FALSE if there is no rule for the currently processed path.
+ */
+function _nexteuropa_piwik_get_piwik_rule() {
+  global $language;
+  // Get the current path and convert to lowercase.
+  $path = drupal_strtolower(drupal_get_path_alias());
+  // Get the current language.
+  $lang_code = $language->language;
+
+  // Overwrite path value for the front page.
+  if (drupal_is_front_page()) {
+    $path = '<front>';
+  }
+
+  // Get the advanced PIWIK rule based on the direct path.
+  if ($piwik_rule = _nexteuropa_piwik_get_direct_path_rule($path, $lang_code)) {
+    return $piwik_rule;
+  }
+
+  // Get the advanced PIWIK rule based on the regular expression rule.
+  if ($piwik_rule = _nexteuropa_piwik_get_regexp_path_rule($path, $lang_code)) {
+    return $piwik_rule;
+  }
+
+  return FALSE;
+}
+
+/**
+ * Returns the PIWIK rule for the direct rule path type.
+ *
+ * @param string $path
+ *   Current path.
+ * @param string $lang_code
+ *   Current language.
+ *
+ * @return mixed
+ *   PIWIK rule entity
+ *   FALSE if there is no rule for the currently processed path.
+ */
+function _nexteuropa_piwik_get_direct_path_rule($path, $lang_code) {
+  $query = db_query("
+      SELECT n.id FROM {nexteuropa_piwik_rule} n
+      WHERE n.rule_path = :path
+      AND n.rule_path_type = :direct_path
+    ",
+    array(
+      ':path' => $path,
+      ':direct_path' => PiwikRule::DIRECT_PATH,
+    )
+  );
+  $results = $query->fetchAllAssoc('id');
+
+  if ($results) {
+    return _nexteuropa_piwik_filter_results($results, $path, $lang_code);
+  }
+
+  return FALSE;
+}
+
+/**
+ * Returns the PIWIK rule for the regular expression rule path type.
+ *
+ * @param string $path
+ *   Current path.
+ * @param string $lang_code
+ *   Current language.
+ *
+ * @return mixed
+ *   PIWIK rule entity
+ *   FALSE if there is no rule for the currently processed path.
+ */
+function _nexteuropa_piwik_get_regexp_path_rule($path, $lang_code) {
+  // The db_query function is used to perform query with the REGEXP comparison
+  // option.
+  $query = db_query("
+      SELECT n.id FROM {nexteuropa_piwik_rule} n
+      WHERE n.rule_path_type = :regexp_path
+      AND :path REGEXP `rule_path`
+    ",
+    array(
+      ':path' => $path,
+      ':regexp_path' => PiwikRule::REGEXP_PATH,
+    )
+  );
+  $results = $query->fetchAllAssoc('id');
+
+  if ($results) {
+    return _nexteuropa_piwik_filter_results($results, $path, $lang_code);
+  }
+
+  return FALSE;
+}
+
+/**
+ * Filters results and returns the PIWIK rule.
+ *
+ * @param array $results
+ *   An array with the PIWIK rules IDs.
+ * @param string $path
+ *   Current path.
+ * @param string $lang_code
+ *   Current language.
+ *
+ * @return mixed
+ *   PiwikRule entity
+ *   FALSE if there is no rule for the currently processed path.
+ */
+function _nexteuropa_piwik_filter_results($results, $path, $lang_code) {
+  // Log the overlapping rules case.
+  if (count($results) > 1) {
+    watchdog(
+      'nexteuropa_piwik',
+      'Overlapping PIWIK rules for the following path detected: @path. Overlapping rules IDs: @rules_ids',
+      array(
+        '@path' => $path,
+        '@rules_ids' => implode(', ', array_keys($results)),
+      ),
+      WATCHDOG_WARNING
+    );
+  }
+  // Return PIWIK rule.
+  $lang_code_rules = array();
+  $lang_all_rules = array();
+  $piwik_rules = entity_load('nexteuropa_piwik_rule', array_keys($results));
+  foreach ($piwik_rules as $piwik_rule) {
+    if ($lang_code === $piwik_rule->rule_language) {
+      $lang_code_rules[$piwik_rule->id] = $piwik_rule;
+    }
+
+    if ($piwik_rule->rule_language === 'all') {
+      $lang_all_rules[$piwik_rule->id] = $piwik_rule;
+    }
+  }
+  // Return latest rule for the defined language.
+  if (!empty($lang_code_rules)) {
+    return _nexteuropa_piwik_get_latest_rule($lang_code_rules);
+  }
+
+  // Return latest rule defined for all languages.
+  if (!empty($lang_all_rules)) {
+    return _nexteuropa_piwik_get_latest_rule($lang_all_rules);
+  }
+
+  return FALSE;
+}
+
+/**
+ * Returns the latest rule object from the array.
+ *
+ * @param array $rules_array
+ *   An array with the PiwikRule objects keyed by the id.
+ *
+ * @return PiwikRule
+ *   PiwikRule entity.
+ */
+function _nexteuropa_piwik_get_latest_rule($rules_array) {
+  ksort($rules_array, SORT_DESC);
+  return array_pop($rules_array);
 }

--- a/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.rule.admin.inc
+++ b/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.rule.admin.inc
@@ -1,0 +1,176 @@
+<?php
+/**
+ * @file
+ * Callbacks used by the administration area.
+ */
+
+use Drupal\nexteuropa_piwik\Entity\PiwikRule;
+
+/**
+ * Generates the Next Europa PIWIK rule editing form.
+ */
+function nexteuropa_piwik_rule_form($form, &$form_state, $piwik_rule, $op = 'edit', $entity_type = NULL) {
+  // Adjusting the form page title.
+  drupal_set_title(t("@operation the Next Europa PIWIK rule", array('@operation' => ucfirst($op))));
+
+  $form['rule_section'] = array(
+    '#title' => t('Site section'),
+    '#type' => 'textfield',
+    '#default_value' => isset($piwik_rule->rule_section) ? $piwik_rule->rule_section : '',
+    '#required' => TRUE,
+    '#description' => t('Enter the name of the site section.'),
+  );
+
+  // Preparing the PIWIK rule language options.
+  $options = array('all' => t('All'));
+  $options = array_merge($options, locale_language_list());
+
+  $form['rule_language'] = array(
+    '#title' => t('Language'),
+    '#type' => 'select',
+    '#options' => $options,
+    '#default_value' => isset($piwik_rule->rule_language) ? $piwik_rule->rule_language : 'all',
+    '#required' => TRUE,
+    '#description' => t(
+      'Select the language for the section. You can use "All" if the given rule
+      should be applied for all languages.'
+    ),
+  );
+
+  // Setting up default rule path type.
+  $rule_path_type_default_value = isset($piwik_rule->is_new) ? $piwik_rule::DIRECT_PATH : (string) $piwik_rule->rule_path_type;
+  $form['rule_type'] = array(
+    '#title' => t('Select rule type'),
+    '#type' => 'radios',
+    '#options' => array(
+      $piwik_rule::DIRECT_PATH => t('Direct path'),
+      $piwik_rule::REGEXP_PATH => t('Path based on regular expression'),
+    ),
+    '#limit_validation_errors' => array(),
+    '#default_value' => $rule_path_type_default_value,
+    '#required' => TRUE,
+    '#ajax' => array(
+      'callback' => 'nexteuropa_piwik_rule_path_type_selection',
+      'wrapper' => 'specifics-for-piwik-rule-path-type',
+    ),
+  );
+
+  // This fieldset just serves as a container for the part of the form
+  // that gets rebuilt.
+  $form['specifics'] = array(
+    '#type' => 'item',
+    '#prefix' => '<div id="specifics-for-piwik-rule-path-type">',
+    '#suffix' => '</div>',
+  );
+
+  // Setting up the dynamic values based on the PIWIK rule type.
+  $rule_path_type = '';
+  $rule_path_desc = '';
+  switch ($op) {
+    case 'add':
+      if (isset($form_state['values'])) {
+        $rule_path_type = $form_state['values']['rule_type'];
+        $rule_path_desc = _nexteuropa_piwik_rule_path_description($rule_path_type);
+      }
+      else {
+        $rule_path_type = $piwik_rule::DIRECT_PATH;
+        $rule_path_desc = _nexteuropa_piwik_rule_path_description($rule_path_type);
+      }
+      break;
+
+    case 'edit':
+      if (isset($form_state['values'])) {
+        $rule_path_type = $form_state['values']['rule_type'];
+        $rule_path_desc = _nexteuropa_piwik_rule_path_description($rule_path_type);
+      }
+      else {
+        $rule_path_type = $piwik_rule->rule_path_type;
+        $rule_path_desc = _nexteuropa_piwik_rule_path_description($rule_path_type);
+      }
+
+      break;
+  }
+
+  $form['specifics']['rule_path'] = array(
+    '#title' => t('Site path'),
+    '#type' => 'textfield',
+    '#default_value' => isset($piwik_rule->rule_path) ? $piwik_rule->rule_path : '',
+    '#required' => TRUE,
+    '#description' => $rule_path_desc,
+  );
+
+  $form['rule_path_type'] = array(
+    '#type' => 'value',
+    '#value' => $rule_path_type,
+  );
+
+  $form['actions'] = array('#type' => 'actions');
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save'),
+    '#weight' => 40,
+  );
+
+  return $form;
+}
+
+/**
+ * Ajax callback triggered when the cache purge type is changed.
+ */
+function nexteuropa_piwik_rule_path_type_selection($form, $form_state) {
+  return $form['specifics'];
+}
+
+
+/**
+ * Form API submit callback for the cache purge rule editing form.
+ */
+function nexteuropa_piwik_rule_form_submit(&$form, &$form_state) {
+  // Building and saving the PIWIK rule entity.
+  $piwik_rule = entity_ui_form_submit_build_entity($form, $form_state);
+  entity_save('nexteuropa_piwik_rule', $piwik_rule);
+
+  // Redirecting a user to the PWIKI rules admin page.
+  $form_state['redirect'] = 'admin/config/system/webtools/piwik/advanced_rules';
+}
+
+/**
+ * Get the description for the PIWIK rule path field.
+ *
+ * @param string $rule_path_type
+ *   PIWIK rule patt type.
+ *
+ * @return string $description
+ *   Description for the field.
+ */
+function _nexteuropa_piwik_rule_path_description($rule_path_type) {
+  $description = '';
+  switch ($rule_path_type) {
+    case PiwikRule::DIRECT_PATH:
+      $description = t('Enter the direct path for the rule. The path should be relative to the base URL. <br/> Example: "content/test-page"');
+      break;
+
+    case PiwikRule::REGEXP_PATH:
+      $wildcard_descriptions = array(
+        t('"^admin/*" - All administrative pages'),
+        t('"^content/*" - All pages following "content" part in the path'),
+      );
+      $description = '<p>' . t('Enter the regular expression path pattern for the rule.') . '</p>';
+      $description .= '<p>' . t('You can check your expression at the
+        <a href="@regex101">Regex101 page</a>.',
+          array('@regex101' => 'https://regex101.com')
+        ) . '</p>';
+      $description .= '<p>' . t('Below you can find some examples:') . '</p>';
+      $wildcard_description = array(
+        '#theme' => 'item_list',
+        '#type' => 'ul',
+        '#items' => $wildcard_descriptions,
+      );
+      $description .= drupal_render(
+        $wildcard_description
+      );
+      break;
+  }
+
+  return $description;
+}

--- a/profiles/common/modules/custom/nexteuropa_piwik/src/Entity/PiwikRule.php
+++ b/profiles/common/modules/custom/nexteuropa_piwik/src/Entity/PiwikRule.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @file
+ * Definition of Drupal\nexteuropa_piwik\Entity\PiwikRule.
+ */
+
+namespace Drupal\nexteuropa_piwik\Entity;
+use \Entity;
+
+/**
+ * PIWIK rule entity.
+ */
+class PiwikRule extends Entity {
+  const DIRECT_PATH = 'direct';
+  const REGEXP_PATH = 'regexp';
+
+}

--- a/profiles/common/modules/custom/nexteuropa_piwik/src/EntityDefaultUIController/PiwikRuleEntityUIController.php
+++ b/profiles/common/modules/custom/nexteuropa_piwik/src/EntityDefaultUIController/PiwikRuleEntityUIController.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @file
+ * Definition of PiwikRuleEntityUIController.
+ */
+
+namespace Drupal\nexteuropa_piwik\EntityDefaultUIController;
+use \EntityDefaultUIController;
+
+/**
+ * Entity UI controller for the Next Europa PIWIK rules.
+ */
+class PiwikRuleEntityUIController extends EntityDefaultUIController {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function overviewTableHeaders($conditions, $rows, $additional_header = array()) {
+    // Rule path type header.
+    array_unshift($additional_header, t('Path type'));
+    // Rule paths header.
+    array_unshift($additional_header, t('Path'));
+    // Rule language header.
+    array_unshift($additional_header, t('Language'));
+    // Rule section header.
+    array_unshift($additional_header, t('Section'));
+
+    // Get the parent table headers.
+    $headers = parent::overviewTableHeaders($conditions, $rows, $additional_header);
+
+    return $headers;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function overviewTableRow($conditions, $id, $entity, $additional_cols = array()) {
+    // Rule paths row.
+    array_unshift($additional_cols, $entity->rule_path_type);
+    // Rule paths row.
+    array_unshift($additional_cols, $entity->rule_path);
+    // Rule language row.
+    array_unshift($additional_cols, $entity->rule_language);
+    // Rule section row.
+    array_unshift($additional_cols, $entity->rule_section);
+
+    // Get the parent table row.
+    $row = parent::overviewTableRow($conditions, $id, $entity, $additional_cols);
+
+    return $row;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function overviewTable($conditions = array()) {
+    $render = parent::overviewTable($conditions);
+
+    // Add a unique id to the table. This will make it easier to target it
+    // in acceptance tests.
+    $render['#attributes']['id'] = 'next-europa-piwik-rules';
+
+    return $render;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function hook_menu() {
+    $items = parent::hook_menu();
+    $items[$this->path]['title'] = t('Advanced PIWIK rules');
+    $items[$this->path]['type'] = MENU_LOCAL_TASK;
+
+    return $items;
+  }
+
+}

--- a/tests/behat.yml.dist
+++ b/tests/behat.yml.dist
@@ -33,6 +33,7 @@ default:
         - Drupal\nexteuropa\Context\PathautoContext
         - Drupal\nexteuropa\Context\MultilingualContext
         - Drupal\nexteuropa\Context\DrupalMailContext
+        - Drupal\nexteuropa\Context\PiwikRulesContext
       filters:
         tags: "~@wip&&~@communities"
   extensions:

--- a/tests/features/piwik.feature
+++ b/tests/features/piwik.feature
@@ -1,22 +1,95 @@
-@wip
+@wip @api @reset-nodes
 Feature: Check Piwik
   In order to check if the the type attribute is set for the Piwik element.
   As an administrator
   I want to check Piwik is available.
+  # Advanced PIWIK rules functionality
+  In order to make PIWIK analysis more granular and accurate
+  As a site administrator
+  I can define advanced PIWIK rules to define the site section based on path or regular expression
 
-@api
-Scenario: Administrator user can check Piwik Script with the theme Bootstrap
-  Given the module is enabled
-    | modules            |
-    | nexteuropa_piwik   |
-  Given I am logged in as a user with the 'administrator' role
-  When I run drush "pm-enable bootstrap -y"
-  And I run drush "vset theme_default bootstrap"
-  And the cache has been cleared
-  Then I am on the homepage
-  And the response should contain "{\"utility\":\"piwik\",\"siteID\":\"\",\"sitePath\":[\"\"],\"is404\":false,\"instance\":\"\"}"
-  When I run drush "vset theme_default ec_resp"
-  And the cache has been cleared
-  Then I am on the homepage
-  And the response should contain "{\"utility\":\"piwik\",\"siteID\":\"\",\"sitePath\":[\"\"],\"is404\":false,\"instance\":\"\"}"
+  Background:
+    Given these modules are enabled
+      | modules            |
+      | nexteuropa_piwik   |
+    And I am logged in as a user with the "PIWIK administrator" role
 
+  @wip
+  Scenario: Administrator user can check Piwik Script with the theme Bootstrap
+    When I run drush "pm-enable bootstrap -y"
+    And I run drush "vset theme_default bootstrap"
+    And the cache has been cleared
+    Then I am on the homepage
+    And the response should contain "{\"utility\":\"piwik\",\"siteID\":\"\",\"sitePath\":[\"\"],\"is404\":false,\"instance\":\"\"}"
+    When I run drush "vset theme_default ec_resp"
+    And the cache has been cleared
+    Then I am on the homepage
+    And the response should contain "{\"utility\":\"piwik\",\"siteID\":\"\",\"sitePath\":[\"\"],\"is404\":false,\"instance\":\"\"}"
+
+  Scenario: View advanced PIWIK rules.
+    Given the nexteuropa_piwik module is configured to use advanced PIWIK rules
+    And the following PIWIK rules:
+      | Rule language | Rule path       | Rule path type | Rule section         |
+      | all           | ^admin/*        | regexp         | Regexp based section |
+      | en            | content/test    | direct         | Direct path section  |
+    When I go to "/admin/config/system/webtools/piwik/advanced_rules"
+    Then I see an overview with the following PIWIK rules:
+      | Rule language | Rule path       | Rule path type | Rule section         |
+      | all           | ^admin/*        | regexp         | Regexp based section |
+      | en            | content/test    | direct         | Direct path section  |
+
+  @javascript
+  Scenario: Add a PIWIK rule.
+    Given the nexteuropa_piwik module is configured to use advanced PIWIK rules
+    When I go to "/admin/config/system/webtools/piwik/advanced_rules"
+    And I click "Add piwik rule"
+    And I fill in "Site section" with "Regexp based section"
+    And I select "English" from "Language"
+    And I select the radio button "Path based on regular expression" with the id "edit-rule-type-regexp"
+    And I wait for AJAX to finish
+    And I fill in "Site path" with "^admin/*"
+    And I press the "Save" button
+    Then I see an overview with the following PIWIK rules:
+      | Rule language | Rule path       | Rule path type | Rule section         |
+      | en            | ^admin/*        | regexp         | Regexp based section |
+
+  Scenario: Remove a PIWIK rule.
+    Given the nexteuropa_piwik module is configured to use advanced PIWIK rules
+    And I create the following multilingual "page" content:
+      | language | title  | field_ne_body         |
+      | en       | Test   | The test body content |
+    And the following PIWIK rules:
+      | Rule language | Rule path       | Rule path type | Rule section         |
+      | all           | ^admin/*        | regexp         | Regexp based section |
+      | en            | content/test    | direct         | Direct path section  |
+    When I go to "/admin/config/system/webtools/piwik/advanced_rules"
+    And I click "delete" next to the 2nd PIWIK rule
+    And I press the "Confirm" button
+    Then I see an overview with the following PIWIK rules:
+      | Rule language | Rule path       | Rule path type | Rule section         |
+      | all           | ^admin/*        | regexp         | Regexp based section |
+    And I should not see the text "content/test"
+    When I go to "content/test"
+    Then the response should not contain "\"siteSection\":\"Direct path section\""
+
+  Scenario: Assert that the direct path PIWIK rule is triggered and embedded correctly.
+    Given the nexteuropa_piwik module is configured to use advanced PIWIK rules
+    And the following PIWIK rules:
+      | Rule language | Rule path       | Rule path type | Rule section         |
+      | en            | content/test    | direct         | Direct path section  |
+    And I create the following multilingual "page" content:
+      | language | title | field_ne_body |
+      | en       | Test  | Test          |
+    And I go to "content/test_en"
+    Then the response should contain "\"siteSection\":\"Direct path section\""
+
+  Scenario: Assert that the regular expression based PIWIK rule is triggered and embedded correctly.
+    Given the nexteuropa_piwik module is configured to use advanced PIWIK rules
+    And the following PIWIK rules:
+      | Rule language | Rule path       | Rule path type | Rule section         |
+      | all           | ^content/*      | regexp         | Regexp based section |
+    And I create the following multilingual "page" content:
+      | language | title              | field_ne_body     |
+      | en       | Testing Title no 1 | Body content no 1 |
+    When I go to "content/testing-title-no-1_en"
+    Then the response should contain "\"siteSection\":\"Regexp based section\""

--- a/tests/src/Context/PiwikRulesContext.php
+++ b/tests/src/Context/PiwikRulesContext.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\nexteuropa\Context\FrontendCacheContext.
+ */
+
+namespace Drupal\nexteuropa\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Element\Element;
+use function bovigo\assert\assert;
+use function bovigo\assert\predicate\equals;
+use function bovigo\assert\predicate\isOfSize;
+
+/**
+ * Context for steps and assertions related to web frontend caching (Varnish).
+ */
+class PiwikRulesContext implements Context {
+
+  /**
+   * The Mink context.
+   *
+   * @var MinkContext
+   */
+  protected $mink;
+
+  /**
+   * The variable context.
+   *
+   * @var VariableContext
+   */
+  protected $variables;
+
+
+  /**
+   * Gathers other contexts we rely on, before the scenario starts.
+   *
+   * @BeforeScenario
+   */
+  public function gatherContexts(BeforeScenarioScope $scope) {
+    $environment = $scope->getEnvironment();
+
+    $this->mink = $environment->getContext(MinkContext::class);
+    $this->variables = $environment->getContext(VariableContext::class);
+  }
+
+  /**
+   * Configures the nexteuropa PIWIK module to use advanced PIWIK rules.
+   *
+   * @Given the nexteuropa_piwik module is configured to use advanced PIWIK rules
+   */
+  public function nexteuropaPiwikIsConfiguredToUseAdvancedPiwikRules() {
+    $this->variables->setVariable('nexteuropa_piwik_rules_state', TRUE);
+    entity_info_cache_clear();
+    menu_rebuild();
+  }
+
+  /**
+   * Inserts cache purge rules via the entity API.
+   *
+   * @Given the following PIWIK rules:
+   */
+  public function theFollowingPiwikRules(TableNode $table) {
+    $rules = $table->getHash();
+
+    foreach ($rules as $rule) {
+      $rule = entity_create(
+        'nexteuropa_piwik_rule',
+        array(
+          'rule_language' => $rule['Rule language'],
+          'rule_path' => $rule['Rule path'],
+          'rule_path_type' => $rule['Rule path type'],
+          'rule_section' => $rule['Rule section'],
+        )
+      );
+
+      entity_save('nexteuropa_piwik_rule', $rule);
+    }
+  }
+
+  /**
+   * Asserts the PIWIK rules displayed in the overview.
+   *
+   * @Then I see an overview with the following PIWIK rules:
+   */
+  public function assertOverviewOfPiwikRules(TableNode $table) {
+    $expected_rules = $table->getHash();
+
+    $overview = $this->getPiwikRulesOverview();
+
+    $rows = $overview->findAll('css', 'tr');
+
+    \bovigo\assert\assert($rows, isOfSize(count($expected_rules)));
+
+    /** @var Element $row */
+    foreach (array_values($rows) as $i => $row) {
+      $expected_rule = $expected_rules[$i];
+
+      $this->assertOverviewPiwikRule($row, $expected_rule);
+    }
+  }
+
+  /**
+   * Gets the PIWIK rules overview.
+   *
+   * @return Element
+   *   The table body.
+   */
+  protected function getPiwikRulesOverview() {
+    return $this->mink->getSession()
+      ->getPage()
+      ->find('css', 'table#next-europa-piwik-rules > tbody');
+  }
+
+  /**
+   * Asserts a particular row from the PIWIK rules overview.
+   *
+   * @param Element $row
+   *   The table row.
+   * @param array $expected_rule
+   *   The expected values for the PIWIK rule.
+   */
+  protected function assertOverviewPiwikRule(Element $row, array $expected_rule) {
+    /** @var Element[] $cells */
+    $cells = $row->findAll('css', 'td');
+    assert($cells[1]->getText(), equals($expected_rule['Rule section']));
+    assert($cells[2]->getText(), equals($expected_rule['Rule language']));
+    assert($cells[3]->getText(), equals($expected_rule['Rule path']));
+    assert($cells[4]->getText(), equals($expected_rule['Rule path type']));
+  }
+
+  /**
+   * Clicks a link in a specific table row given the number of that row.
+   *
+   * @When I click :arg1 next to the :nth PIWIK rule
+   */
+  public function iClickLinkNextToTheNthPiwikRule($arg1, $nth) {
+    $overview = $this->getPiwikRulesOverview();
+
+    $matched = preg_match('/^[0-9]+/', $nth, $matches);
+    assert($matched, equals(1));
+    // In human language we start to count from 1, but in code from 0.
+    // So we need to substract by 1.
+    $row_number = $matches[0] - 1;
+
+    $rows = $overview->findAll('css', 'tr');
+    assert($rows, \bovigo\assert\predicate\hasKey($row_number));
+    $row = $rows[$row_number];
+
+    $link = $row->findLink($arg1);
+    $link->click();
+  }
+
+  /**
+   * Removes all PIWIK rules.
+   *
+   * @AfterScenario
+   */
+  public function purgeAllCacheRules() {
+    if (module_exists('nexteuropa_piwik')) {
+      $rules = entity_load('nexteuropa_piwik_rule');
+      $rule_ids = array_keys($rules);
+      entity_delete_multiple('nexteuropa_piwik_rule', $rule_ids);
+    }
+  }
+
+}


### PR DESCRIPTION
Clone of the PR #1324 which have been merged with the master branch.

List of squashed commits:

NEPT-717: Advanced PIWIK rules feature
NEPT-717: Appling the code review suggestions
NEPT-717: Another part of code review suggestions
NEPT-717: Another portion of Code Review suggestions
NEPT-717: Disabling piwik.feature as it has problems with the currently implemented way of cleaning DB in the after scenario step
NEPT-717: Filling the missing parts of the documentation
NEPT-717: Stabilizing and implementing the code review suggestions
NEPT-717: Extending 'Remove a Piwik rule' scenario
NEPT-717 - Add an extra check that the removed rule does not show
NEPT-717: Made small remarks on Readme and removed permission from administrators