### PR TITLE
NEPT-1187: use withEnv step to override variables

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,12 @@ try {
             // Build and test the communities profile
             node('communities') {
                 try {
-                    executeStages('communities')
+                    withEnv([
+                        "BEHAT_PROFILE=communities",
+                        "PLATFORM_PROFILE=multisite_drupal_communities"
+                    ]) {
+                        executeStages('communities')
+                    }
                 } catch(err) {
                     throw(err)
                 }


### PR DESCRIPTION
## NEPT-1187

### Description

Use withEnv step in the pipeline to override variables

### Change log

- Merge Fixed: communities profile was not tested correctly

### Commands

No additional command needed.