### PR TITLE
NEPT-1268: Locked metatag files.

### DIFF
--- a/profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.helpers.inc
+++ b/profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.helpers.inc
@@ -59,7 +59,7 @@ function _nexteuropa_metatags_create_metatag_config() {
         0 => 'format',
       ),
     ),
-    'locked' => 0,
+    'locked' => 1,
     'module' => 'text',
     'settings' => array(
       'entity_translation_sync' => FALSE,
@@ -89,7 +89,7 @@ function _nexteuropa_metatags_create_metatag_config() {
         0 => 'format',
       ),
     ),
-    'locked' => 0,
+    'locked' => 1,
     'module' => 'text',
     'settings' => array(
       'entity_translation_sync' => FALSE,


### PR DESCRIPTION
## NEPT-1268

### Description

Locking default fieldsprovided by metatag feature.

### Change log
- Changed: Metatag fields are locked.

