### PR TITLE
NEPT-1191: Stabilize theme: Create new phing target

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,7 @@ void executeStages(String label, String theme) {
     // Use random ports for the HTTP mock and PhantomJS, compute paths, use random DB name
     Random random = new Random()
     env.PROJECT = 'platform-dev'
+    env.DEFAULT_THEME = theme
     tokens = "${env.WORKSPACE}".tokenize('/')
     env.SITE_PATH = tokens[tokens.size()-1]
     env.DB_NAME = "${env.PROJECT}".replaceAll('-','_').trim() + '_' + sh(returnStdout: true, script: 'date | md5sum | head -c 4').trim()
@@ -66,7 +67,7 @@ void executeStages(String label, String theme) {
                 [$class: 'UsernamePasswordMultiBinding', credentialsId: 'mysql', usernameVariable: 'DB_USER', passwordVariable: 'DB_PASS'],
                 [$class: 'UsernamePasswordMultiBinding', credentialsId: 'flickr', usernameVariable: 'FLICKR_KEY', passwordVariable: 'FLICKR_SECRET']
             ]) {
-                sh "./bin/phing build-platform-dev -Dcomposer.bin=`which composer` -D'behat.base_url'='$BASE_URL/$SITE_PATH/build' -D'behat.wd_host.url'='$WD_HOST_URL' -D'behat.browser.name'='$WD_BROWSER_NAME' -D'env.FLICKR_KEY'='$FLICKR_KEY' -D'env.FLICKR_SECRET'='$FLICKR_SECRET' -D'integration.server.port'='$HTTP_MOCK_PORT' -D'varnish.server.port'='$HTTP_MOCK_PORT' -D'platform.profile.name'='$PLATFORM_PROFILE'"
+                sh "./bin/phing build-platform-dev -Dcomposer.bin=`which composer` -D'behat.base_url'='$BASE_URL/$SITE_PATH/build' -D'behat.wd_host.url'='$WD_HOST_URL' -D'behat.browser.name'='$WD_BROWSER_NAME' -D'env.FLICKR_KEY'='$FLICKR_KEY' -D'env.FLICKR_SECRET'='$FLICKR_SECRET' -D'integration.server.port'='$HTTP_MOCK_PORT' -D'varnish.server.port'='$HTTP_MOCK_PORT' -D'platform.profile.name'='$PLATFORM_PROFILE' -D'platform.site.theme_default'='$DEFAULT_THEME'"
                 sh "./bin/phing install-platform -D'platform.site.theme_default'='"  + theme + "' -D'drupal.db.name'='$DB_NAME' -D'drupal.db.user'='$DB_USER' -D'drupal.db.password'='$DB_PASS' -D'platform.profile.name'='$PLATFORM_PROFILE'"
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,14 +14,14 @@ try {
                 }
             }
         },
-        'standard-europa' : {
+        'standard-ec-europa' : {
             // Build and test the standard profile with europa theme
             node('php5') {
                 try {
                     withEnv([
-                        "THEME_DEFAULT=europa"
+                        "THEME_DEFAULT=ec_europa"
                     ]) {
-                        executeStages('standard europa')
+                        executeStages('standard ec_europa')
                     }
                 } catch(err) {
                     throw(err)
@@ -43,16 +43,16 @@ try {
                 }
             }
         },
-        'communities-europa' : {
+        'communities-ec-europa' : {
             // Build and test the communities profile with europa theme
             node('php5') {
                 try {
                     withEnv([
                         "BEHAT_PROFILE=communities",
                         "PLATFORM_PROFILE=multisite_drupal_communities",
-                        "THEME_DEFAULT=europa"
+                        "THEME_DEFAULT=ec_europa"
                     ]) {
-                        executeStages('communities europa')
+                        executeStages('communities ec_europa')
                     }
                 } catch(err) {
                     throw(err)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,14 +8,8 @@ try {
             // Build, test and package the standard profile
             node('standard') {
                 try {
-                    executeStages('Standard EC Resp', 'ec_resp')
-                } catch(err) {
-                    throw(err)
-                }
-            }
-            node('standard') {
-                try {
                     executeStages('Standard Europa', 'europa')
+                    executeStages('Standard EC Resp', 'ec_resp')
                 } catch(err) {
                     throw(err)
                 }
@@ -25,14 +19,8 @@ try {
             // Build and test the communities profile
             node('communities') {
                 try {
-                    executeStages('Communities EC Resp', 'ec_resp')
-                } catch(err) {
-                    throw(err)
-                }
-            }
-            node('communities') {
-                try {
                     executeStages('Communities Europa', 'europa')
+                    executeStages('Communities EC Resp', 'ec_resp')
                 } catch(err) {
                     throw(err)
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ try {
     parallel (
         'standard-ec-resp' : {
             // Build and test the standard profile with ec_resp theme
-            node('standard') {
+            node('php5') {
                 try {
                     executeStages('standard ec_resp')
                 } catch(err) {
@@ -16,13 +16,12 @@ try {
         },
         'standard-europa' : {
             // Build and test the standard profile with europa theme
-            node('standard') {
+            node('php5') {
                 try {
                     withEnv([
                         "THEME_DEFAULT=europa"
                     ]) {
-                        // TODO: tests to be fixed, see NEPT-1172
-                        // executeStages('standard europa')
+                        executeStages('standard europa')
                     }
                 } catch(err) {
                     throw(err)
@@ -31,12 +30,11 @@ try {
         },
         'communities-ec-resp' : {
             // Build and test the communities profile with ec_resp theme
-            node('communities') {
+            node('php5') {
                 try {
                     withEnv([
                         "BEHAT_PROFILE=communities",
-                        "PLATFORM_PROFILE=multisite_drupal_communities",
-                        "THEME_DEFAULT=ec_resp"
+                        "PLATFORM_PROFILE=multisite_drupal_communities"
                     ]) {
                         executeStages('communities ec_resp')
                     }
@@ -47,15 +45,14 @@ try {
         },
         'communities-europa' : {
             // Build and test the communities profile with europa theme
-            node('communities') {
+            node('php5') {
                 try {
                     withEnv([
                         "BEHAT_PROFILE=communities",
                         "PLATFORM_PROFILE=multisite_drupal_communities",
                         "THEME_DEFAULT=europa"
                     ]) {
-                        // TODO: tests to be fixed, see NEPT-1172
-                        // executeStages('communities europa')
+                        executeStages('communities europa')
                     }
                 } catch(err) {
                     throw(err)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,8 @@ try {
                     withEnv([
                         "THEME_DEFAULT=europa"
                     ]) {
-                        executeStages('standard europa')
+                        // TODO: tests to be fixed, see NEPT-1172
+                        // executeStages('standard europa')
                     }
                 } catch(err) {
                     throw(err)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,8 @@ try {
                         "PLATFORM_PROFILE=multisite_drupal_communities",
                         "THEME_DEFAULT=europa"
                     ]) {
-                        executeStages('communities europa')
+                        // TODO: tests to be fixed, see NEPT-1172
+                        // executeStages('communities europa')
                     }
                 } catch(err) {
                     throw(err)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,12 @@ try {
             // Build and test the standard profile with ec_resp theme
             node('php5') {
                 try {
-                    executeStages('standard ec_resp')
+                    withEnv([
+                        "BEHAT_PROFILE=standard_ec_resp",
+                        "THEME_DEFAULT=ec_resp"
+                    ]) {
+                        executeStages('standard ec_resp')
+                    }
                 } catch(err) {
                     throw(err)
                 }
@@ -33,7 +38,7 @@ try {
             node('php5') {
                 try {
                     withEnv([
-                        "BEHAT_PROFILE=communities",
+                        "BEHAT_PROFILE=communities_ec_resp",
                         "PLATFORM_PROFILE=multisite_drupal_communities"
                     ]) {
                         executeStages('communities ec_resp')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,14 @@ try {
             // Build, test and package the standard profile
             node('standard') {
                 try {
-                    executeStages('standard')
+                    executeStages('Standard EC Resp', 'ec_resp')
+                } catch(err) {
+                    throw(err)
+                }
+            }
+            node('standard') {
+                try {
+                    executeStages('Standard Europa', 'europa')
                 } catch(err) {
                     throw(err)
                 }
@@ -18,12 +25,14 @@ try {
             // Build and test the communities profile
             node('communities') {
                 try {
-                    withEnv([
-                        "BEHAT_PROFILE=communities",
-                        "PLATFORM_PROFILE=multisite_drupal_communities"
-                    ]) {
-                        executeStages('communities')
-                    }
+                    executeStages('Communities EC Resp', 'ec_resp')
+                } catch(err) {
+                    throw(err)
+                }
+            }
+            node('communities') {
+                try {
+                    executeStages('Communities Europa', 'europa')
                 } catch(err) {
                     throw(err)
                 }
@@ -42,7 +51,7 @@ slackSend color: "good", message: "${env.slackMessage} complete."
  *
  * @param label The text that will be displayed as stage label.
  */
-void executeStages(String label) {
+void executeStages(String label, String theme) {
     // Use random ports for the HTTP mock and PhantomJS, compute paths, use random DB name
     Random random = new Random()
     env.PROJECT = 'platform-dev'
@@ -65,7 +74,7 @@ void executeStages(String label) {
                 [$class: 'UsernamePasswordMultiBinding', credentialsId: 'flickr', usernameVariable: 'FLICKR_KEY', passwordVariable: 'FLICKR_SECRET']
             ]) {
                 sh "./bin/phing build-platform-dev -Dcomposer.bin=`which composer` -D'behat.base_url'='$BASE_URL/$SITE_PATH/build' -D'behat.wd_host.url'='$WD_HOST_URL' -D'behat.browser.name'='$WD_BROWSER_NAME' -D'env.FLICKR_KEY'='$FLICKR_KEY' -D'env.FLICKR_SECRET'='$FLICKR_SECRET' -D'integration.server.port'='$HTTP_MOCK_PORT' -D'varnish.server.port'='$HTTP_MOCK_PORT' -D'platform.profile.name'='$PLATFORM_PROFILE'"
-                sh "./bin/phing install-platform -D'drupal.db.name'='$DB_NAME' -D'drupal.db.user'='$DB_USER' -D'drupal.db.password'='$DB_PASS' -D'platform.profile.name'='$PLATFORM_PROFILE'"
+                sh "./bin/phing install-platform -D'platform.site.theme_default'='"  + theme + "' -D'drupal.db.name'='$DB_NAME' -D'drupal.db.user'='$DB_USER' -D'drupal.db.password'='$DB_PASS' -D'platform.profile.name'='$PLATFORM_PROFILE'"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,8 @@ try {
             // Build, test and package the standard profile
             node('standard') {
                 try {
-                    executeStages('Standard Europa', 'europa')
                     executeStages('Standard EC Resp', 'ec_resp')
+                    executeStages('Standard Europa', 'europa')
                 } catch(err) {
                     throw(err)
                 }
@@ -19,8 +19,13 @@ try {
             // Build and test the communities profile
             node('communities') {
                 try {
-                    executeStages('Communities Europa', 'europa')
-                    executeStages('Communities EC Resp', 'ec_resp')
+                    withEnv([
+                        "BEHAT_PROFILE=communities",
+                        "PLATFORM_PROFILE=multisite_drupal_communities"
+                    ]) {
+                        executeStages('Communities EC Resp', 'ec_resp')
+                        executeStages('Communities Europa', 'europa')
+                    }
                 } catch(err) {
                     throw(err)
                 }

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ ./bin/phing install-platform
   - The default Atomium and Europa theme build properties. Used only if default theme is set to "europa".
   You can find default values of those variables below. 
   
->platform.theme.atomium.repo.url = https://github. com/ec-europa/atomium.git
+>platform.theme.atomium.repo.url = https://github.com/ec-europa/atomium.git
 >platform.theme.atomium.repo.branch = 7.x-1.x
 >platform.theme.europa.repo.url = https://github.com/ec-europa/ec-europa-theme.git
 >platform.theme.europa.repo.branch = europa-atomium

--- a/README.md
+++ b/README.md
@@ -83,13 +83,16 @@ $ ./bin/phing install-platform
 
 > ecl.version = v0.10.0
   
-  - The default Atomium and Europa theme build properties. Used only if default theme is set to "europa".
+  - The default EC Europa theme release version.
+
+> ec_europa.version = 0.0.2
+
+  - The default Atomium theme build properties. Used only if default theme is set to "europa".
   You can find default values of those variables below. 
   
 >platform.theme.atomium.repo.url = https://github.com/ec-europa/atomium.git
 >platform.theme.atomium.repo.branch = 7.x-1.x
->platform.theme.europa.repo.url = https://github.com/ec-europa/ec-europa-theme.git
->platform.theme.europa.repo.branch = europa-atomium
+
 
 ## Building a local development environment for the EC Europa theme
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ ./bin/phing install-platform
 
 ### From the release 2.4.x following configuration variables are available:
 
-  - The default theme to enable, set to either "ec_resp" (default) or "europa".
+  - The default theme to enable, set to either "ec_resp" (default) or "ec_europa".
 
 > platform.site.theme_default = ec_resp
 
@@ -87,7 +87,7 @@ $ ./bin/phing install-platform
 
 > ec_europa.version = 0.0.2
 
-  - The default Atomium theme build properties. Used only if default theme is set to "europa".
+  - The default Atomium theme build properties. Used only if default theme is set to "ec_europa".
   You can find default values of those variables below. 
   
 >platform.theme.atomium.repo.url = https://github.com/ec-europa/atomium.git
@@ -105,7 +105,7 @@ fetch the release package of the Europa Components Library and regenerate theme 
 **To run this target you must have node.js and npm installed on your local machine.**
 You need also configure additional configuration variables which are described in the
 section above. The most important is to set the `platform.site.theme_default` variable
-to `europa`.
+to `ec_europa`.
 
 You can use this Phing target in the following way:
 ```

--- a/README.md
+++ b/README.md
@@ -73,6 +73,43 @@ $ ./bin/phing build-platform-dev
 $ ./bin/phing install-platform
 ```
 
+### From the release 2.4.x following configuration variables are available:
+
+  - The default theme to enable, set to either "ec_resp" (default) or "europa".
+
+> platform.site.theme_default = ec_resp
+
+  - The default Europa Component Library release which is used to build the EC Europa theme.
+
+> ecl.version = v0.10.0
+  
+  - The default Atomium and Europa theme build properties. Used only if default theme is set to "europa".
+  You can find default values of those variables below. 
+  
+>platform.theme.atomium.repo.url = https://github. com/ec-europa/atomium.git
+>platform.theme.atomium.repo.branch = 7.x-1.x
+>platform.theme.europa.repo.url = https://github.com/ec-europa/ec-europa-theme.git
+>platform.theme.europa.repo.branch = europa-atomium
+
+## Building a local development environment for the EC Europa theme
+
+There is a specific Phing target which is setting up the development environment
+for the EC Europa theme needs. It helps developers to perform code reviews and
+contribute code to the repositories.
+It clones the repository of the Atomium and EC Europa themes. It will also
+fetch the release package of the Europa Components Library and regenerate theme assets.
+
+**To run this target you must have node.js and npm installed on your local machine.**
+You need also configure additional configuration variables which are described in the
+section above. The most important is to set the `platform.site.theme_default` variable
+to `europa`.
+
+You can use this Phing target in the following way:
+```
+$ ./bin/phing build-europa-dev
+```
+This Phing target is meant to be used only for the local development purposes.
+
 ## Running Behat tests
 
 The Behat test suite is located in the `tests/` folder. When the development

--- a/build.package.xml
+++ b/build.package.xml
@@ -206,7 +206,7 @@
         <mkdir dir="profiles/common/themes/ec_europa" />
         <exec
             dir="profiles/common/themes"
-            command="tar xzv ec_europa.tar.gz --strip=1 -C ec_europa"
+            command="tar xzf ec_europa.tar.gz --strip=1 -C ec_europa"
             passthru="true" />
         <delete file="profiles/common/themes/ec_europa.tar.gz" quiet="true" />
         <phingcall target="embed-ecl-assets" />
@@ -220,7 +220,7 @@
         <!-- Extract and embed the ECL artifacts into the Europa theme. -->
         <exec
             dir="profiles/common/themes/ec_europa"
-            command="tar xzv framework.tar.gz --strip=1 -C assets"
+            command="tar xzf framework.tar.gz --strip=1 -C assets"
             passthru="true" />
         <delete file="profiles/common/themes/ec_europa/framework.tar.gz" quiet="true" />
     </target>
@@ -239,14 +239,14 @@
         description="Build a local development version of the platform based on the EC Europa theme."
         depends="install-build-dependencies, delete-platform, make-drupal-core, link-platform-profiles, make-platform, link-platform-resources, install-platform-dev-dependencies, setup-behat, setup-behat-balancer, setup-phpunit, setup-php-codesniffer, update-htaccess, setup-files-directory, europa-theme-repo-clone, europa-theme-build" />
 
-    <!-- Clonning and checking out the branch of the Atomium and EC Europa theme repositories. -->
+    <!-- Cloning and checking out the branch of the Atomium and EC Europa theme repositories. -->
     <target name="europa-theme-repo-clone">
-        <!-- Deleting theme directories before clonning -->
+        <!-- Deleting theme directories before cloning -->
         <delete dir="${platform.resources.profiles.common.themes.dir}/atomium" quiet="true"/>
         <delete dir="${platform.resources.profiles.common.themes.dir}/ec_europa" quiet="true"/>
 
-        <!-- Clonning the Atomium theme repo into the common profiles directory -->
-        <echo msg = "Clonning the Atomium theme repository."/>
+        <!-- Cloning the Atomium theme repo into the common profiles directory -->
+        <echo msg = "Cloning the Atomium theme repository."/>
         <gitclone
             repository="${platform.theme.atomium.repo.url}"
             targetPath="${platform.resources.profiles.common.themes.dir}/atomium"/>
@@ -255,7 +255,7 @@
             repository="${platform.resources.profiles.common.themes.dir}/atomium"
             branchname="${platform.theme.atomium.repo.branch}"/>
 
-        <!-- Clonning the EC Europa theme repo into the common profiles directory -->
+        <!-- cloning the EC Europa theme repo into the common profiles directory -->
         <echo msg = "Cloning the EC Europa theme repository."/>
         <gitclone
             repository="${platform.theme.europa.repo.url}"

--- a/build.package.xml
+++ b/build.package.xml
@@ -206,7 +206,7 @@
         <mkdir dir="profiles/common/themes/ec_europa" />
         <exec
             dir="profiles/common/themes"
-            command="tar xzvf europa.tar.gz --strip=1 -C europa"
+            command="tar xzvf ec_europa.tar.gz --strip=1 -C ec_europa"
             passthru="true" />
         <delete file="profiles/common/themes/ec_europa.tar.gz" quiet="true" />
         <phingcall target="embed-ecl-assets" />

--- a/build.package.xml
+++ b/build.package.xml
@@ -200,13 +200,13 @@
     <target name="process-europa-theme">
         <!-- Download the Europa theme archive for a given branch. -->
         <exec
-            command="curl -L https://api.github.com/repos/ec-europa/ec_europa/tarball/${platform.theme.europa.repo.tag} > profiles/common/themes/europa.tar.gz"
+            command="curl -L https://github.com/ec-europa/ec_europa/releases/download/${ec_europa.version}/ec_europa-${ec_europa.version}.tar.gz > profiles/common/themes/europa.tar.gz"
             passthru="true" />
         <!-- Extract the archive -->
         <mkdir dir="profiles/common/themes/europa" />
         <exec
             dir="profiles/common/themes"
-            command="tar xvf europa.tar.gz --strip=1 -C europa"
+            command="tar xzvf europa.tar.gz --strip=1 -C europa"
             passthru="true" />
         <delete file="profiles/common/themes/europa.tar.gz" quiet="true" />
         <phingcall target="embed-ecl-assets" />
@@ -256,7 +256,7 @@
             branchname="${platform.theme.atomium.repo.branch}"/>
 
         <!-- Clonning the Europa theme repo into the common profiles directory -->
-        <echo msg = "Clonning the Europa theme repository."/>
+        <echo msg = "Cloning the Europa theme repository."/>
         <gitclone
             repository="${platform.theme.europa.repo.url}"
             targetPath="${platform.resources.profiles.common.themes.dir}/europa"/>

--- a/build.package.xml
+++ b/build.package.xml
@@ -200,7 +200,7 @@
     <target name="process-europa-theme">
         <!-- Download the Europa theme archive for a given branch. -->
         <exec
-            command="curl -L https://api.github.com/repos/ec-europa/ec-europa-theme/tarball/${platform.theme.europa.repo.branch} > profiles/common/themes/europa.tar.gz"
+            command="curl -L https://api.github.com/repos/ec-europa/ec_europa/tarball/${platform.theme.europa.repo.tag} > profiles/common/themes/europa.tar.gz"
             passthru="true" />
         <!-- Extract the archive -->
         <mkdir dir="profiles/common/themes/europa" />

--- a/build.package.xml
+++ b/build.package.xml
@@ -190,26 +190,10 @@
 
     <target
         name="build-europa-theme"
-        description="Downloads Atomium and Europa themes with embedded ECL artifacts.">
+        description="Downloads Europa theme and creates symlink.">
 
-        <phingcall target="process-atomium-theme" />
         <phingcall target="process-europa-theme" />
         <phingcall target="create-europa-theme-symlinks" />
-    </target>
-
-    <!-- Download and extract the Atomium theme. -->
-    <target name="process-atomium-theme">
-        <!-- Download the Atomium theme archive for a given branch. -->
-        <exec
-            command="curl -L https://api.github.com/repos/ec-europa/atomium/tarball/${platform.theme.atomium.repo.branch} > profiles/common/themes/atomium.tar.gz"
-            passthru="true" />
-        <!-- Extract the archive -->
-        <mkdir dir="profiles/common/themes/atomium" />
-        <exec
-            dir="profiles/common/themes"
-            command="tar xvf atomium.tar.gz --strip=1 -C atomium"
-            passthru="true" />
-        <delete file="profiles/common/themes/atomium.tar.gz" quiet="true" />
     </target>
 
     <!-- This step in future will become a part of a build on the new Europa theme repository. -->
@@ -245,7 +229,6 @@
     <target name="create-europa-theme-symlinks" >
         <symlink link="profiles/${platform.profile.name}/themes">
             <fileset dir="${platform.resources.profiles.common.themes.dir}">
-                <include name="atomium" />
                 <include name="europa" />
             </fileset>
         </symlink>

--- a/build.package.xml
+++ b/build.package.xml
@@ -196,6 +196,7 @@
             <then>
                 <phingcall target="process-atomium-theme" />
                 <phingcall target="process-europa-theme" />
+                <phingcall target="create-europa-theme-symlinks" />
             </then>
         </if>
     </target>
@@ -242,6 +243,16 @@
             command="tar xvf framework.tar.gz --strip=1 -C assets"
             passthru="true" />
         <delete file="profiles/common/themes/europa/framework.tar.gz" quiet="true" />
+    </target>
+
+    <!-- Creates symlinks for the atomium and europa themes. -->
+    <target name="create-europa-theme-symlinks" >
+        <symlink link="profiles/${platform.profile.name}/themes">
+            <fileset dir="${platform.resources.profiles.common.themes.dir}">
+                <include name="atomium" />
+                <include name="europa" />
+            </fileset>
+        </symlink>
     </target>
 
     <target

--- a/build.package.xml
+++ b/build.package.xml
@@ -206,7 +206,7 @@
         <mkdir dir="profiles/common/themes/ec_europa" />
         <exec
             dir="profiles/common/themes"
-            command="tar xzvf ec_europa.tar.gz --strip=1 -C ec_europa"
+            command="tar xzv ec_europa.tar.gz --strip=1 -C ec_europa"
             passthru="true" />
         <delete file="profiles/common/themes/ec_europa.tar.gz" quiet="true" />
         <phingcall target="embed-ecl-assets" />
@@ -220,7 +220,7 @@
         <!-- Extract and embed the ECL artifacts into the Europa theme. -->
         <exec
             dir="profiles/common/themes/ec_europa"
-            command="tar xvf framework.tar.gz --strip=1 -C assets"
+            command="tar xzv framework.tar.gz --strip=1 -C assets"
             passthru="true" />
         <delete file="profiles/common/themes/ec_europa/framework.tar.gz" quiet="true" />
     </target>

--- a/build.package.xml
+++ b/build.package.xml
@@ -191,14 +191,10 @@
     <target
         name="build-europa-theme"
         description="Downloads Atomium and Europa themes with embedded ECL artifacts.">
-        <if>
-            <equals arg1="${platform.site.theme_default}" arg2="europa" />
-            <then>
-                <phingcall target="process-atomium-theme" />
-                <phingcall target="process-europa-theme" />
-                <phingcall target="create-europa-theme-symlinks" />
-            </then>
-        </if>
+
+        <phingcall target="process-atomium-theme" />
+        <phingcall target="process-europa-theme" />
+        <phingcall target="create-europa-theme-symlinks" />
     </target>
 
     <!-- Download and extract the Atomium theme. -->

--- a/build.package.xml
+++ b/build.package.xml
@@ -163,7 +163,7 @@
     <target
         name="build-platform-dev"
         description="Build a local development version of the platform."
-        depends="install-build-dependencies, delete-platform, make-drupal-core, link-platform-profiles, make-platform, link-platform-resources, install-platform-dev-dependencies, setup-behat, setup-behat-balancer, setup-phpunit, setup-php-codesniffer, update-htaccess, setup-files-directory" />
+        depends="install-build-dependencies, delete-platform, make-drupal-core, link-platform-profiles, make-platform, link-platform-resources, install-platform-dev-dependencies, setup-behat, setup-behat-balancer, setup-phpunit, setup-php-codesniffer, update-htaccess, setup-files-directory, build-europa-theme" />
 
     <target
         name="build-platform-dist"
@@ -186,6 +186,62 @@
         <!-- Call the remaining build targets. -->
         <phingcall target="copy-platform-resources" />
         <phingcall target="install-platform-dependencies" />
+    </target>
+
+    <target
+        name="build-europa-theme"
+        description="Downloads Atomium and Europa themes with embedded ECL artifacts.">
+        <if>
+            <equals arg1="${platform.site.theme_default}" arg2="europa" />
+            <then>
+                <phingcall target="process-atomium-theme" />
+                <phingcall target="process-europa-theme" />
+            </then>
+        </if>
+    </target>
+
+    <!-- Download and extract the Atomium theme. -->
+    <target name="process-atomium-theme">
+        <!-- Download the Atomium theme archive for a given branch. -->
+        <exec
+            command="curl -L https://api.github.com/repos/ec-europa/atomium/tarball/${platform.theme.atomium.repo.branch} > profiles/common/themes/atomium.tar.gz"
+            passthru="true" />
+        <!-- Extract the archive -->
+        <mkdir dir="profiles/common/themes/atomium" />
+        <exec
+            dir="profiles/common/themes"
+            command="tar xvf atomium.tar.gz --strip=1 -C atomium"
+            passthru="true" />
+        <delete file="profiles/common/themes/atomium.tar.gz" quiet="true" />
+    </target>
+
+    <!-- This step in future will become a part of a build on the new Europa theme repository. -->
+    <target name="process-europa-theme">
+        <!-- Download the Europa theme archive for a given branch. -->
+        <exec
+            command="curl -L https://api.github.com/repos/ec-europa/ec-europa-theme/tarball/${platform.theme.europa.repo.branch} > profiles/common/themes/europa.tar.gz"
+            passthru="true" />
+        <!-- Extract the archive -->
+        <mkdir dir="profiles/common/themes/europa" />
+        <exec
+            dir="profiles/common/themes"
+            command="tar xvf europa.tar.gz --strip=1 -C europa"
+            passthru="true" />
+        <delete file="profiles/common/themes/europa.tar.gz" quiet="true" />
+        <phingcall target="embed-ecl-assets" />
+    </target>
+
+    <target name="embed-ecl-assets">
+        <!-- Download the ECL release package. -->
+        <exec
+            command="curl -L https://github.com/ec-europa/europa-component-library/releases/download/${ecl.version}/framework.tar.gz > profiles/common/themes/europa/framework.tar.gz"
+            passthru="true" />
+        <!-- Extract and embed the ECL artifacts into the Europa theme. -->
+        <exec
+            dir="profiles/common/themes/europa"
+            command="tar xvf framework.tar.gz --strip=1 -C assets"
+            passthru="true" />
+        <delete file="profiles/common/themes/europa/framework.tar.gz" quiet="true" />
     </target>
 
     <target

--- a/build.package.xml
+++ b/build.package.xml
@@ -200,50 +200,50 @@
     <target name="process-europa-theme">
         <!-- Download the Europa theme archive for a given branch. -->
         <exec
-            command="curl -L https://github.com/ec-europa/ec_europa/releases/download/${ec_europa.version}/ec_europa-${ec_europa.version}.tar.gz > profiles/common/themes/europa.tar.gz"
+            command="curl -L https://github.com/ec-europa/ec_europa/releases/download/${ec_europa.version}/ec_europa-${ec_europa.version}.tar.gz > profiles/common/themes/ec_europa.tar.gz"
             passthru="true" />
         <!-- Extract the archive -->
-        <mkdir dir="profiles/common/themes/europa" />
+        <mkdir dir="profiles/common/themes/ec_europa" />
         <exec
             dir="profiles/common/themes"
             command="tar xzvf europa.tar.gz --strip=1 -C europa"
             passthru="true" />
-        <delete file="profiles/common/themes/europa.tar.gz" quiet="true" />
+        <delete file="profiles/common/themes/ec_europa.tar.gz" quiet="true" />
         <phingcall target="embed-ecl-assets" />
     </target>
 
     <target name="embed-ecl-assets">
         <!-- Download the ECL release package. -->
         <exec
-            command="curl -L https://github.com/ec-europa/europa-component-library/releases/download/${ecl.version}/framework.tar.gz > profiles/common/themes/europa/framework.tar.gz"
+            command="curl -L https://github.com/ec-europa/europa-component-library/releases/download/${ecl.version}/framework.tar.gz > profiles/common/themes/ec_europa/framework.tar.gz"
             passthru="true" />
         <!-- Extract and embed the ECL artifacts into the Europa theme. -->
         <exec
-            dir="profiles/common/themes/europa"
+            dir="profiles/common/themes/ec_europa"
             command="tar xvf framework.tar.gz --strip=1 -C assets"
             passthru="true" />
-        <delete file="profiles/common/themes/europa/framework.tar.gz" quiet="true" />
+        <delete file="profiles/common/themes/ec_europa/framework.tar.gz" quiet="true" />
     </target>
 
     <!-- Creates symlinks for the atomium and europa themes. -->
     <target name="create-europa-theme-symlinks" >
         <symlink link="profiles/${platform.profile.name}/themes">
             <fileset dir="${platform.resources.profiles.common.themes.dir}">
-                <include name="europa" />
+                <include name="ec_europa" />
             </fileset>
         </symlink>
     </target>
 
     <target
         name="build-europa-dev"
-        description="Build a local development version of the platform based on the Europa theme."
+        description="Build a local development version of the platform based on the EC Europa theme."
         depends="install-build-dependencies, delete-platform, make-drupal-core, link-platform-profiles, make-platform, link-platform-resources, install-platform-dev-dependencies, setup-behat, setup-behat-balancer, setup-phpunit, setup-php-codesniffer, update-htaccess, setup-files-directory, europa-theme-repo-clone, europa-theme-build" />
 
-    <!-- Clonning and checking out the branch of the Atomium and Europa theme repositories. -->
+    <!-- Clonning and checking out the branch of the Atomium and EC Europa theme repositories. -->
     <target name="europa-theme-repo-clone">
         <!-- Deleting theme directories before clonning -->
         <delete dir="${platform.resources.profiles.common.themes.dir}/atomium" quiet="true"/>
-        <delete dir="${platform.resources.profiles.common.themes.dir}/europa" quiet="true"/>
+        <delete dir="${platform.resources.profiles.common.themes.dir}/ec_europa" quiet="true"/>
 
         <!-- Clonning the Atomium theme repo into the common profiles directory -->
         <echo msg = "Clonning the Atomium theme repository."/>
@@ -255,14 +255,14 @@
             repository="${platform.resources.profiles.common.themes.dir}/atomium"
             branchname="${platform.theme.atomium.repo.branch}"/>
 
-        <!-- Clonning the Europa theme repo into the common profiles directory -->
-        <echo msg = "Cloning the Europa theme repository."/>
+        <!-- Clonning the EC Europa theme repo into the common profiles directory -->
+        <echo msg = "Cloning the EC Europa theme repository."/>
         <gitclone
             repository="${platform.theme.europa.repo.url}"
-            targetPath="${platform.resources.profiles.common.themes.dir}/europa"/>
+            targetPath="${platform.resources.profiles.common.themes.dir}/ec_europa"/>
         <!-- Checking out the configured branch in the cloned repo -->
         <gitcheckout
-            repository="${platform.resources.profiles.common.themes.dir}/europa"
+            repository="${platform.resources.profiles.common.themes.dir}/ec_europa"
             branchname="${platform.theme.europa.repo.branch}"/>
     </target>
 
@@ -271,19 +271,19 @@
         <exec
             command="npm install"
             passthru="true"
-            dir="${platform.resources.profiles.common.themes.dir}/europa"
+            dir="${platform.resources.profiles.common.themes.dir}/ec_europa"
         />
         <exec
             command="npm run build"
             passthru="true"
-            dir="${platform.resources.profiles.common.themes.dir}/europa"
+            dir="${platform.resources.profiles.common.themes.dir}/ec_europa"
         />
         <!-- Deleting *.map files (currently there is a bug in the ecl-builder) -->
         <delete>
-            <fileset dir="${platform.resources.profiles.common.themes.dir}/europa/assets/css">
+            <fileset dir="${platform.resources.profiles.common.themes.dir}/ec_europa/assets/css">
                 <include name="*.map" />
             </fileset>
-            <fileset dir="${platform.resources.profiles.common.themes.dir}/europa/wysiwyg">
+            <fileset dir="${platform.resources.profiles.common.themes.dir}/ec_europa/wysiwyg">
                 <include name="*.map" />
             </fileset>
         </delete>

--- a/build.package.xml
+++ b/build.package.xml
@@ -188,4 +188,58 @@
         <phingcall target="install-platform-dependencies" />
     </target>
 
+    <target
+        name="build-europa-dev"
+        description="Build a local development version of the platform based on the Europa theme."
+        depends="install-build-dependencies, delete-platform, make-drupal-core, link-platform-profiles, make-platform, link-platform-resources, install-platform-dev-dependencies, setup-behat, setup-behat-balancer, setup-phpunit, setup-php-codesniffer, update-htaccess, setup-files-directory, europa-theme-repo-clone, europa-theme-build" />
+
+    <!-- Clonning and checking out the branch of the Atomium and Europa theme repositories. -->
+    <target name="europa-theme-repo-clone">
+        <!-- Deleting theme directories before clonning -->
+        <delete dir="${platform.resources.profiles.common.themes.dir}/atomium" quiet="true"/>
+        <delete dir="${platform.resources.profiles.common.themes.dir}/europa" quiet="true"/>
+
+        <!-- Clonning the Atomium theme repo into the common profiles directory -->
+        <echo msg = "Clonning the Atomium theme repository."/>
+        <gitclone
+            repository="${platform.theme.atomium.repo.url}"
+            targetPath="${platform.resources.profiles.common.themes.dir}/atomium"/>
+        <!-- Checking out the configured branch in the cloned repo -->
+        <gitcheckout
+            repository="${platform.resources.profiles.common.themes.dir}/atomium"
+            branchname="${platform.theme.atomium.repo.branch}"/>
+
+        <!-- Clonning the Europa theme repo into the common profiles directory -->
+        <echo msg = "Clonning the Europa theme repository."/>
+        <gitclone
+            repository="${platform.theme.europa.repo.url}"
+            targetPath="${platform.resources.profiles.common.themes.dir}/europa"/>
+        <!-- Checking out the configured branch in the cloned repo -->
+        <gitcheckout
+            repository="${platform.resources.profiles.common.themes.dir}/europa"
+            branchname="${platform.theme.europa.repo.branch}"/>
+    </target>
+
+    <!-- Generating assets -->
+    <target name="europa-theme-build">
+        <exec
+            command="npm install"
+            passthru="true"
+            dir="${platform.resources.profiles.common.themes.dir}/europa"
+        />
+        <exec
+            command="npm run build"
+            passthru="true"
+            dir="${platform.resources.profiles.common.themes.dir}/europa"
+        />
+        <!-- Deleting *.map files (currently there is a bug in the ecl-builder) -->
+        <delete>
+            <fileset dir="${platform.resources.profiles.common.themes.dir}/europa/assets/css">
+                <include name="*.map" />
+            </fileset>
+            <fileset dir="${platform.resources.profiles.common.themes.dir}/europa/wysiwyg">
+                <include name="*.map" />
+            </fileset>
+        </delete>
+    </target>
 </project>

--- a/build.properties.dist
+++ b/build.properties.dist
@@ -8,7 +8,7 @@ platform.profile.name = multisite_drupal_standard
 platform.site.name = NextEuropa
 
 # The default theme to enable, set to either "europa" or "ec_resp".
-platform.site.theme_default = europa
+platform.site.theme_default = ec_resp
 
 # The default Europa Component Library release
 ecl.version = v0.10.0

--- a/build.properties.dist
+++ b/build.properties.dist
@@ -10,6 +10,13 @@ platform.site.name = NextEuropa
 # The default theme to enable, set to either "europa" or "ec_resp".
 platform.site.theme_default = europa
 
+# The default Atomium and Europa theme build properties.
+# Used only if default theme is set to "europa".
+platform.theme.atomium.repo.url = https://github.com/ec-europa/atomium.git
+platform.theme.atomium.repo.branch = 7.x-1.x
+platform.theme.europa.repo.url = https://github.com/ec-europa/ec-europa-theme.git
+platform.theme.europa.repo.branch = nept-1191
+
 # The Drupal core make file.
 drupal.make = ${platform.resources.dir}/drupal-core.make
 
@@ -67,6 +74,7 @@ platform.build.dir = ${project.basedir}/${phing.project.build.dir}
 # Local resources
 platform.resources.dir = ${platform.basedir}/resources
 platform.resources.profiles.dir = ${platform.basedir}/profiles
+platform.resources.profiles.common.themes.dir = ${platform.basedir}/profiles/common/themes
 platform.resources.profile.dir = ${platform.resources.profiles.dir}/${platform.profile.name}
 
 platform.resources.composer.json = ${platform.resources.dir}/composer.json

--- a/build.properties.dist
+++ b/build.properties.dist
@@ -13,12 +13,15 @@ platform.site.theme_default = ec_resp
 # The default Europa Component Library release
 ecl.version = v0.10.0
 
+# The default EC Europa theme release
+ec_europa.version = 0.0.2
+
 # The default Atomium and Europa theme build properties.
 # Used only if default theme is set to "europa".
 platform.theme.atomium.repo.url = https://github.com/ec-europa/atomium.git
 platform.theme.atomium.repo.branch = 7.x-1.x
 platform.theme.europa.repo.url = https://github.com/ec-europa/ec_europa.git
-platform.theme.europa.repo.tag = 0.0.2
+platform.theme.europa.repo.branch = master
 
 # The Drupal core make file.
 drupal.make = ${platform.resources.dir}/drupal-core.make

--- a/build.properties.dist
+++ b/build.properties.dist
@@ -7,6 +7,9 @@ platform.profile.name = multisite_drupal_standard
 # The site name.
 platform.site.name = NextEuropa
 
+# The default theme to enable, set to either "europa" or "ec_resp".
+platform.site.theme_default = europa
+
 # The Drupal core make file.
 drupal.make = ${platform.resources.dir}/drupal-core.make
 

--- a/build.properties.dist
+++ b/build.properties.dist
@@ -17,8 +17,8 @@ ecl.version = v0.10.0
 # Used only if default theme is set to "europa".
 platform.theme.atomium.repo.url = https://github.com/ec-europa/atomium.git
 platform.theme.atomium.repo.branch = 7.x-1.x
-platform.theme.europa.repo.url = https://github.com/ec-europa/ec-europa-theme.git
-platform.theme.europa.repo.branch = nept-1191
+platform.theme.europa.repo.url = https://github.com/ec-europa/ec_europa.git
+platform.theme.europa.repo.tag = 0.0.1
 
 # The Drupal core make file.
 drupal.make = ${platform.resources.dir}/drupal-core.make

--- a/build.properties.dist
+++ b/build.properties.dist
@@ -10,6 +10,9 @@ platform.site.name = NextEuropa
 # The default theme to enable, set to either "europa" or "ec_resp".
 platform.site.theme_default = europa
 
+# The default Europa Component Library release
+ecl.version = v0.10.0
+
 # The default Atomium and Europa theme build properties.
 # Used only if default theme is set to "europa".
 platform.theme.atomium.repo.url = https://github.com/ec-europa/atomium.git

--- a/build.properties.dist
+++ b/build.properties.dist
@@ -18,7 +18,7 @@ ecl.version = v0.10.0
 platform.theme.atomium.repo.url = https://github.com/ec-europa/atomium.git
 platform.theme.atomium.repo.branch = 7.x-1.x
 platform.theme.europa.repo.url = https://github.com/ec-europa/ec_europa.git
-platform.theme.europa.repo.tag = 0.0.1
+platform.theme.europa.repo.tag = 0.0.2
 
 # The Drupal core make file.
 drupal.make = ${platform.resources.dir}/drupal-core.make

--- a/build.properties.dist
+++ b/build.properties.dist
@@ -14,7 +14,7 @@ platform.site.theme_default = ec_resp
 ecl.version = v0.10.0
 
 # The default EC Europa theme release
-ec_europa.version = 0.0.2
+ec_europa.version = 0.0.3
 
 # The default Atomium and Europa theme build properties.
 # Used only if default theme is set to "ec_europa".

--- a/build.properties.dist
+++ b/build.properties.dist
@@ -7,7 +7,7 @@ platform.profile.name = multisite_drupal_standard
 # The site name.
 platform.site.name = NextEuropa
 
-# The default theme to enable, set to either "europa" or "ec_resp".
+# The default theme to enable, set to either "ec_europa" or "ec_resp".
 platform.site.theme_default = ec_resp
 
 # The default Europa Component Library release
@@ -17,7 +17,7 @@ ecl.version = v0.10.0
 ec_europa.version = 0.0.2
 
 # The default Atomium and Europa theme build properties.
-# Used only if default theme is set to "europa".
+# Used only if default theme is set to "ec_europa".
 platform.theme.atomium.repo.url = https://github.com/ec-europa/atomium.git
 platform.theme.atomium.repo.branch = 7.x-1.x
 platform.theme.europa.repo.url = https://github.com/ec-europa/ec_europa.git

--- a/build.test.xml
+++ b/build.test.xml
@@ -18,6 +18,8 @@
             <param>${platform.profile.name}</param>
             <!-- Prevent e-mails from being sent during the installation. -->
             <param>install_configure_form.update_status_module='array(FALSE,FALSE)'</param>
+            <!-- Setup default theme. -->
+            <param>cce_basic_config_profile_theme_default_form.theme_default=${platform.site.theme_default}</param>
         </drush>
 
 		<!-- Rebuild node access after site installation -->

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -20,14 +20,14 @@
     <exclude-pattern>profiles/multisite_drupal_communities/inject_data.php</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_communities/themes/bootstrap</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_standard/themes/bootstrap</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_standard/themes/europa</exclude-pattern>
+    <exclude-pattern>profiles/multisite_drupal_standard/themes/ec_europa</exclude-pattern>
 
     <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal" />
 
     <!-- Exclude third party code. -->
     <exclude-pattern>profiles/common/libraries/</exclude-pattern>
     <exclude-pattern>profiles/common/modules/custom/ecas/libraries/</exclude-pattern>
-    <exclude-pattern>profiles/common/themes/europa</exclude-pattern>
+    <exclude-pattern>profiles/common/themes/ec_europa</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_communities/libraries/</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_communities/modules/contrib/</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_standard/libraries/</exclude-pattern>
@@ -37,9 +37,9 @@
     <exclude-pattern>profiles/common/modules/custom/tmgmt_poetry/tests/</exclude-pattern>
     <exclude-pattern>build/vendor/</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_standard/themes/atomium</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_standard/themes/europa</exclude-pattern>
+    <exclude-pattern>profiles/multisite_drupal_standard/themes/ec_europa</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_communities/themes/atomium</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_communities/themes/europa</exclude-pattern>
+    <exclude-pattern>profiles/multisite_drupal_communities/themes/ec_europa</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_standard/themes/ec_resp/scripts</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_communities/themes/ec_resp/scripts</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_standard/themes/ec_resp/css</exclude-pattern>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -27,6 +27,8 @@
     <!-- Exclude third party code. -->
     <exclude-pattern>profiles/common/libraries/</exclude-pattern>
     <exclude-pattern>profiles/common/modules/custom/ecas/libraries/</exclude-pattern>
+    <exclude-pattern>profiles/common/themes/atomium</exclude-pattern>
+    <exclude-pattern>profiles/common/themes/europa</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_communities/libraries/</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_communities/modules/contrib/</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_standard/libraries/</exclude-pattern>
@@ -36,6 +38,7 @@
     <exclude-pattern>profiles/common/modules/custom/tmgmt_poetry/tests/</exclude-pattern>
     <exclude-pattern>build/vendor/</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_standard/themes/atomium</exclude-pattern>
+    <exclude-pattern>profiles/multisite_drupal_standard/themes/europa</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_communities/themes/atomium</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_communities/themes/europa</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_standard/themes/ec_resp/scripts</exclude-pattern>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -27,7 +27,6 @@
     <!-- Exclude third party code. -->
     <exclude-pattern>profiles/common/libraries/</exclude-pattern>
     <exclude-pattern>profiles/common/modules/custom/ecas/libraries/</exclude-pattern>
-    <exclude-pattern>profiles/common/themes/atomium</exclude-pattern>
     <exclude-pattern>profiles/common/themes/europa</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_communities/libraries/</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_communities/modules/contrib/</exclude-pattern>

--- a/profiles/common/modules/custom/nexteuropa_ecl_migrate/nexteuropa_ecl_migrate.module
+++ b/profiles/common/modules/custom/nexteuropa_ecl_migrate/nexteuropa_ecl_migrate.module
@@ -9,6 +9,7 @@
  * Custom function that moves the proper blocks in the right areas.
  */
 function _nexteuropa_ecl_migrate_blocks() {
+  _nexteuropa_ecl_migrate_remove_blocks_header_top();
   _nexteuropa_ecl_migrate_dt_menus();
   _nexteuropa_ecl_migrate_europa_main_menu();
   _nexteuropa_ecl_migrate_europa_utility_region();
@@ -208,4 +209,12 @@ function _nexteuropa_ecl_migrate_europa_main_menu() {
 function _nexteuropa_ecl_migrate_europa_utility_region() {
   multisite_drupal_toolbox_add_block_context('site_wide', 'user-menu', 'system', 'user-menu', 'utility', 1);
   multisite_drupal_toolbox_add_block_context('site_wide', 'create-content-button', 'multisite_create_button', 'create-content-button', 'utility', 2);
+}
+
+/**
+ * Custom function that deletes blocks in the header_top region.
+ */
+function _nexteuropa_ecl_migrate_remove_blocks_header_top() {
+  multisite_drupal_toolbox_remove_block_context('site_wide', 'menu-service-tools');
+  multisite_drupal_toolbox_remove_block_context('site_wide', 'language_selector_site');
 }

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.context.inc
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.context.inc
@@ -38,6 +38,12 @@ function cce_basic_config_context_default_contexts() {
           'region' => 'tools',
           'weight' => '2',
         ),
+        'locale-language' => array(
+          'module' => 'locale',
+          'delta' => 'language',
+          'region' => 'header_top',
+          'weight' => '-10',
+        ),
         'system-main-menu' => array(
           'module' => 'system',
           'delta' => 'main-menu',
@@ -61,6 +67,12 @@ function cce_basic_config_context_default_contexts() {
           'delta' => 'form',
           'region' => 'header_right',
           'weight' => 1,
+        ),
+        'menu-service-tools' => array(
+          'module' => 'menu',
+          'delta' => 'menu-service-tools',
+          'region' => 'header_top',
+          'weight' => '-9',
         ),
         'footer' => array(
           'module' => 'cce_basic_config',

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -517,6 +517,7 @@ function cce_basic_config_profile_theme_default_form_submit($form, &$form_state)
   if ($theme_default == 'europa') {
     $theme_list[] = 'atomium';
     module_enable(array('nexteuropa_ecl_migrate'));
+    _nexteuropa_ecl_migrate_blocks();
   }
   theme_enable($theme_list);
   variable_set('theme_default', $theme_default);

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -494,10 +494,10 @@ function cce_basic_config_profile_theme_default_form() {
     '#type' => 'radios',
     '#required' => TRUE,
     '#options' => array(
-      'europa' => st('Europa'),
       'ec_resp' => st('EC Resp'),
+      'europa' => st('Europa'),
     ),
-    '#default_value' => 'europa',
+    '#default_value' => 'ec_resp',
   );
   $form['container']['submit'] = array(
     '#type' => 'submit',

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -474,21 +474,60 @@ function cce_basic_config_install() {
 }
 
 /**
- * Initialize 'theme default' and 'admin theme'.
+ * "Choose theme" installation task form.
+ *
+ * This form is shared by both standard and communities profile, hence it is
+ * exposed by the 'cce_basic_config' module.
+ *
+ * @see multisite_drupal_standard_install_tasks()
+ */
+function cce_basic_config_profile_theme_default_form() {
+  $form = array();
+  $form['container'] = array(
+    '#type' => 'fieldset',
+    '#title' => st('Choose theme'),
+    '#collapsible' => FALSE,
+    '#tree' => FALSE,
+  );
+  $form['container']['theme_default'] = array(
+    '#type' => 'radios',
+    '#required' => TRUE,
+    '#options' => array(
+      'europa' => st('Europa'),
+      'ec_resp' => st('EC Resp'),
+    ),
+    '#default_value' => 'europa',
+  );
+  $form['container']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => st('Continue'),
+  );
+  return $form;
+}
+
+/**
+ * Form submit.
+ *
+ * @see multisite_drupal_standard_install_tasks()
+ */
+function cce_basic_config_profile_theme_default_form_submit($form, &$form_state) {
+  $theme_default = $form_state['values']['theme_default'];
+  $theme_list = array($theme_default);
+  if ($theme_default == 'europa') {
+    $theme_list[] = 'atomium';
+  }
+  theme_enable($theme_list);
+  variable_set('theme_default', $theme_default);
+  $theme_name = $form['container']['theme_default']['#options'][$theme_default];
+  drupal_set_message(st("'@name' has been set as default theme.", array('@name' => $theme_name)));
+}
+
+/**
+ * Initialize 'admin theme'.
  */
 function _cce_basic_config_post_install_theme() {
-  // Define themes.
-  $themes = array(
-    'theme_default' => 'europa',
-    'admin_theme' => 'seven',
-  );
-  theme_enable($themes);
-  $themes[] = array('dependency' => 'atomium');
-  foreach ($themes as $var => $theme) {
-    if (!is_numeric($var)) {
-      variable_set($var, $theme);
-    }
-  }
+  theme_enable(array('seven'));
+  variable_set('admin_theme', 'seven');
 }
 
 /**

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -516,6 +516,7 @@ function cce_basic_config_profile_theme_default_form_submit($form, &$form_state)
   $theme_list = array($theme_default);
   if ($theme_default == 'europa') {
     $theme_list[] = 'atomium';
+    module_enable(array('nexteuropa_ecl_migrate'));
   }
   theme_enable($theme_list);
   variable_set('theme_default', $theme_default);

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -495,7 +495,7 @@ function cce_basic_config_profile_theme_default_form() {
     '#required' => TRUE,
     '#options' => array(
       'ec_resp' => st('EC Resp'),
-      'europa' => st('Europa'),
+      'ec_europa' => st('EC Europa'),
     ),
     '#default_value' => 'ec_resp',
   );
@@ -514,7 +514,7 @@ function cce_basic_config_profile_theme_default_form() {
 function cce_basic_config_profile_theme_default_form_submit($form, &$form_state) {
   $theme_default = $form_state['values']['theme_default'];
   $theme_list = array($theme_default);
-  if ($theme_default == 'europa') {
+  if ($theme_default == 'ec_europa') {
     $theme_list[] = 'atomium';
     module_enable(array('nexteuropa_ecl_migrate'));
     _nexteuropa_ecl_migrate_blocks();

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -474,12 +474,13 @@ function cce_basic_config_install() {
 }
 
 /**
- * "Choose theme" installation task form.
+ * Form for the installation profile task "Choose theme".
  *
  * This form is shared by both standard and communities profile, hence it is
  * exposed by the 'cce_basic_config' module.
  *
  * @see multisite_drupal_standard_install_tasks()
+ * @see multisite_drupal_communities_install_tasks()
  */
 function cce_basic_config_profile_theme_default_form() {
   $form = array();

--- a/profiles/common/modules/features/multisite_settings/multisite_settings_core/multisite_settings_core.strongarm.inc
+++ b/profiles/common/modules/features/multisite_settings/multisite_settings_core/multisite_settings_core.strongarm.inc
@@ -57,7 +57,7 @@ function multisite_settings_core_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'theme_default';
-  $strongarm->value = 'europa';
+  $strongarm->value = 'ec_europa';
   $export['theme_default'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
@@ -144,8 +144,7 @@ function _multisite_wysiwyg_get_ckeditor_css_paths($default_theme = NULL) {
   }
   $css_file_paths = array();
   $list_theme = list_themes();
-
-  $implied_themes = drupal_find_base_themes($list_theme, $default_theme);
+  $implied_themes = !empty($list_theme[$default_theme]->info['base theme']) ? drupal_find_base_themes($list_theme, $default_theme) : array();
   // If drupal_find_base_themes can return an array with only one NULL item.
   if (empty(current($implied_themes))) {
     $implied_themes = array();

--- a/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.install
+++ b/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.install
@@ -92,6 +92,10 @@ function nexteuropa_multilingual_install() {
   multisite_drupal_toolbox_remove_block_context('site_wide', 'language');
   multisite_drupal_toolbox_remove_block_context('site_wide', 'locale-language');
 
+  // Add new language switcher block.
+  multisite_drupal_toolbox_add_block_context('site_wide', 'language_selector_site', 'language_selector_site', 'language_selector_site', "header_top", -10);
+  multisite_drupal_toolbox_add_block_context('site_wide', 'language_selector_page', 'language_selector_page', 'language_selector_page', "content_top", -10);
+
   // Set the warning message when changing node state.
   variable_set('nexteuropa_multilingual_warning_message_languages', "The state of the content <b>[node:title]</b> and all its validated translations <b>[node:entity-translation-languages]</b> will be updated!");
 

--- a/profiles/multisite_drupal_communities/multisite_drupal_communities.install
+++ b/profiles/multisite_drupal_communities/multisite_drupal_communities.install
@@ -21,6 +21,19 @@ function multisite_drupal_communities_install() {
 }
 
 /**
+ * Implements hook_install_tasks().
+ */
+function multisite_drupal_communities_install_tasks() {
+  $tasks = array(
+    'cce_basic_config_profile_theme_default_form' => array(
+      'display_name' => st('Choose theme'),
+      'type' => 'form',
+    ),
+  );
+  return $tasks;
+}
+
+/**
  * NEXTEUROPA-3298: Disable ckeditor_link features.
  */
 function multisite_drupal_communities_update_7201() {

--- a/profiles/multisite_drupal_standard/multisite_drupal_standard.install
+++ b/profiles/multisite_drupal_standard/multisite_drupal_standard.install
@@ -12,6 +12,19 @@ function multisite_drupal_standard_install() {
 }
 
 /**
+ * Implements hook_install_tasks().
+ */
+function multisite_drupal_standard_install_tasks() {
+  $tasks = array(
+    'cce_basic_config_profile_theme_default_form' => array(
+      'display_name' => st('Choose theme'),
+      'type' => 'form',
+    ),
+  );
+  return $tasks;
+}
+
+/**
  * Implements hook_update_N().
  */
 function multisite_drupal_standard_update_7100() {

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1000,3 +1000,7 @@ projects[ec_resp][download][type] = git
 projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
 projects[ec_resp][download][tag] = 2.3
 
+projects[atomium][type] = theme
+projects[atomium][download][type] = git
+projects[atomium][download][url] = https://github.com/ec-europa/atomium.git
+projects[atomium][download][branch] = 7.x-1.x

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1000,12 +1000,3 @@ projects[ec_resp][download][type] = git
 projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
 projects[ec_resp][download][tag] = 2.3
 
-projects[europa][type] = theme
-projects[europa][download][type] = git
-projects[europa][download][url] = https://github.com/ec-europa/ec-europa-theme.git
-projects[europa][download][branch] = europa-atomium 
-
-projects[atomium][type] = theme
-projects[atomium][download][type] = git
-projects[atomium][download][url] = https://github.com/ec-europa/atomium.git
-projects[atomium][download][branch] = 7.x-1.x

--- a/tests/features/search/europa_search_ec_europa.feature
+++ b/tests/features/search/europa_search_ec_europa.feature
@@ -4,6 +4,7 @@ Feature: Europa Search features
   As a anonymous user
   I want to search content from a form available on the site
 
+  @wip
   Scenario: Anonymous user can use the header search form to find contents on Europa and
     the results is displayed on the "Europa Search" interface
     Given I am on the homepage


### PR DESCRIPTION
## NEPT-1191

### Description

The scope of this PR is to allow theme to be set at installation time, both via UI or via Drush. This will allow CI to set which theme to use per build.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

