### PR TITLE
NEPT-1171: Implement the components in WYSIWYG via custom stylesheet

### DIFF
--- a/profiles/common/modules/features/multisite_wysiwyg/README.md
+++ b/profiles/common/modules/features/multisite_wysiwyg/README.md
@@ -1,0 +1,37 @@
+The "Multisite WYSIWYG" feature provides default settings for the WYSIWYG features available in the NextEuropa platform.
+
+The WYSIWYG feature available on the platform is based on the [WYSIWYG module](https://www.drupal.org/project/wysiwyg) and 
+[CKEditor](http://ckeditor.com/).
+
+
+Table of content:
+=================
+- [Installation](#installation)
+- [Proposed features](#features)
+- [Configuration](#configuration)
+
+# Installation
+
+The feature is enabled by default in the NextEuropa platform.
+
+
+[Go to top](#table-of-content)
+
+# Proposed features
+
+Beside the default settings definition, it contains a mechanism that allows inserting a CSS file specific to the widget 
+of WYSIWYG fields.
+This CSS file can style the field widget content and allows contributors to see what they are typing like it will be displayed in the front-end.
+
+The difference between this mechanism and what the "WYSIWYG" module proposes is that it is based on the automatic detection of the CSS file 
+(see the [next section](#configuration)).
+
+# Configuration
+ 
+As it is a feature, the settings are applied with the module activation.
+ 
+If you need to apply a specific CSS file to the WYSIWYG field widgets, you just have to store it:
+* Under a "wysiwyg" repository placed at the root of the your default theme;
+* With "editor.css" as file name.
+
+[Go to top](#table-of-content)

--- a/profiles/common/modules/features/multisite_wysiwyg/README.md
+++ b/profiles/common/modules/features/multisite_wysiwyg/README.md
@@ -19,9 +19,9 @@ The feature is enabled by default in the NextEuropa platform.
 
 # Proposed features
 
-Beside the default settings definition, it contains a mechanism that allows inserting a CSS file specific to the widget 
-of WYSIWYG fields.
+Beside the default settings definition, it contains a mechanism that allows inserting a CSS file specific to the widget of WYSIWYG fields.
 This CSS file can style the field widget content and allows contributors to see what they are typing like it will be displayed in the front-end.
+If the base theme of the current one contains a similar file, it will be taken into account too.
 
 The difference between this mechanism and what the "WYSIWYG" module proposes is that it is based on the automatic detection of the CSS file 
 (see the [next section](#configuration)).

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
@@ -23,15 +23,15 @@ function multisite_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
     // theme, we add it to the editor settings; even if it is displayed in
     // the admin theme.
     // This approach allows a "soft" configuration of the platform.
-    $css_file_path = _multisite_wysiwyg_get_ckeditor_css_path($default_theme);
-    if ($css_file_path) {
-      $settings['contentsCss'][] = $base_url . '/' . $css_file_path;
+    $css_file_paths = _multisite_wysiwyg_get_ckeditor_css_paths($default_theme);
+    if ($css_file_paths) {
+      foreach ($css_file_paths as $css_file_path) {
+        $settings['contentsCss'][] = $base_url . '/' . $css_file_path;
+      }
     }
-
     // This namespace must be applied even if the node edit forms are displayed
     // with the admin theme.
     $settings['bodyClass'] = 'ecl-editor';
-
   }
 
 }
@@ -123,23 +123,47 @@ function multisite_wysiwyg_wysiwyg_plugin($editor, $version) {
 }
 
 /**
- * Gets the css file to use specifically with CKEditor.
+ * Gets the css files paths to use specifically with CKEditor.
  *
  * @param string $default_theme
  *   The site's default theme.
  *
- * @return bool|string
- *   The css file path or FALSE if not found.
+ * @return array
+ *   The css file paths or empty.
  */
-function _multisite_wysiwyg_get_ckeditor_css_path($default_theme = NULL) {
+function _multisite_wysiwyg_get_ckeditor_css_paths($default_theme = NULL) {
+  $cache_id = 'multisite_wysiwyg_css_paths';
+
+  if ($cache = cache_get($cache_id)) {
+    $css_file_paths = $cache->data;
+    return $css_file_paths;
+  }
+
   if (!$default_theme) {
     $default_theme = variable_get('theme_default', '');
   }
-  $css_file_path = drupal_get_path('theme', $default_theme) . '/wysiwyg/editor.css';
+  $css_file_paths = array();
+  $list_theme = list_themes();
 
-  if (file_exists($css_file_path)) {
-    return $css_file_path;
+  $implied_themes = drupal_find_base_themes($list_theme, $default_theme);
+  // If drupal_find_base_themes can return an array with only one NULL item.
+  if (empty(current($implied_themes))) {
+    $implied_themes = array();
+  }
+  // Add the active theme to the list in order to retrieve its css file
+  // reference, if exists.
+  $implied_themes[] = $default_theme;
+
+  // Build the css file paths list.
+  foreach ($implied_themes as $implied_theme) {
+    $css_file_path = drupal_get_path('theme', $implied_theme) . '/wysiwyg/editor.css';
+    if (file_exists($css_file_path)) {
+      $css_file_paths[] = $css_file_path;
+    }
   }
 
-  return FALSE;
+  // Save in the Drupal cache.
+  cache_set($cache_id, $css_file_paths, 'cache', CACHE_TEMPORARY);
+
+  return $css_file_paths;
 }

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
@@ -28,13 +28,9 @@ function multisite_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
       $settings['contentsCss'][] = $base_url . '/' . $css_file_path;
     }
 
-    // When the europa theme is the site default theme, the WYSIWYG field must
-    // receive a class that acts as namespace.
     // This namespace must be applied even if the node edit forms are displayed
     // with the admin theme.
-    if (variable_get('theme_default', '') == 'europa') {
-      $settings['bodyClass'] = 'ecl-editor';
-    }
+    $settings['bodyClass'] = 'ecl-editor';
 
   }
 

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
@@ -17,6 +17,25 @@ function multisite_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
 
     // Provide additional custom settings.
     $settings['customConfig'] = base_path() . drupal_get_path('module', 'multisite_wysiwyg') . '/multisite_wysiwyg_config.js';
+
+    $default_theme = variable_get('theme_default', '');
+    // If a specific css file has been created for CKEditor in the default
+    // theme, we add it to the editor settings; even if it is displayed in
+    // the admin theme.
+    // This approach allows a "soft" configuration of the platform.
+    $css_file_path = _multisite_wysiwyg_get_ckeditor_css_path($default_theme);
+    if ($css_file_path) {
+      $settings['contentsCss'][] = $base_url . '/' . $css_file_path;
+    }
+
+    // When the europa theme is the site default theme, the WYSIWYG field must
+    // receive a class that acts as namespace.
+    // This namespace must be applied even if the node edit forms are displayed
+    // with the admin theme.
+    if (variable_get('theme_default', '') == 'europa') {
+      $settings['bodyClass'] = 'ecl-editor';
+    }
+
   }
 
 }
@@ -105,4 +124,26 @@ function multisite_wysiwyg_wysiwyg_plugin($editor, $version) {
       ),
     );
   }
+}
+
+/**
+ * Gets the css file to use specifically with CKEditor.
+ *
+ * @param string $default_theme
+ *   The site's default theme.
+ *
+ * @return bool|string
+ *   The css file path or FALSE if not found.
+ */
+function _multisite_wysiwyg_get_ckeditor_css_path($default_theme = NULL) {
+  if (!$default_theme) {
+    $default_theme = variable_get('theme_default', '');
+  }
+  $css_file_path = drupal_get_path('theme', $default_theme) . '/wysiwyg/editor.css';
+
+  if (file_exists($css_file_path)) {
+    return $css_file_path;
+  }
+
+  return FALSE;
 }


### PR DESCRIPTION
## NEPT-1171

### Description

Implement a namespace CSS class into the CKEditor widget to format the WYSIWYG content according the ECL style guide.

### Change log

- Added: The mechanism referencing automatically the CSS file specific to the WYSIWYG widget
- Added: The "ecl-editor" CSS class into the "body" tag of the CKEditor flag to format the widget content according to the ECL style guide

### Commands

```sh
drush cc all

```

