### PR TITLE
Master into release 2.4

### DIFF
--- a/tests/behat.yml.dist
+++ b/tests/behat.yml.dist
@@ -32,6 +32,7 @@ default:
             mock_server_port: {{ varnish.server.port }}
         - Drupal\nexteuropa\Context\DatabaseLogContext
         - Drupal\nexteuropa\Context\PathautoContext
+        - Drupal\nexteuropa\Context\SchedulerContext
         - Drupal\nexteuropa\Context\MultilingualContext
         - Drupal\nexteuropa\Context\DrupalMailContext
         - Drupal\nexteuropa\Context\PiwikRulesContext

--- a/tests/features/scheduler.feature
+++ b/tests/features/scheduler.feature
@@ -1,0 +1,43 @@
+@api
+Feature: Scheduler features
+  In order to moderate contents
+  As an administrator
+  I want to be able to schedule state transitions for contents
+
+  Background:
+    Given I am logged in as a user with the 'administrator' role
+    And I change the variable "scheduler_use_vertical_tabs_page" to 1
+    And I change the variable "scheduler_unpublish_revision_page" to 0
+
+  Scenario: User can schedule a date to publish a content
+    When I go to "node/add/page"
+    And I fill in "Title" with "Next content"
+    And I fill in "publish_on[date]" with "2000-12-31"
+    And I fill in "publish_on[time]" with "23:59:59"
+    And I press the "Save" button
+    Then I should see the error message "The 'publish on' date must be in the future"
+    And I change the variable "scheduler_publish_past_date_page" to "schedule"
+    And I press the "Save" button
+    Then I should see the message "This post is unpublished and will be published 2000-12-31 23:59:59."
+    And I should see the text "Revision state: Draft"
+    And I run cron
+    And I visit the "page" content with title "Next content"
+    Then I should see the text "Revision state: Published"
+
+  Scenario: User can schedule a date to unpublish a content
+    When I go to "node/add/page"
+    And I fill in "Title" with "Old content"
+    # And I click "Publishing options"
+    And I select "Published" from "Moderation state"
+    # And I click "Scheduling options"
+    And I fill in "unpublish_on[date]" with "2000-12-31"
+    And I fill in "unpublish_on[time]" with "23:59:59"
+    And I press the "Save" button
+    Then I should see the error message "The 'unpublish on' date must be in the future"
+    When I fill in "unpublish_on[date]" with "2100-12-31"
+    And I press the "Save" button
+    Then I should see the text "Revision state: Published"
+    When I change the unpublishing date of the "page" node with title "Old content" to "-1 day"
+    And I run cron
+    And I visit the "page" content with title "Old content"
+    Then I should see the text "Revision state: Expired"

--- a/tests/src/Context/SchedulerContext.php
+++ b/tests/src/Context/SchedulerContext.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\nexteuropa\Context\SchedulerContext.
+ */
+
+namespace Drupal\nexteuropa\Context;
+
+use Behat\Behat\Context\Context;
+
+/**
+ * Context for configuring the SchedulerContext.
+ */
+class SchedulerContext implements Context {
+
+  /**
+   * The variable context.
+   *
+   * @var VariableContext
+   */
+  protected $variableContext;
+
+  /**
+   * Update unpublishing date of a node.
+   *
+   * @When I change the unpublishing date of the :type node with title :title to :date
+   */
+  public function iChangeUnpublishingDateOfTypeNodeWithTitleToDate($type, $title, $date) {
+    $target_node = db_select('node', 'n')
+      ->fields('n')
+      ->condition('title', $title, '=')
+      ->condition('type', $type, '=')
+      ->execute()
+      ->fetchAssoc();
+    if (!empty($target_node)) {
+      db_update("scheduler")
+        ->fields(array("unpublish_on" => strtotime($date)))
+        ->condition('nid', $target_node['nid'], '=')
+        ->execute();
+    }
+    else {
+      throw new \InvalidArgumentException("Node '{$title}' of type '{$type}' not found.");
+    }
+  }
+
+}


### PR DESCRIPTION
## NEPT-968

### Description

Scheduler Workbench doesn't change the state of a node on cron run

### Change log

- Fixed:
Scheduler Workbench doesn't change the state of a node on cron run

### Commands

```sh
No additional commands needed

```

