### PR TITLE
NEPT-611: Fix display of username in watchdog upon logout. 

### DIFF
--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -213,7 +213,7 @@ function ecas_login_page() {
 function ecas_logout($full_logout = TRUE) {
   global $user;
 
-  watchdog('user', 'Session closed for %name.', array('%name' => theme('placeholder', $user->name)));
+  watchdog('user', 'Session closed for %name.', array('%name' => format_username($user)));
 
   // Destroy the current session.
   session_destroy();


### PR DESCRIPTION
Fix already merged into the support-2.2 branch (PR #1200: https://github.com/ec-europa/platform-dev/pull/1200/), but not into the master branch.

Fix of the display of username in watchdog upon logout.

(Mentioned in MULTISITE-17812)