### PR TITLE
NEPT-1185: Upgrade Drupal Core to 7.56 and disable patch

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -39,7 +39,7 @@ projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-n1256368-
 ; Please read carefully: https://www.drupal.org/node/1399846?page=1#comment-11718181
 ; The hook_update_N() has been removed from the patch, it needs to be added somewhere else to be consistent.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-5641
-; projects[drupal][patch][] = https://www.drupal.org/files/issues/cleanup-files-1399846-306_0.patch
+projects[drupal][patch][] = https://www.drupal.org/files/issues/cleanup-files-1399846-315.patch 
 
 ; Make sure drupal_add_js marks files as external when no type is specified and is_external is true:
 ; https://www.drupal.org/node/2697611

--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = "core"
-projects[drupal][version] = "7.55"
+projects[drupal][version] = "7.56"
 
 ; AJAX callbacks not properly working with the language url suffix.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-4268
@@ -39,7 +39,7 @@ projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-n1256368-
 ; Please read carefully: https://www.drupal.org/node/1399846?page=1#comment-11718181
 ; The hook_update_N() has been removed from the patch, it needs to be added somewhere else to be consistent.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-5641
-projects[drupal][patch][] = https://www.drupal.org/files/issues/cleanup-files-1399846-306_0.patch
+; projects[drupal][patch][] = https://www.drupal.org/files/issues/cleanup-files-1399846-306_0.patch
 
 ; Make sure drupal_add_js marks files as external when no type is specified and is_external is true:
 ; https://www.drupal.org/node/2697611

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -271,6 +271,10 @@ projects[file_entity][patch][] = https://www.drupal.org/files/issues/2537982-fix
 
 projects[filefield_sources][subdir] = "contrib"
 projects[filefield_sources][version] = "1.10"
+; Update custom version of file_save_upload() to match Drupal 7.56
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1185
+; https://www.drupal.org/node/2888308
+projects[filefield_sources][patch][] = https://www.drupal.org/files/issues/filefield-sources-2888308-2.patch
 
 projects[filefield_sources_plupload][subdir] = "contrib"
 projects[filefield_sources_plupload][version] = "1.1"


### PR DESCRIPTION
## NEPT-1185

### Description

Update Drupal Core to 7.56

### Change log

- Removed: removed patch from MULTISITE-5641
- Security: Drupal Core 7.56

### Commands

No specific command to execute.