### PR TITLE
NEPT-859: Automaticaly logout user after inactivity

### DIFF
--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -457,7 +457,7 @@ function ecas_login_check() {
       _ecas_session_end();
       drupal_goto('ecas_warning_page');
     }
-    // Case when returning with same ECAS login as before closing Drupal session.
+    // When returning with same ECAS login as before closing Drupal session.
     else {
       if (
         isset($account->data['ecas_login_date']) &&
@@ -470,11 +470,10 @@ function ecas_login_check() {
         _ecas_session_end();
 
         $msg = 'Your EU Login session needs to be renewed. For security reasons,';
-        $msg .= ' please <a href="@url">logout and login again</a>.';
-        drupal_set_message(
-          t($msg, ['@url' => phpCAS::getServerLogoutURL() . '?url=' . _ecas_get_url_site_frontpage()]),
-          'error'
-        );
+        $msg .= ' please <a href="%url">logout and login again</a>.';
+        $url = phpCAS::getServerLogoutURL() . '?url=' . _ecas_get_url_site_frontpage();
+        drupal_set_message(t('asdad', ['%url' => 'asd']), 'error');
+
         drupal_goto(_ecas_get_url_site_frontpage());
       }
       else {
@@ -820,6 +819,7 @@ function _ecas_session_end() {
  * Get the full URL for the homepage of the site.
  *
  * @return string
+ *    The full URL for the homepage of the site.
  */
 function _ecas_get_url_site_frontpage() {
   return url(variable_get('site_frontpage', 'node'), ['absolute' => TRUE]);

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -470,7 +470,7 @@ function ecas_login_check() {
         _ecas_session_end();
 
         $url = phpCAS::getServerLogoutURL() . '?url=' . _ecas_get_url_site_frontpage();
-        $msg = t('Your EU Login session needs to be renewed. For security reasons, please <a href="%url">logout and login again</a>.', ['%url' => $url]);
+        $msg = t('Your EU Login session needs to be renewed. For security reasons, please <a href="@url">logout and login again</a>.', ['@url' => $url]);
         drupal_set_message($msg, 'error');
 
         drupal_goto(_ecas_get_url_site_frontpage());

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -261,8 +261,12 @@ function ecas_logout($full_logout = TRUE, $call_hook_user_logout = TRUE) {
 
   if ($full_logout) {
     _ecas_init_phpcas_client();
+    $params = array(
+      'service' => variable_get('site_name', 'ecas'),
+      'url' => url('front', array('absolute' => TRUE)),
+    );
     drupal_alter('ecas_full_logout_parameters', $params);
-    phpCAS::logoutWithUrl(_ecas_get_url_site_frontpage());
+    phpCAS::logout($params);
   }
 
   // Go to the constructed logout destination.

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -469,10 +469,8 @@ function ecas_login_check() {
 
         _ecas_session_end();
 
-        $msg = 'Your EU Login session needs to be renewed. For security reasons,';
-        $msg .= ' please <a href="%url">logout and login again</a>.';
         $url = phpCAS::getServerLogoutURL() . '?url=' . _ecas_get_url_site_frontpage();
-        drupal_set_message(t('asdad', ['%url' => 'asd']), 'error');
+        drupal_set_message(t('Your EU Login session needs to be renewed. For security reasons, please <a href="%url">logout and login again</a>.', ['%url' => $url]), 'error');
 
         drupal_goto(_ecas_get_url_site_frontpage());
       }

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -451,26 +451,38 @@ function ecas_login_check() {
         drupal_set_message(t('Warning: no information could be found for username :username', $args));
       }
 
+      // Case when account is blocked.
       if ($account->status == 0) {
-        // Case when account is blocked.
-        session_destroy();
-
-        $user = drupal_anonymous_user();
-
-        // Since the user is blocked, we absolutely want to redirect the user
-        // to the ECAS warning page - thus, we unset any previously set
-        // destination.
-        if (isset($_REQUEST['destination'])) {
-          unset($_REQUEST['destination']);
-        }
-        if (isset($_REQUEST['edit']['destination'])) {
-          unset($_REQUEST['edit']['destination']);
-        }
+        _ecas_session_end();
         drupal_goto('ecas_warning_page');
       }
+      // Case when returning with same ECAS login as before closing Drupal session.
+      else if (
+        isset($account->data['ecas_login_date']) &&
+        $account->data['ecas_login_date'] == $user_info['cas:loginDate']
+        ) {
+
+        $msg = 'Rejected ECAS reused login: %n (ECAS)';
+        watchdog('user', $msg, array('%n' => $account->name), WATCHDOG_NOTICE);
+
+        _ecas_session_end();
+
+        $msg = 'Your EU Login session needs to be renewed. For security reasons,';
+        $msg .= ' please <a href="@url">logout and login again</a>.';
+        drupal_set_message(
+          t($msg, ['@url' => phpCAS::getServerLogoutURL() . '?url=' . _ecas_get_url_site_frontpage()]),
+          'error'
+        );
+        drupal_goto(_ecas_get_url_site_frontpage());
+      }
       else {
+
         $user = $account;
         user_login_finalize();
+
+        $edit = ['data' => []];
+        $edit['data']['ecas_login_date'] = $user_info['cas:loginDate'];
+        user_save($user, $edit);
 
         // Optionally set a non-secure cookie meaning "the user has logged in
         // using HTTPS and should not use HTTP for the duration of this
@@ -778,4 +790,34 @@ function ecas_get_user_department($user_info) {
   }
 
   return array();
+}
+
+/**
+ * End session and set global variable $user to anonymous.
+ */
+function _ecas_session_end() {
+  global $user;
+
+  session_destroy();
+
+  $user = drupal_anonymous_user();
+
+  // Since the user is blocked, we absolutely want to redirect the user
+  // to the ECAS warning page - thus, we unset any previously set
+  // destination.
+  if (isset($_REQUEST['destination'])) {
+    unset($_REQUEST['destination']);
+  }
+  if (isset($_REQUEST['edit']['destination'])) {
+    unset($_REQUEST['edit']['destination']);
+  }
+}
+
+/**
+ * Get the full URL for the homepage of the site.
+ *
+ * @return string
+ */
+function _ecas_get_url_site_frontpage() {
+  return url(variable_get('site_frontpage', 'node'), ['absolute' => TRUE]);
 }

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -151,6 +151,19 @@ function _ecas_menu(array &$items) {
 }
 
 /**
+ * Implements hook_user_logout().
+ *
+ * Apply ECAS logout logic when logging out because of autologout rules.
+ */
+function ecas_user_logout($account) {
+
+  $autologout = isset($_GET['q']) && $_GET['q'] == 'autologout_ahah_logout';
+  if ($autologout && ecas_menu_logout_check()) {
+    ecas_logout();
+  }
+}
+
+/**
  * Checks the menu.
  *
  * @return bool
@@ -765,17 +778,4 @@ function ecas_get_user_department($user_info) {
   }
 
   return array();
-}
-
-/**
- * Implements hook_user_logout().
- *
- * Apply ECAS logout logic when logging out because of autologout rules.
- */
-function ecas_user_logout($account) {
-
-  $autologout = isset($_GET['q']) && $_GET['q'] == 'autologout_ahah_logout';
-  if ($autologout && ecas_menu_logout_check()) {
-    ecas_logout();
-  }
 }

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -162,7 +162,7 @@ function ecas_user_logout($account) {
       ecas_logout(TRUE, FALSE);
     }
     elseif (variable_get('autologout_use_alt_logout_method', TRUE)) {
-      // we are taking over the default logout process from autologout,
+      // We are taking over the default logout process from autologout,
       // so we need to take full control here.
       session_destroy();
       $user = drupal_anonymous_user();
@@ -231,7 +231,6 @@ function ecas_login_page() {
  *
  * @param bool $full_logout
  *   TRUE to also log out from ECAS itself, FALSE to log out only from Drupal.
- *
  * @param bool $call_hook_user_logout
  *   TRUE to call the hook_user_logout.
  */

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -518,7 +518,7 @@ function ecas_block_view($delta = '') {
 
         // NOTE: special care needs to be taken because on pages with forms,
         // such as node and comment submission pages, the $edit variable might
-        // already be set.
+        // already be set. @todo remove this comment or explain better please.
         $output .= l(t('Login'), 'ecas');
         $output .= '</div>' . "\n";
         $block['subject'] = t('User Login');
@@ -529,7 +529,7 @@ function ecas_block_view($delta = '') {
 
         // NOTE: special care needs to be taken because on pages with forms,
         // such as node and comment submission pages, the $edit variable might
-        // already be set.
+        // already be set. @todo remove this comment or explain better please.
         $output .= l(t('Logout'), 'ecaslogout');
         $output .= '</div>' . "\n";
         $block['subject'] = t('User Login');
@@ -765,4 +765,17 @@ function ecas_get_user_department($user_info) {
   }
 
   return array();
+}
+
+/**
+ * Implements hook_user_logout().
+ *
+ * Apply ECAS logout logic when logging out because of autologout rules.
+ */
+function ecas_user_logout($account) {
+
+  $autologout = isset($_GET['q']) && $_GET['q'] == 'autologout_ahah_logout';
+  if ($autologout && ecas_menu_logout_check()) {
+    ecas_logout();
+  }
 }

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -156,17 +156,12 @@ function _ecas_menu(array &$items) {
  * Apply ECAS logout logic when logging out because of autologout rules.
  */
 function ecas_user_logout($account) {
-
   if (isset($_GET['q']) && $_GET['q'] == 'autologout_ahah_logout') {
     if (ecas_menu_logout_check()) {
       ecas_logout(TRUE, FALSE);
     }
     elseif (variable_get('autologout_use_alt_logout_method', TRUE)) {
-      // We are taking over the default logout process from autologout,
-      // so we need to take full control here.
-      session_destroy();
-      $user = drupal_anonymous_user();
-      _autologout_inactivity_message();
+      _ecas_session_end();
       drupal_goto(variable_get('site_frontpage', 'node'));
     }
   }

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -246,12 +246,8 @@ function ecas_logout($full_logout = TRUE) {
 
   if ($full_logout) {
     _ecas_init_phpcas_client();
-    $params = array(
-      'service' => variable_get('site_name', 'ecas'),
-      'url' => url('front', array('absolute' => TRUE)),
-    );
     drupal_alter('ecas_full_logout_parameters', $params);
-    phpCAS::logout($params);
+    phpCAS::logoutWithUrl(_ecas_get_url_site_frontpage());
   }
 
   // Go to the constructed logout destination.
@@ -367,100 +363,106 @@ function ecas_sync_user_info(&$user, array $user_info, array $args) {
 function ecas_login_check() {
   global $user;
 
-  $force_login = _ecas_force_login();
   if ($user->uid) {
     // The user has an uid, and it is > 0 (which is anonymous user's uid) do
     // nothing because user is already logged into Drupal.
+    return;
   }
-  elseif ($force_login != ECAS_NO_LOGIN) {
-    $ecas_sync_user_info_args = array();
 
-    // Start a new Drupal session.
-    drupal_session_start();
+  $force_login = _ecas_force_login();
+  if ($force_login == ECAS_NO_LOGIN) {
+    return;
+  }
 
-    ecas_save_page();
+  $ecas_sync_user_info_args = array();
 
-    _ecas_init_phpcas_client();
+  // Start a new Drupal session.
+  drupal_session_start();
 
-    // Adds an optional "domain" parameter to the login URL - this allows Drupal
-    // admins to specify the default ecas domain to be displayed on the login
-    // page when none could be found in the cookies sent by the browser.
-    $ecas_domain = (string) variable_get('ecas_domain', '');
-    if (drupal_strlen($ecas_domain)) {
-      $initial_server_login_url = phpCAS::getServerLoginURL();
-      $custom_server_login_url = sprintf('%s&domain=%s', $initial_server_login_url, urlencode($ecas_domain));
-      phpCAS::setServerLoginURL($custom_server_login_url);
+  ecas_save_page();
+
+  _ecas_init_phpcas_client();
+
+  // Adds an optional "domain" parameter to the login URL - this allows Drupal
+  // admins to specify the default ecas domain to be displayed on the login
+  // page when none could be found in the cookies sent by the browser.
+  $ecas_domain = (string) variable_get('ecas_domain', '');
+  if (drupal_strlen($ecas_domain)) {
+    $initial_server_login_url = phpCAS::getServerLoginURL();
+    $custom_server_login_url = sprintf('%s&domain=%s', $initial_server_login_url, urlencode($ecas_domain));
+    phpCAS::setServerLoginURL($custom_server_login_url);
+  }
+
+  // Preparing validation URL to retrieve attributes as well :
+  $assurance_level = variable_get('ecas_assurance_level', constant('ECAS_DEFAULT_ASSURANCE_LEVEL'));
+  $validate_server_url = 'https://' . FPFIS_ECAS_URL . ':' . FPFIS_ECAS_PORT;
+  $validate_server_url .= FPFIS_ECAS_URI . '/TicketValidationService?assuranceLevel=' . $assurance_level . '&ticketTypes=SERVICE,PROXY&userDetails=true&groups=*';
+  phpCAS::setServerServiceValidateURL($validate_server_url);
+
+  if ($force_login === ECAS_LOGIN) {
+    phpCAS::forceAuthentication();
+  }
+
+  if (phpCAS::isAuthenticated() && (($force_login === ECAS_GATEWAY && ($ecas_logout == NULL || $ecas_logout == 'false')) || ($force_login === ECAS_LOGIN))) {
+    $ecas_name = phpCAS::getUser();
+    $ecas_attributes = phpCAS::getAttributes();
+    $ecas_groups = $ecas_attributes['cas:groups'];
+    $ecas_email = $ecas_attributes['cas:email'];
+
+    // Try to log into Drupal.
+    $account = user_load_by_name($ecas_name);
+
+    // Extra process to filter ECAS user.
+    drupal_alter('ecas_extra_filter', $ecas_name, $account, $_SESSION['ecas_goto']);
+  }
+  else {
+    // These variables will be checked by later conditions.
+    $account = FALSE;
+    $ecas_name = NULL;
+  }
+
+  // If we don't have a user register them.
+  if (!$account && !empty($ecas_name)) {
+
+    $account = ecas_create_user($ecas_name);
+
+    if ($account && $account->uid > 0) {
+      $_SESSION['ecas_goto'] = sprintf('user/%d/edit', $account->uid);
     }
 
-    // Preparing validation URL to retrieve attributes as well :
-    $assurance_level = variable_get('ecas_assurance_level', constant('ECAS_DEFAULT_ASSURANCE_LEVEL'));
-    $validate_server_url = 'https://' . FPFIS_ECAS_URL . ':' . FPFIS_ECAS_PORT;
-    $validate_server_url .= FPFIS_ECAS_URI . '/TicketValidationService?assuranceLevel=' . $assurance_level . '&ticketTypes=SERVICE,PROXY&userDetails=true&groups=*';
-    phpCAS::setServerServiceValidateURL($validate_server_url);
+    // Set a session variable to denote this the initial login.
+    $_SESSION['ecas_first_login'] = TRUE;
 
-    if ($force_login === ECAS_LOGIN) {
-      phpCAS::forceAuthentication();
-    }
+    // Also set an extra parameter for ecas_sync_user_info() -- this allows
+    // other modules to detect a user creation.
+    $ecas_sync_user_info_args['ecas_user_creation'] = TRUE;
+  }
 
-    if (phpCAS::isAuthenticated() && (($force_login === ECAS_GATEWAY && ($ecas_logout == NULL || $ecas_logout == 'false')) || ($force_login === ECAS_LOGIN))) {
-      $ecas_name = phpCAS::getUser();
-      $ecas_attributes = phpCAS::getAttributes();
-      $ecas_groups = $ecas_attributes['cas:groups'];
-      $ecas_email = $ecas_attributes['cas:email'];
+  // Final check to make sure we have a good user.
+  if ($account && $account->uid > 0) {
+    // Retrieve information about the user from ECAS attributes.
+    $user_info = phpCAS::getAttributes();
 
-      // Try to log into Drupal.
-      $account = user_load_by_name($ecas_name);
-
-      // Extra process to filter ECAS user.
-      drupal_alter('ecas_extra_filter', $ecas_name, $account, $_SESSION['ecas_goto']);
+    // Update her information.
+    if (!empty($user_info)) {
+      ecas_sync_user_info($account, $user_info, $ecas_sync_user_info_args);
     }
     else {
-      // These variables will be checked by later conditions.
-      $account = FALSE;
-      $ecas_name = NULL;
+      $args = array(':username' => $account->name);
+      drupal_set_message(t('Warning: no information could be found for username :username', $args));
     }
 
-    // If we don't have a user register them.
-    if (!$account && !empty($ecas_name)) {
-
-      $account = ecas_create_user($ecas_name);
-
-      if ($account && $account->uid > 0) {
-        $_SESSION['ecas_goto'] = sprintf('user/%d/edit', $account->uid);
-      }
-
-      // Set a session variable to denote this the initial login.
-      $_SESSION['ecas_first_login'] = TRUE;
-
-      // Also set an extra parameter for ecas_sync_user_info() -- this allows
-      // other modules to detect a user creation.
-      $ecas_sync_user_info_args['ecas_user_creation'] = TRUE;
+    // Case when account is blocked.
+    if ($account->status == 0) {
+      _ecas_session_end();
+      drupal_goto('ecas_warning_page');
     }
-
-    // Final check to make sure we have a good user.
-    if ($account && $account->uid > 0) {
-      // Retrieve information about the user from ECAS attributes.
-      $user_info = phpCAS::getAttributes();
-
-      // Update her information.
-      if (!empty($user_info)) {
-        ecas_sync_user_info($account, $user_info, $ecas_sync_user_info_args);
-      }
-      else {
-        $args = array(':username' => $account->name);
-        drupal_set_message(t('Warning: no information could be found for username :username', $args));
-      }
-
-      // Case when account is blocked.
-      if ($account->status == 0) {
-        _ecas_session_end();
-        drupal_goto('ecas_warning_page');
-      }
-      // Case when returning with same ECAS login as before closing Drupal session.
-      else if (
+    // Case when returning with same ECAS login as before closing Drupal session.
+    else {
+      if (
         isset($account->data['ecas_login_date']) &&
         $account->data['ecas_login_date'] == $user_info['cas:loginDate']
-        ) {
+      ) {
 
         $msg = 'Rejected ECAS reused login: %n (ECAS)';
         watchdog('user', $msg, array('%n' => $account->name), WATCHDOG_NOTICE);
@@ -502,12 +504,13 @@ function ecas_login_check() {
         ecas_login_page();
       }
     }
-    // If we have a good user.
-    else {
-      unset($_SESSION['phpCAS']);
-      $user = drupal_anonymous_user();
-    }
   }
+  // If we have a good user.
+  else {
+    unset($_SESSION['phpCAS']);
+    $user = drupal_anonymous_user();
+  }
+
 }
 
 /**

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -560,9 +560,6 @@ function ecas_block_view($delta = '') {
       if (!$user->uid) {
         $output = '<div class="user-login-block">' . "\n";
 
-        // NOTE: special care needs to be taken because on pages with forms,
-        // such as node and comment submission pages, the $edit variable might
-        // already be set. @todo remove this comment or explain better please.
         $output .= l(t('Login'), 'ecas');
         $output .= '</div>' . "\n";
         $block['subject'] = t('User Login');
@@ -571,9 +568,6 @@ function ecas_block_view($delta = '') {
       else {
         $output = '<div class="user-login-block">' . "\n";
 
-        // NOTE: special care needs to be taken because on pages with forms,
-        // such as node and comment submission pages, the $edit variable might
-        // already be set. @todo remove this comment or explain better please.
         $output .= l(t('Logout'), 'ecaslogout');
         $output .= '</div>' . "\n";
         $block['subject'] = t('User Login');

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -470,7 +470,8 @@ function ecas_login_check() {
         _ecas_session_end();
 
         $url = phpCAS::getServerLogoutURL() . '?url=' . _ecas_get_url_site_frontpage();
-        drupal_set_message(t('Your EU Login session needs to be renewed. For security reasons, please <a href="%url">logout and login again</a>.', ['%url' => $url]), 'error');
+        $msg = t('Your EU Login session needs to be renewed. For security reasons, please <a href="%url">logout and login again</a>.', ['%url' => $url]);
+        drupal_set_message($msg, 'error');
 
         drupal_goto(_ecas_get_url_site_frontpage());
       }

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -157,9 +157,18 @@ function _ecas_menu(array &$items) {
  */
 function ecas_user_logout($account) {
 
-  $autologout = isset($_GET['q']) && $_GET['q'] == 'autologout_ahah_logout';
-  if ($autologout && ecas_menu_logout_check()) {
-    ecas_logout();
+  if (isset($_GET['q']) && $_GET['q'] == 'autologout_ahah_logout') {
+    if (ecas_menu_logout_check()) {
+      ecas_logout(TRUE, FALSE);
+    }
+    elseif (variable_get('autologout_use_alt_logout_method', TRUE)) {
+      // we are taking over the default logout process from autologout,
+      // so we need to take full control here.
+      session_destroy();
+      $user = drupal_anonymous_user();
+      _autologout_inactivity_message();
+      drupal_goto(variable_get('site_frontpage', 'node'));
+    }
   }
 }
 
@@ -222,8 +231,11 @@ function ecas_login_page() {
  *
  * @param bool $full_logout
  *   TRUE to also log out from ECAS itself, FALSE to log out only from Drupal.
+ *
+ * @param bool $call_hook_user_logout
+ *   TRUE to call the hook_user_logout.
  */
-function ecas_logout($full_logout = TRUE) {
+function ecas_logout($full_logout = TRUE, $call_hook_user_logout = TRUE) {
   global $user;
 
   watchdog('user', 'Session closed for %name.', array('%name' => format_username($user)));
@@ -231,7 +243,10 @@ function ecas_logout($full_logout = TRUE) {
   // Destroy the current session.
   session_destroy();
   $user = drupal_anonymous_user();
-  module_invoke_all('user_logout', $user);
+
+  if ($call_hook_user_logout) {
+    module_invoke_all('user_logout', $user);
+  }
 
   // We have to use $GLOBALS to unset a global variable.
   $user = user_load(0);

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.info
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.info
@@ -2,6 +2,7 @@ name = NextEuropa Core
 description = NextEuropa Core feature.
 core = 7.x
 package = NextEuropa
+dependencies[] = autologout
 dependencies[] = bean
 dependencies[] = bean_admin_ui
 dependencies[] = bean_entitycache

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.install
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.install
@@ -130,7 +130,7 @@ function nexteuropa_core_update_7004() {
 /**
  * Implements hook_update_N().
  */
-function ecas_update_7005() {
-  module_enable('autologout');
-  vset('autologout_use_alt_logout_method', 1);
+function nexteuropa_core_update_7005() {
+  module_enable(['autologout']);
+  variable_set('autologout_use_alt_logout_method', 1);
 }

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.install
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.install
@@ -133,4 +133,6 @@ function nexteuropa_core_update_7004() {
 function nexteuropa_core_update_7005() {
   module_enable(['autologout']);
   variable_set('autologout_use_alt_logout_method', 1);
+  variable_set('autologout_use_watchdog', 1);
+  variable_set('autologout_enforce_admin', 1);
 }

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.install
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.install
@@ -131,5 +131,6 @@ function nexteuropa_core_update_7004() {
  * Implements hook_update_N().
  */
 function ecas_update_7005() {
+  module_enable('autologout');
   vset('autologout_use_alt_logout_method', 1);
 }

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.install
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.install
@@ -126,3 +126,10 @@ function nexteuropa_core_update_7004() {
   // Set permissions for "editor" role.
   multisite_config_service('user')->grantPermission('editor', $permissions);
 }
+
+/**
+ * Implements hook_update_N().
+ */
+function ecas_update_7005() {
+  vset('autologout_use_alt_logout_method', 1);
+}

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.module
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.module
@@ -8,13 +8,6 @@ include_once 'nexteuropa_core.features.inc';
 include_once 'nexteuropa_core.tokens.inc';
 
 /**
- * Implements hook_init().
- */
-function nexteuropa_core_init() {
-
-}
-
-/**
  * Implements hook_form_FORM_ID_alter().
  */
 function nexteuropa_core_form_taxonomy_overview_terms_alter(&$form, $form_state) {

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.strongarm.inc
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.strongarm.inc
@@ -87,5 +87,12 @@ function nexteuropa_core_strongarm() {
   $strongarm->value = 1;
   $export['chosen_use_theme'] = $strongarm;
 
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'autologout_use_alt_logout_method';
+  $strongarm->value = 1;
+  $export['autologout_use_alt_logout_method'] = $strongarm;
+
   return $export;
 }

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.strongarm.inc
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.strongarm.inc
@@ -94,5 +94,19 @@ function nexteuropa_core_strongarm() {
   $strongarm->value = 1;
   $export['autologout_use_alt_logout_method'] = $strongarm;
 
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'autologout_use_watchdog';
+  $strongarm->value = 1;
+  $export['autologout_use_watchdog'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'autologout_enforce_admin';
+  $strongarm->value = 1;
+  $export['autologout_enforce_admin'] = $strongarm;
+
   return $export;
 }

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -72,6 +72,11 @@ projects[apachesolr_multilingual][version] = "1.3"
 projects[apachesolr_multisitesearch][subdir] = "contrib"
 projects[apachesolr_multisitesearch][version] = "1.1"
 
+projects[autologout][subdir] = "contrib"
+projects[autologout][version] = "4.4"
+; https://www.drupal.org/node/2739114
+projects[autologout][patch][] = https://www.drupal.org/files/issues/change-warning-message-2739114-15.patch
+
 projects[autosave][subdir] = "contrib"
 projects[autosave][version] = "2.2"
 

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -74,6 +74,7 @@ projects[apachesolr_multisitesearch][version] = "1.1"
 
 projects[autologout][subdir] = "contrib"
 projects[autologout][version] = "4.4"
+; Issue #2739114 : Change warning message to be more user friendly
 ; https://www.drupal.org/node/2739114
 projects[autologout][patch][] = https://www.drupal.org/files/issues/change-warning-message-2739114-15.patch
 


### PR DESCRIPTION
## NEPT-859

### Description

Automaticaly logout user after inactivity.
Don't allow to use the same EU Login session after logout from Drupal.

### Change log

- Added: Module [Autologout](https://www.drupal.org/project/autologout), always enabled;
- Added: Set variables for Autologout;
- Changed: Automaticaly logout user after inactivity (set to 30 minutes);
- Changed: ECAS login process will prevent reuse of same EU Login session after logout from Drupal.

### Commands

```sh
$ drush updb
```

