### PR TITLE
NEPT-1163: nexteuropa_varnish - unable to use cache invalidation

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -254,6 +254,11 @@ function _nexteuropa_varnish_get_paths_to_purge($node) {
     $paths = array_merge($paths, $node_paths);
   }
 
+  // NEPT-1163: Removing base path from the collected paths.
+  foreach ($paths as $key => $path) {
+    $paths[$key] = _nexteuropa_varnish_trim_base_path($path);
+  }
+
   return $paths;
 }
 
@@ -677,4 +682,24 @@ function _nexteuropa_varnish_temporary_message() {
   }
 
   return FALSE;
+}
+
+/**
+ * Trims the base path from the given path.
+ *
+ * @param string $path
+ *   Path which is going to be trimmed.
+ *
+ * @return string
+ *   Trimmed path.
+ */
+function _nexteuropa_varnish_trim_base_path($path) {
+  $base_path = base_path();
+  $base_path_position = strpos($path, $base_path);
+
+  if ($base_path_position !== FALSE) {
+    return substr_replace($path, '', $base_path_position, strlen($base_path));
+  }
+
+  return $path;
 }


### PR DESCRIPTION
## NEPT-1163

### Description
Removing base path part form the purge paths.

### Change log
- Added: new trimming function for the purge paths
- Changed: functionality of collecting paths

### Commands
No specific commands to execute 