### PR TITLE
NEPT-831: Cleaning the environment before running the Behat feature - 2.4

### DIFF
--- a/build.properties.dist
+++ b/build.properties.dist
@@ -197,3 +197,7 @@ integration.server.port = 8888
 
 # Port on which the mocked Varnish server used by the behat tests will listen.
 varnish.server.port = 8888
+
+# Drush Context configuration
+# ---------------------------
+drush.db.dump = ${platform.build.dir}/dump.sql

--- a/build.test.xml
+++ b/build.test.xml
@@ -81,6 +81,7 @@
                     <token key="flickr.key" value="${flickr.key}" />
                     <token key="flickr.secret" value="${flickr.secret}" />
                     <token key="drush.bin" value="${drush.bin}" />
+                    <token key="drush.db.dump" value="${drush.db.dump}" />
                     <token key="behat.formatter.name" value="${behat.formatter.name}" />
                     <token key="integration.server.port" value="${integration.server.port}" />
                     <token key="varnish.server.port" value="${varnish.server.port}" />

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/tmgmt_poetry_mock.behat.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/tmgmt_poetry_mock.behat.inc
@@ -11,6 +11,8 @@ use Drupal\DrupalExtension\Context\DrupalSubContextInterface;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 use Drupal\tmgmt_poetry_mock\Mock\PoetryMock;
 use Behat\Gherkin\Node\TableNode;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
 use function bovigo\assert\assert;
 use function bovigo\assert\predicate\equals;
 use function bovigo\assert\predicate\isTrue;
@@ -115,21 +117,40 @@ class TMGMTPoetryMockSubContext extends RawDrupalContext implements DrupalSubCon
   }
 
   /**
-   * Remove pending translations in a scenario tagged with @poetry_mock.
+   * Remove all translation files in a scenario tagged with @poetry_mock.
    *
-   * @poetry_mock
+   * @AfterScenario @poetry_mock
    */
-  public function removePendingTranslations() {
+  public function removeAllRequestTranslationFiles() {
     PoetryMock::removeAllRequestTranslationFiles();
+
+    // Delete the tmgmt_file directory.
+    $tmgmt_poetry_dir = drupal_realpath('public://') . '/tmgmt_file';
+    $process = new Process('rm -rf ' . $tmgmt_poetry_dir);
+    $process->run();
+
+    if (!$process->isSuccessful()) {
+      throw new ProcessFailedException($process);
+    }
   }
 
   /**
    * Remove pending jobs in a scenario tagged with @poetry_mock.
    *
-   * @poetry_mock
+   * @AfterScenario @poetry_mock
    */
-  public function removePendingJobss() {
+  public function removePendingJobs() {
     PoetryMock::removeAllRequestJobs();
+  }
+
+  /**
+   * Removes the mock TMGMT translator.
+   *
+   * @AfterScenario @poetry_mock_cleanup_translator
+   */
+  public function cleanupMockTranslator() {
+    PoetryMock::removeMockTranslator();
+    PoetryMock::importMockTranslator();
   }
 
   /**

--- a/tests/behat.yml.dist
+++ b/tests/behat.yml.dist
@@ -9,7 +9,6 @@ default:
         - Drupal\nexteuropa\Context\AgnosticBatchContext
         - Drupal\nexteuropa\Context\ApacheSolrContext
         - Drupal\nexteuropa\Context\CKEditorContext
-        - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\nexteuropa\Context\MessageContext
         - Drupal\nexteuropa\Context\BeanContext
         - Drupal\nexteuropa\Context\DrupalContext
@@ -34,6 +33,9 @@ default:
         - Drupal\nexteuropa\Context\MultilingualContext
         - Drupal\nexteuropa\Context\DrupalMailContext
         - Drupal\nexteuropa\Context\PiwikRulesContext
+        - Drupal\nexteuropa\Context\DrushContext:
+            drush_bin: "{{ drush.bin }}"
+            db_dump_location: '{{ drush.db.dump }}'
       filters:
         tags: "~@wip&&~@communities"
   extensions:

--- a/tests/features/embedded_image.feature
+++ b/tests/features/embedded_image.feature
@@ -1,43 +1,44 @@
-@api @javascript @wip
+@api @javascript
 Feature: Embedded images
   In order to make my website more attractive
   As a contributor
   I can embed images from Flickr in my content
 
-Background:
-  Given the module is enabled
-  |modules       |
-  |ec_embedded_image|
-  And a valid Flickr API key & secret have been configured
-  And there is a media gallery content type with a field to embed images from flickr
-  And I am logged in as a user with the 'contributor' role
+  Background:
+    Given the module is enabled
+    | modules           |
+    | ec_embedded_image |
+    And a valid Flickr API key & secret have been configured
+    And there is a media gallery content type with a field to embed images from flickr
+    And I am logged in as a user with the 'contributor' role
 
-Scenario Outline: Embed Flickr photoset via media asset field
-  When I go to "node/add/test-media-gallery"
-  And I fill in "title" with "<title>"
-  And I click "Browse"
-  Then the media browser opens
-  When I fill in "File URL or media resource" with "<url>"
-  And I press "Next"
-  Then the media browser closes
-  And I see the "Flickr set" preview
-  When I press "Save"
-  Then I should see the success message "Media Gallery <title> has been created."
+  @wip
+  Scenario Outline: Embed Flickr photoset via media asset field
+    When I go to "node/add/test-media-gallery"
+    And I fill in "title" with "<title>"
+    And I click "Browse"
+    Then the media browser opens
+    When I fill in "File URL or media resource" with "<url>"
+    And I press "Next"
+    Then the media browser closes
+    And I see the "Flickr set" preview
+    When I press "Save"
+    Then I should see the success message "Media Gallery <title> has been created."
 
-  Examples:
-  | title              | url                                                                 |
-  | Old Flickr set URL | https://www.flickr.com/photos/69583224@N05/sets/72157669193515074   |
-  | New Flickr set URL | https://www.flickr.com/photos/69583224@N05/albums/72157669193515074 |
+    Examples:
+    | title              | url                                                                 |
+    | Old Flickr set URL | https://www.flickr.com/photos/69583224@N05/sets/72157669193515074   |
+    | New Flickr set URL | https://www.flickr.com/photos/69583224@N05/albums/72157669193515074 |
 
-Scenario Outline: Error when an invalid Flickr url is filled in
-  When I go to "node/add/test-media-gallery"
-  And I fill in "title" with "<title>"
-  And I click "Browse"
-  Then the media browser opens
-  When I fill in "File URL or media resource" with "<url>"
-  And I press "Next"
-  Then I should see the error message "Unable to handle the provided embed string or URL."
+  Scenario Outline: Error when an invalid Flickr url is filled in
+    When I go to "node/add/test-media-gallery"
+    And I fill in "title" with "<title>"
+    And I click "Browse"
+    Then the media browser opens
+    When I fill in "File URL or media resource" with "<url>"
+    And I press "Next"
+    Then I should see the error message "Unable to handle the provided embed string or URL."
 
-  Examples:
-    | title              | url                                       |
-    | Invalid Flickr URL | https://www.flickr.com/thisisnotavalidurl |
+    Examples:
+      | title              | url                                       |
+      | Invalid Flickr URL | https://www.flickr.com/thisisnotavalidurl |

--- a/tests/features/events.feature
+++ b/tests/features/events.feature
@@ -1,4 +1,4 @@
-@api @wip
+@api
 Feature: Event features
   In order to schedule events
   As a citizen of the European Union

--- a/tests/features/feature_set/nexteuropa_trackedchanges_set.feature
+++ b/tests/features/feature_set/nexteuropa_trackedchanges_set.feature
@@ -6,11 +6,16 @@ Feature: Change tracking features
   Background:
     Given I am logged in as a user with the 'administrator' role
 
-  Scenario: As administrator, I can disable the "NextEuropa Tracked Changes" feature if tracked changes are not detected
-  on fields that use this profile
-    Given the module is enabled
-      | modules                   |
-      | nexteuropa_trackedchanges |
+  Scenario: As administrator, I can enable/disable the "NextEuropa Tracked Changes" feature if tracked changes are not
+  detected on fields that use this profile
+    When I go to "admin/structure/feature-set"
+    And I click "Editorial Management"
+    And I click the ".form-item-featureset-nexteuropa-trackedchanges" element
+    And I press "Validate"
+    And I wait for the end of the batch job
+    Then I should see the success message "NextEuropa Tracked Changes feature is now active on your site."
+    When I go to "admin/config/content/wysiwyg/tracked_changes/table_status"
+    Then the response should contain "Tracked changes logs status"
     When I go to "admin/structure/feature-set"
     And I click "Editorial Management"
     And I click the ".form-item-featureset-nexteuropa-trackedchanges" element
@@ -18,20 +23,23 @@ Feature: Change tracking features
     And I wait for the end of the batch job
     Then I should see the success message "NextEuropa Tracked Changes feature is now inactive on your site."
     When I go to "admin/config/content/wysiwyg/tracked_changes/table_status"
-    And the response should not contain "Tracked changes logs status"
+    Then the response should not contain "Tracked changes logs status"
 
   Scenario: As administrator, I could not disable the "NextEuropa Tracked Changes" feature if tracked changes are detected
   on fields that use this profile
-    Given the module is enabled
-      | modules                   |
-      | nexteuropa_trackedchanges |
-    And the following contents using "Full HTML + Change tracking" for WYSIWYG fields:
+    When I go to "admin/structure/feature-set"
+    And I click "Editorial Management"
+    And I click the ".form-item-featureset-nexteuropa-trackedchanges" element
+    And I press "Validate"
+    And I wait for the end of the batch job
+    Then I should see the success message "NextEuropa Tracked Changes feature is now active on your site."
+    When the following contents using "Full HTML + Change tracking" for WYSIWYG fields:
       | language | title                                                 | Body                                                                                                                                                                                                  | moderation state | type          |
       | und      | Article without tracked changes                       | No tracked change                                                                                                                                                                                     | validated        | article       |
       | und      | Article with tracked changes                          | There are <span class="ice-del ice-cts-1" data-changedata="" data-cid="2" data-last-change-time="1470931683200" data-time="1470931683200" data-userid="1" data-username="admin">tracked change</span> | draft            | article       |
       | en       | Page without tracked changes                          | No tracked change                                                                                                                                                                                     | validated        | page          |
       | en       | Page with tracked changes                             | There are <span class="ice-del ice-cts-1" data-changedata="" data-cid="2" data-last-change-time="1470931683200" data-time="1470931683200" data-userid="1" data-username="admin">tracked change</span> | draft            | page          |
-    When I go to "admin/structure/feature-set"
+    And I go to "admin/structure/feature-set"
     And I click "Editorial Management"
     And I click the ".form-item-featureset-nexteuropa-trackedchanges" element
     And I press "Validate"
@@ -42,16 +50,4 @@ Feature: Change tracking features
     Please accept or reject them before proceeding to the deactivation; the list of entities with tracked changes is available here.
     """
     When I go to "admin/config/content/wysiwyg/tracked_changes/table_status"
-    And the response should contain "Tracked changes logs status"
-
-  @wip
-  Scenario: As administrator, I can enable the "NextEuropa Tracked Changes" feature
-    When I go to "admin/structure/feature-set"
-    And I click "Editorial Management"
-    And I click the ".form-item-featureset-nexteuropa-trackedchanges" element
-    And I press "Validate"
-    And I wait for the end of the batch job
-    Then I should see the success message "NextEuropa Tracked Changes feature is now active on your site."
-    When I go to "admin/config/content/wysiwyg/tracked_changes/table_status"
-    And the response should contain "Tracked changes logs status"
-
+    Then the response should contain "Tracked changes logs status"

--- a/tests/features/maxlength.feature
+++ b/tests/features/maxlength.feature
@@ -8,7 +8,7 @@ Feature: Check the feature Maxlength
       | modules                 |
       | multisite_maxlength     |
 
-  @api
+  @api @resetFields
   Scenario: Contributor User can check the maxlength counts (without the tags and specific characters).
     Given I am logged in as a user with the 'administrator' role
     When I create a new "text_long" field named "test_maxlength" on "article"

--- a/tests/features/multilingual_admin.feature
+++ b/tests/features/multilingual_admin.feature
@@ -71,3 +71,104 @@ Feature: Content translation
       | fr       | Title in French  |
     When I click "New draft" in the "primary_tabs" region
     Then I should see the text "New Message!"
+
+  Scenario: Files can be translated in available languages
+    Given the following languages are available:
+      | languages |
+      | en        |
+      | fr        |
+    When I go to "file/add"
+    And I attach the file "/tests/files/logo.png" to "edit-upload-upload"
+    And I press "Next"
+    And I select the radio button "Public local files served by the webserver."
+    And I press "Next"
+    And I fill in "File name" with "English File name"
+    And I fill in "Alt Text" with "English Alt Text"
+    And I fill in "Title Text" with "English Title Text"
+    And I fill in "Caption" with "English Caption"
+    And I press "Save"
+    Then I should see the success message "Image English File name was uploaded."
+    When I click "English File name"
+    Then I should see the heading "English File name"
+    When I click "Translate" in the "primary_tabs" region
+    And I click "add" in the "French" row
+    And I fill in "File name" with "French File name"
+    And I fill in "Alt Text" with "French Alt Text"
+    And I fill in "Title Text" with "French Title Text"
+    And I fill in "Caption" with "French Caption"
+    And I press "Save"
+    Then I should see the success message "Image French File name has been updated."
+    And I should see the heading "French File name"
+    And the response should contain "alt=\"French Alt Text\""
+    And the response should contain "title=\"French Title Text\""
+    And I should see "French Caption"
+
+  Scenario: Custom URL suffix language negotiation is applied by default on new content.
+    Given the following languages are available:
+      | languages |
+      | en        |
+      | fr        |
+      | de        |
+    And I am viewing a multilingual "page" content:
+      | language | title                                  |
+      | en       | Custom URL suffix language negotiation |
+      | fr       | Suffix de language negotiation French  |
+      | de       | Suffix Sprache Verhandlung German      |
+    Then I should be on "content/custom-url-suffix-language-negotiation_en"
+    When I click "English" in the "header_top" region
+    Then I should be on the language selector page
+    When I click "Français"
+    Then I should be on "content/custom-url-suffix-language-negotiation_fr"
+    When I click "Français" in the "header_top" region
+    Then I should be on the language selector page
+    When I click "Deutsch"
+    Then I should be on "content/custom-url-suffix-language-negotiation_de"
+
+  Scenario: Enable multiple languages
+    Given the following languages are available:
+      | languages |
+      | en        |
+      | fr        |
+      | de        |
+    When I go to "admin/config/regional/language"
+    Then I should see "English"
+    And I should see "French"
+    And I should see "German"
+
+  Scenario: Check the base path doesn't change when changing language prefix
+    Given the site front page is set to "admin/fake-url"
+    And the "en" language "prefix" is set to "en-prefix"
+    And the cache has been cleared
+    When I go to "admin/config/system/site-information"
+    Then I should be on "admin/config/system/site-information"
+    # We check that path prefix set earlier does not bleeds into the site base path.
+    And I should not see "en-prefix" in the ".form-item-site-frontpage span.field-prefix" element
+    When I click "Home"
+    Then I should be on "admin/fake-url_en-prefix"
+
+  Scenario: Path alias must be synchronized through all translations of
+  content when it is manually defined and the configuration is maintained
+  when I come back on the content edit form
+    Given the following languages are available:
+      | languages |
+      | en        |
+      | fr        |
+    And I am viewing a multilingual "page" content:
+      | language | title            |
+      | en       | Title in English |
+      | fr       | Title in French  |
+    When I click "English" in the "header_top" region
+    And I click "Français"
+    Then I should be on "content/title-english_fr"
+    When I click "New draft"
+    And I uncheck the box "edit-path-pathauto"
+    And I fill in "URL alias" with "page-alias-for-all-languages"
+    And I select "published" from "Moderation state"
+    And I press "Save"
+    Then I should be on "page-alias-for-all-languages_fr"
+    When I click "Français" in the "header_top" region
+    And I click "English"
+    Then I should be on "page-alias-for-all-languages_en"
+    When I click "New draft"
+    Then I should not see the box "edit-path-pathauto" checked
+    And the "URL alias" field should contain "page-alias-for-all-languages"

--- a/tests/features/multilingual_admin.feature
+++ b/tests/features/multilingual_admin.feature
@@ -27,7 +27,7 @@ Feature: Content translation
     And I click "English" in the "content" region
     Then I should not see the text "Deutsch Body not for English version."
 
-  @javascript @maximizedwindow @wip
+  @javascript @maximizedwindow
   Scenario: Make sure that I can add "title_field" fields to a view when the Estonian language is enabled.
     Given the following languages are available:
       | languages |
@@ -71,104 +71,3 @@ Feature: Content translation
       | fr       | Title in French  |
     When I click "New draft" in the "primary_tabs" region
     Then I should see the text "New Message!"
-
-  Scenario: Files can be translated in available languages
-    Given the following languages are available:
-      | languages |
-      | en        |
-      | fr        |
-    When I go to "file/add"
-    And I attach the file "/tests/files/logo.png" to "edit-upload-upload"
-    And I press "Next"
-    And I select the radio button "Public local files served by the webserver."
-    And I press "Next"
-    And I fill in "File name" with "English File name"
-    And I fill in "Alt Text" with "English Alt Text"
-    And I fill in "Title Text" with "English Title Text"
-    And I fill in "Caption" with "English Caption"
-    And I press "Save"
-    Then I should see the success message "Image English File name was uploaded."
-    When I click "English File name"
-    Then I should see the heading "English File name"
-    When I click "Translate" in the "primary_tabs" region
-    And I click "add" in the "French" row
-    And I fill in "File name" with "French File name"
-    And I fill in "Alt Text" with "French Alt Text"
-    And I fill in "Title Text" with "French Title Text"
-    And I fill in "Caption" with "French Caption"
-    And I press "Save"
-    Then I should see the success message "Image French File name has been updated."
-    And I should see the heading "French File name"
-    And the response should contain "alt=\"French Alt Text\""
-    And the response should contain "title=\"French Title Text\""
-    And I should see "French Caption"
-
-  Scenario: Custom URL suffix language negotiation is applied by default on new content.
-    Given the following languages are available:
-      | languages |
-      | en        |
-      | fr        |
-      | de        |
-    And I am viewing a multilingual "page" content:
-      | language | title                                  |
-      | en       | Custom URL suffix language negotiation |
-      | fr       | Suffix de language negotiation French  |
-      | de       | Suffix Sprache Verhandlung German      |
-    Then I should be on "content/custom-url-suffix-language-negotiation_en"
-    When I click "English" in the "header_top" region
-    Then I should be on the language selector page
-    When I click "Français"
-    Then I should be on "content/custom-url-suffix-language-negotiation_fr"
-    When I click "Français" in the "header_top" region
-    Then I should be on the language selector page
-    When I click "Deutsch"
-    Then I should be on "content/custom-url-suffix-language-negotiation_de"
-
-  Scenario: Enable multiple languages
-    Given the following languages are available:
-      | languages |
-      | en        |
-      | fr        |
-      | de        |
-    When I go to "admin/config/regional/language"
-    Then I should see "English"
-    And I should see "French"
-    And I should see "German"
-
-  Scenario: Check the base path doesn't change when changing language prefix
-    Given the site front page is set to "admin/fake-url"
-    And the "en" language "prefix" is set to "en-prefix"
-    And the cache has been cleared
-    When I go to "admin/config/system/site-information"
-    Then I should be on "admin/config/system/site-information"
-    # We check that path prefix set earlier does not bleeds into the site base path.
-    And I should not see "en-prefix" in the ".form-item-site-frontpage span.field-prefix" element
-    When I click "Home"
-    Then I should be on "admin/fake-url_en-prefix"
-
-  Scenario: Path alias must be synchronized through all translations of
-  content when it is manually defined and the configuration is maintained
-  when I come back on the content edit form
-    Given the following languages are available:
-      | languages |
-      | en        |
-      | fr        |
-    And I am viewing a multilingual "page" content:
-      | language | title            |
-      | en       | Title in English |
-      | fr       | Title in French  |
-    When I click "English" in the "header_top" region
-    And I click "Français"
-    Then I should be on "content/title-english_fr"
-    When I click "New draft"
-    And I uncheck the box "edit-path-pathauto"
-    And I fill in "URL alias" with "page-alias-for-all-languages"
-    And I select "published" from "Moderation state"
-    And I press "Save"
-    Then I should be on "page-alias-for-all-languages_fr"
-    When I click "Français" in the "header_top" region
-    And I click "English"
-    Then I should be on "page-alias-for-all-languages_en"
-    When I click "New draft"
-    Then I should not see the box "edit-path-pathauto" checked
-    And the "URL alias" field should contain "page-alias-for-all-languages"

--- a/tests/features/nexteuropa_communities.feature
+++ b/tests/features/nexteuropa_communities.feature
@@ -14,6 +14,8 @@ Feature: Nexteuropa Communities
     And I fill in "edit-on" with "Private"
     And I fill in "edit-off" with "Public"
     And I press the "Save field settings" button
+    Then I should be on "admin/structure/types/manage/community/fields_en"
+    And I should see "Updated field Group visibility field setting"
     
   Scenario: As a group admin, all community's block are present.
     Given "community" content:
@@ -30,8 +32,6 @@ Feature: Nexteuropa Communities
     And I should see "Test community" in the "#block-menu-menu-community-menu" element
     And I should see "Test community" in the "#block-views-community-members-block-1" element
     And I should see "Create Content" in the "#block-multisite-og-button-og-contextual-links" element
-
-
 
   Scenario: URL alias for community contents are correctly generated.
     Given these modules are enabled

--- a/tests/features/nexteuropa_communities.feature
+++ b/tests/features/nexteuropa_communities.feature
@@ -1,4 +1,4 @@
-@api @cleanCommunityEnvironment
+@api @reset-nodes
 Feature: Nexteuropa Communities
   In order to effectively manage groups of people
   As a site administrator
@@ -9,14 +9,9 @@ Feature: Nexteuropa Communities
       | modules                 |
       | nexteuropa_communities  |
     # We need to rewrite value of 'group_access', because the dash in the input table does not work
-    And I am logged in as a user with the 'administrator' role
-    And I go to "admin/structure/types/manage/community/fields/group_access/field-settings_en"
-    And I fill in "edit-on" with "Private"
-    And I fill in "edit-off" with "Public"
-    And I press the "Save field settings" button
-    Then I should be on "admin/structure/types/manage/community/fields_en"
-    And I should see "Updated field Group visibility field setting"
-    
+    Given I am logged in as a user with the 'administrator' role
+    And the group access field is configured for test
+
   Scenario: As a group admin, all community's block are present.
     Given "community" content:
       | title          | workbench_moderation_state_new | status | language |
@@ -55,13 +50,12 @@ Feature: Nexteuropa Communities
       | field_ne_body                  | Lorem ipsum dolor sit amet body.     |
       | workbench_moderation_state     | published                            |
       | workbench_moderation_state_new | published                            |
-      When I go to "community/public-community"
-      Then I should see the heading "A public community"
-      When I go to "community/public-community/news/news-public-community"
-      Then I should see the heading "A News in a public community"
-      When I go to "community/public-community/basic-page/page-public-community"
-      Then I should see the heading "A page in a public community"
-
+    When I go to "community/public-community"
+    Then I should see the heading "A public community"
+    When I go to "community/public-community/news/news-public-community"
+    Then I should see the heading "A News in a public community"
+    When I go to "community/public-community/basic-page/page-public-community"
+    Then I should see the heading "A page in a public community"
 
   Scenario: As an anonymous user, I can see content of public community, and community's block
     Given I am not logged in
@@ -81,7 +75,6 @@ Feature: Nexteuropa Communities
       | workbench_moderation_state_new | published                            |
     Then I should see the heading "A Page in a public community"
     And I should see "A public community" in the "#block-menu-menu-community-menu" element
-
 
   Scenario: As an anonymous user, I cannot see content of private community
     Given I am not logged in
@@ -136,7 +129,7 @@ Feature: Nexteuropa Communities
     Then I should see the link "Request group membership"
 
 
-    Scenario: As a group member, I can create/edit/delete a group content (page) on my public community
+  Scenario: As a group member, I can create/edit/delete a group content (page) on my public community
     Given I am logged in as a user with the 'authenticated user' role
     When I am viewing a "community" content:
       | title                          | My public Community |

--- a/tests/features/nexteuropa_token/block_type_and_tokens.feature
+++ b/tests/features/nexteuropa_token/block_type_and_tokens.feature
@@ -2,10 +2,10 @@
 Feature: Test the creation of new block type (bean) and the display of them in a page using tokens.
 
   Background:
-    Given I am logged in as a user with the 'administrator' role
     Given the module is enabled
       | modules                  |
       | nexteuropa_webtools      |
+    And I am logged in as a user with the 'administrator' role
 
   Scenario: Add a new block type
     Given the cache has been cleared

--- a/tests/features/pathauto.feature
+++ b/tests/features/pathauto.feature
@@ -1,4 +1,6 @@
-@api
+@wip @api
+# This test fails because the node:field-tag is configured to store one value.
+# Also it seems that the token 'node:field-tag:parents-uri' don't exist.
 Feature: Pathauto
   In order to manage automatic aliases on the website
   As an administrator

--- a/tests/features/piwik.feature
+++ b/tests/features/piwik.feature
@@ -1,6 +1,6 @@
-@wip @api @reset-nodes
+@api
 Feature: Check Piwik
-  In order to check if the the type attribute is set for the Piwik element.
+  In order to check if the type attribute is set for the Piwik element.
   As an administrator
   I want to check Piwik is available.
   # Advanced PIWIK rules functionality
@@ -14,18 +14,11 @@ Feature: Check Piwik
       | nexteuropa_piwik   |
     And I am logged in as a user with the "PIWIK administrator" role
 
-  @wip
-  Scenario: Administrator user can check Piwik Script with the theme Bootstrap
-    When I run drush "pm-enable bootstrap -y"
-    And I run drush "vset theme_default bootstrap"
-    And the cache has been cleared
-    Then I am on the homepage
-    And the response should contain "{\"utility\":\"piwik\",\"siteID\":\"\",\"sitePath\":[\"\"],\"is404\":false,\"instance\":\"\"}"
-    When I run drush "vset theme_default ec_resp"
-    And the cache has been cleared
-    Then I am on the homepage
-    And the response should contain "{\"utility\":\"piwik\",\"siteID\":\"\",\"sitePath\":[\"\"],\"is404\":false,\"instance\":\"\"}"
+  Scenario: Check if the PIWIK script is embedded into the page correctly
+    Given I am on the homepage
+    Then the response should contain "{\"utility\":\"piwik\",\"siteID\":\"\",\"sitePath\":[\"\"],\"is404\":false,\"instance\":\"\"}"
 
+  @delete_piwik_rules
   Scenario: View advanced PIWIK rules.
     Given the nexteuropa_piwik module is configured to use advanced PIWIK rules
     And the following PIWIK rules:
@@ -38,7 +31,7 @@ Feature: Check Piwik
       | all           | ^admin/*        | regexp         | Regexp based section |
       | en            | content/test    | direct         | Direct path section  |
 
-  @javascript
+  @javascript @delete_piwik_rules
   Scenario: Add a PIWIK rule.
     Given the nexteuropa_piwik module is configured to use advanced PIWIK rules
     When I go to "/admin/config/system/webtools/piwik/advanced_rules"
@@ -53,6 +46,7 @@ Feature: Check Piwik
       | Rule language | Rule path       | Rule path type | Rule section         |
       | en            | ^admin/*        | regexp         | Regexp based section |
 
+  @delete_piwik_rules
   Scenario: Remove a PIWIK rule.
     Given the nexteuropa_piwik module is configured to use advanced PIWIK rules
     And I create the following multilingual "page" content:
@@ -72,6 +66,7 @@ Feature: Check Piwik
     When I go to "content/test"
     Then the response should not contain "\"siteSection\":\"Direct path section\""
 
+  @delete_piwik_rules
   Scenario: Assert that the direct path PIWIK rule is triggered and embedded correctly.
     Given the nexteuropa_piwik module is configured to use advanced PIWIK rules
     And the following PIWIK rules:
@@ -83,6 +78,7 @@ Feature: Check Piwik
     And I go to "content/test_en"
     Then the response should contain "\"siteSection\":\"Direct path section\""
 
+  @delete_piwik_rules
   Scenario: Assert that the regular expression based PIWIK rule is triggered and embedded correctly.
     Given the nexteuropa_piwik module is configured to use advanced PIWIK rules
     And the following PIWIK rules:

--- a/tests/features/tmgmt/tmgmt_poetry_translations.feature
+++ b/tests/features/tmgmt/tmgmt_poetry_translations.feature
@@ -5,8 +5,7 @@ Feature: TMGMT Poetry features
   I want to be able to create/manage translation requests.
 
   Background:
-    Given I am logged in as a user with the "cem" role
-    And the module is enabled
+    Given the module is enabled
       |modules                |
       |tmgmt_poetry_mock      |
     And tmgmt_poetry is configured to use tmgmt_poetry_mock
@@ -17,6 +16,7 @@ Feature: TMGMT Poetry features
       | fr        |
       | de        |
       | it        |
+    And I am logged in as a user with the "cem" role
 
   @resetPoetryNumero
   Scenario: Checking a wrong configuration.
@@ -83,7 +83,7 @@ Feature: TMGMT Poetry features
     Then the poetry translation service received the translation request
     And the translation request has titre "NE-CMS: my-website - My page"
 
-  @javascript @cleanup-tmgmt-poetry-website-identifier
+  @javascript @cleanup-tmgmt-poetry-website-identifier @poetry_mock_cleanup_translator
   Scenario: Send translation request including a website identifier with
   characters that have a special meaning in HTML.
     Given I am logged in as a user with the "cem" role

--- a/tests/src/Context/AgnosticBatchContext.php
+++ b/tests/src/Context/AgnosticBatchContext.php
@@ -24,12 +24,12 @@ class AgnosticBatchContext extends RawMinkContext {
    * Wait for the Batch API to finish.
    *
    * Wait until the id="updateprogress" element is gone,
-   * or timeout after 3 minutes (180,000 ms).
+   * or timeout after 10 minutes (600,000 ms).
    *
    * @Given /^I wait for the end of the batch job$/
    */
   public function iWaitForEndBatchJob() {
-    $this->getSession()->wait(180000, 'document.getElementById("updateprogress") == null');
+    $this->getSession()->wait(600000, 'document.getElementById("updateprogress") == null');
   }
 
 }

--- a/tests/src/Context/ContentTypeContext.php
+++ b/tests/src/Context/ContentTypeContext.php
@@ -24,7 +24,7 @@ class ContentTypeContext implements Context {
   /**
    * Remember the list of node type.
    *
-   * @BeforeScenario
+   * BeforeScenario.
    */
   public function rememberCurrentNodeTypes() {
     foreach (node_type_get_types() as $result) {
@@ -35,7 +35,7 @@ class ContentTypeContext implements Context {
   /**
    * Removes any node types created after the last list node type remembered.
    *
-   * @AfterScenario
+   * AfterScenario.
    */
   public function resetNodeTypes() {
     foreach (node_type_get_types() as $result) {

--- a/tests/src/Context/ContentTypeContext.php
+++ b/tests/src/Context/ContentTypeContext.php
@@ -24,7 +24,7 @@ class ContentTypeContext implements Context {
   /**
    * Remember the list of node type.
    *
-   * BeforeScenario.
+   * @BeforeScenario @resetNodeTypes
    */
   public function rememberCurrentNodeTypes() {
     foreach (node_type_get_types() as $result) {
@@ -35,7 +35,7 @@ class ContentTypeContext implements Context {
   /**
    * Removes any node types created after the last list node type remembered.
    *
-   * AfterScenario.
+   * @AfterScenario @resetNodeTypes
    */
   public function resetNodeTypes() {
     foreach (node_type_get_types() as $result) {

--- a/tests/src/Context/DrushContext.php
+++ b/tests/src/Context/DrushContext.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\nexteuropa\Context\DrushContext.
+ */
+
+namespace Drupal\nexteuropa\Context;
+
+use Behat\Behat\Hook\Scope\BeforeFeatureScope;
+use Drupal\DrupalExtension\Context\DrushContext as DrupalExtensionDrushContext;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+/**
+ * Context for the operations which are drush related.
+ *
+ * @package Drupal\nexteuropa\Context
+ */
+class DrushContext extends DrupalExtensionDrushContext {
+  /**
+   * Context configuration.
+   *
+   * @var array
+   */
+  private static $configuration;
+
+  /**
+   * Drush binary location.
+   *
+   * @var string
+   */
+  private $drushBin;
+
+  /**
+   * Database dump location.
+   *
+   * @var string
+   */
+  private $dumpLocation;
+
+  /**
+   * Start Time Feature.
+   *
+   * @var mixed
+   */
+  private static $startFeature;
+
+  /**
+   * DrushContext constructor.
+   *
+   * Existence of the constructor is needed in order to extend a base class.
+   *
+   * @param string $drush_bin
+   *   Drush binary location.
+   * @param string $db_dump_location
+   *   Database dump location.
+   */
+  public function __construct($drush_bin, $db_dump_location) {
+    $this->drushBin = $drush_bin;
+    $this->dumpLocation = $db_dump_location;
+  }
+
+  /**
+   * Importing the initial database dump.
+   *
+   * @BeforeFeature
+   */
+  public static function prepareDatabaseForFeatureTest(BeforeFeatureScope $scope) {
+    /** @var \Behat\Behat\Context\Environment\UninitializedContextEnvironment $env */
+    $env = $scope->getEnvironment();
+    $contexts = $env->getContextClassesWithArguments();
+
+    // We need to access this directly since the class here is not instantiated.
+    self::$configuration = $contexts[DrushContext::class];
+
+    if (!self::checkIfDbDumpFileExist()) {
+      self::createDbDump();
+    }
+    else {
+      self::dropDataBase();
+      self::importDataBase();
+    }
+
+    self::$startFeature = microtime(TRUE);
+  }
+
+  /**
+   * Show performance stats.
+   *
+   * @AfterFeature
+   */
+  public static function showStatForFeatureTest() {
+    $time_elapsed = microtime(TRUE) - self::$startFeature;
+    print ('Feature tests completed in ' . round($time_elapsed, 2) . ' sec.' . PHP_EOL);
+  }
+
+  /**
+   * Checks if the database dump file exist.
+   *
+   * @return bool
+   *   TRUE/FALSE
+   */
+  private static function checkIfDbDumpFileExist() {
+    $fs = new Filesystem();
+    return $fs->exists(self::$configuration['db_dump_location']);
+  }
+
+  /**
+   * Creates the database dump.
+   */
+  private static function createDbDump() {
+    print('Creating the database dump.' . PHP_EOL);
+    $command = "sql-dump --structure-tables-list=cache,cache_* --result-file=" . self::$configuration['db_dump_location'];
+    self::runStaticDrushCommand($command);
+  }
+
+  /**
+   * Drops the database.
+   */
+  private static function dropDataBase() {
+    print('Dropping the database dump.' . PHP_EOL);
+    $command = "sql-drop -y";
+    self::runStaticDrushCommand($command);
+  }
+
+  /**
+   * Imports database from the dump file.
+   */
+  private static function importDataBase() {
+    print('Importing the database dump.' . PHP_EOL);
+    $command = "sqlc < " . self::$configuration['db_dump_location'];
+    self::runStaticDrushCommand($command);
+  }
+
+  /**
+   * Clears all of the Drupal caches.
+   */
+  private static function clearAllCaches() {
+    print('Clearing all caches.' . PHP_EOL);
+    $command = "cc all -y";
+    self::runStaticDrushCommand($command);
+  }
+
+  /**
+   * Runs the drush command and measure the elapsed time.
+   *
+   * @param string $command
+   *   String which contains the drush command. Ex. 'sql-drop -y'.
+   */
+  private static function runStaticDrushCommand($command) {
+    $start = microtime(TRUE);
+    $drush = self::$configuration['drush_bin'];
+    $process = new Process($drush . ' ' . $command);
+    $process->run();
+
+    if (!$process->isSuccessful()) {
+      throw new ProcessFailedException($process);
+    }
+
+    $time_elapsed = microtime(TRUE) - $start;
+    print ('Operation done in ' . round($time_elapsed, 2) . ' sec.' . PHP_EOL . PHP_EOL);
+  }
+
+}

--- a/tests/src/Context/FieldContext.php
+++ b/tests/src/Context/FieldContext.php
@@ -31,7 +31,7 @@ class FieldContext implements Context {
   /**
    * Remember the list of fields existing by default in the site.
    *
-   * BeforeScenario.
+   * @BeforeScenario @resetFields
    */
   public function rememberCurrentFields() {
     $this->defaultFields = field_info_field_map();
@@ -40,7 +40,7 @@ class FieldContext implements Context {
   /**
    * Removes any fields created by a scenario.
    *
-   * AfterScenario.
+   * @AfterScenario @resetFields
    */
   public function resetFields() {
     $current_fields = field_info_field_map();
@@ -81,7 +81,7 @@ class FieldContext implements Context {
   /**
    * Remember the list of field groups existing by default in the site.
    *
-   * BeforeScenario.
+   * @BeforeScenario @resetFieldGroups
    */
   public function rememberCurrentFieldGroups() {
     $this->defaultFieldGroups = field_group_read_groups();
@@ -90,7 +90,7 @@ class FieldContext implements Context {
   /**
    * Removes any fields group created by a scenario.
    *
-   * AfterScenario.
+   * @AfterScenario @resetFieldGroups
    */
   public function resetFieldGroups() {
     $current_field_groups = field_group_read_groups();

--- a/tests/src/Context/FieldContext.php
+++ b/tests/src/Context/FieldContext.php
@@ -7,6 +7,7 @@
 namespace Drupal\nexteuropa\Context;
 
 use Behat\Behat\Context\Context;
+use Exception;
 
 /**
  * Context with field management.
@@ -30,7 +31,7 @@ class FieldContext implements Context {
   /**
    * Remember the list of fields existing by default in the site.
    *
-   * @BeforeScenario
+   * BeforeScenario.
    */
   public function rememberCurrentFields() {
     $this->defaultFields = field_info_field_map();
@@ -39,7 +40,7 @@ class FieldContext implements Context {
   /**
    * Removes any fields created by a scenario.
    *
-   * @AfterScenario
+   * AfterScenario.
    */
   public function resetFields() {
     $current_fields = field_info_field_map();
@@ -80,7 +81,7 @@ class FieldContext implements Context {
   /**
    * Remember the list of field groups existing by default in the site.
    *
-   * @BeforeScenario
+   * BeforeScenario.
    */
   public function rememberCurrentFieldGroups() {
     $this->defaultFieldGroups = field_group_read_groups();
@@ -89,7 +90,7 @@ class FieldContext implements Context {
   /**
    * Removes any fields group created by a scenario.
    *
-   * @AfterScenario
+   * AfterScenario.
    */
   public function resetFieldGroups() {
     $current_field_groups = field_group_read_groups();
@@ -139,6 +140,24 @@ class FieldContext implements Context {
           break;
       }
     }
+  }
+
+  /**
+   * Configures the group access field for testing purposes.
+   *
+   * @Given the group access field is configured for test
+   */
+  public function groupAccessFieldIsConfiguredForTest() {
+    $info = field_info_field('group_access');
+    if (is_null($info)) {
+      throw new Exception(
+        sprintf('The group access field not found.')
+      );
+    }
+    $values = &$info['settings']['allowed_values'];
+    $values[0] = 'Public';
+    $values[1] = 'Private';
+    field_update_field($info);
   }
 
 }

--- a/tests/src/Context/ModuleContext.php
+++ b/tests/src/Context/ModuleContext.php
@@ -17,50 +17,15 @@ use function bovigo\assert\predicate\isEmpty;
 class ModuleContext extends RawDrupalContext {
 
   /**
-   * List of modules enabled before the scenario.
+   * Refresh the list of module.
    *
-   * @var array
-   */
-  protected $initialModuleList  = array();
-
-
-  /**
-   * Stores the list of enabled modules before executing a scenario.
+   * Before all scenario, we need to run module_list to refresh system_list,
+   * which is needed because of memory issues.
    *
    * @BeforeScenario
    */
-  public function storeDefaultEnabledModules() {
-    $this->initialModuleList  = module_list(TRUE);
-  }
-
-  /**
-   * Restores the initial values of the Drupal modules.
-   *
-   * @AfterScenario
-   *
-   * @throws \Exception
-   *   It throws an exception if modules activated by the scenario are not
-   *   correctly uninstalled.
-   */
-  public function restoreInitialState() {
-    $after_scenario_modules = module_list(TRUE);
-
-    $lists_diff = array_diff($after_scenario_modules, $this->initialModuleList);
-
-    if ($lists_diff) {
-      module_disable($lists_diff, FALSE);
-      drupal_uninstall_modules($lists_diff);
-      drupal_flush_all_caches();
-      // Check if modules are really uninstalled.
-      module_list(TRUE);
-      foreach ($lists_diff as $module) {
-        if (module_exists($module)) {
-          throw new \Exception(sprintf('Module "%s" could not be uninstalled', implode(', ', $module)));
-
-        }
-      }
-    }
-    $this->initialModuleList  = array();
+  public function refreshDefaultEnabledModules() {
+    module_list(TRUE);
   }
 
   /**

--- a/tests/src/Context/PiwikRulesContext.php
+++ b/tests/src/Context/PiwikRulesContext.php
@@ -154,11 +154,11 @@ class PiwikRulesContext implements Context {
   }
 
   /**
-   * Removes all PIWIK rules.
+   * Removes all advanced PIWIK rules.
    *
-   * @AfterScenario
+   * @AfterScenario @delete_piwik_rules
    */
-  public function purgeAllCacheRules() {
+  public function deleteAllCacheRules() {
     if (module_exists('nexteuropa_piwik')) {
       $rules = entity_load('nexteuropa_piwik_rule');
       $rule_ids = array_keys($rules);


### PR DESCRIPTION
Clone of the PR #1309 against the release-2.4 branch.

List of squashed commits:
* NEPT-831: New DrushContext + changes in the dist files
* NEPT-831: Adding clear all caches to BeforeFeature step
* NEPT-831: Removing clearing caches (no impact), putting @wip on pathauto.feature
* NEPt-831: Changing order in the background for failing tests
* NEPT-831: Tweaking configuration for the tmgmt_poetry_translations.feature
* NEPT-831: Remove the mock TMGMT translator in a tagged scenario
* NEPT-831: Cleanup the mock TMGMT translator in a tagged scenario
* NEPT-831: Putting '@wip' on the nexteuropa_trackedchanges_set.feature:9 scenario
* NEPT-831: Tweaks on the nexteuropa_trackedchanges_set.feature
* NEPT-831: Revert on the nexteuropa_trackedchanges_set.feature
* NEPT-831: Remove an useless BeforeScenario and the format in jenkins script
* NEPT-831: Add drupal_static_reset('system_list') after ImportDatabase
* NEPT-831: Add Clear Cache All after ImportDatabase
* NEPT-831: Add drupal_static_reset('system_list') after ImportDatabase
* NEPT-831: Remove ClearCacheAll, add drupal_static_reset during BeforeScenario and add first Stats Time
* NEPT-831: Fix little issues
* NEPT-831: Revert some modifications in DrupalContext
* NEPT-831: Refesh list of module
* NEPT-831: Remove @wips
* NEPT-831: Add the NextEuropa Tracked Changes
* NEPT-831: Remove the function removeAllNodes
* NEPT-831: Add description to refreshDefaultEnabledModules
* NEPT-831: Small description change
* NEPT-831: Improve function name and a comment (minor change)
* NEPT-831: Tweaking the piwik.feature file to pass tests
* NEPT-831: Putting 'wip' tag in the piwik.feature
* NEPT-831: Tweaking the piwik.feature file again
* NEPT-831: Last try before putting the 'wip' on failing scenario
* NEPT-831: Fixing failling scenario and tweaking piwik.feature
* NEPT-831: Once again fixing failling scenario and tweaking piwik.feature