### PR TITLE
NEPT-1163: Removing the base path from the purge paths

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -506,18 +506,7 @@ function _nexteuropa_varnish_trim_base_path($path) {
   $base_path_position = strpos($path, $base_path);
 
   if ($base_path_position !== FALSE) {
-    $trimmed_path = substr_replace($path, '', $base_path_position, strlen($base_path));
-
-    // Getting the first character of the path. Function mb_substr is used
-    // because of the UTF-8 multibyte encoding.
-    $first_char = mb_substr($trimmed_path, 0, 1, 'utf-8');
-
-    // Checking if the first character of the path is not a '/'.
-    if ($first_char != "/") {
-      $trimmed_path = "/" . $trimmed_path;
-    }
-
-    return $trimmed_path;
+    return substr_replace($path, '', $base_path_position, strlen($base_path));
   }
 
   return $path;

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -210,6 +210,11 @@ function _nexteuropa_varnish_get_paths_to_purge($node) {
   $paths = array_unique($paths);
   $paths = array_filter($paths);
 
+  // NEPT-1163: Removing base path from the collected paths.
+  foreach ($paths as $key => $path) {
+    $paths[$key] = _nexteuropa_varnish_trim_base_path($path);
+  }
+
   return $paths;
 }
 
@@ -485,4 +490,26 @@ function _nexteuropa_varnish_temporary_message() {
   }
 
   return FALSE;
+}
+
+/**
+ * Trims the base path from the given path.
+ *
+ * @param string $path
+ *   Path which is going to be trimmed.
+ *
+ * @return string
+ *   Trimmed path.
+ */
+function _nexteuropa_varnish_trim_base_path($path) {
+  $base_path = base_path();
+  $base_path_position = strpos($path, $base_path);
+
+  if ($base_path_position !== FALSE) {
+    $trimmed_path = substr_replace($path, '', $base_path_position, strlen($base_path));
+
+    return "/" . $trimmed_path;
+  }
+
+  return $path;
 }

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -508,7 +508,16 @@ function _nexteuropa_varnish_trim_base_path($path) {
   if ($base_path_position !== FALSE) {
     $trimmed_path = substr_replace($path, '', $base_path_position, strlen($base_path));
 
-    return "/" . $trimmed_path;
+    // Getting the first character of the path. Function mb_substr is used
+    // because of the UTF-8 multibyte encoding.
+    $first_char = mb_substr($trimmed_path, 0, 1, 'utf-8');
+
+    // Checking if the first character of the path is not a '/'.
+    if ($first_char != "/") {
+      $trimmed_path = "/" . $trimmed_path;
+    }
+
+    return $trimmed_path;
   }
 
   return $path;


### PR DESCRIPTION
Quick fix to align with the trimmed purge paths which are expected by Varnish.