### PR TITLE
NEPT-1271: Add behat test for last_update module and update the readme.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_lastupdate/README.md
+++ b/profiles/common/modules/custom/nexteuropa_lastupdate/README.md
@@ -16,3 +16,9 @@ configure and place as they see fit in their site.
 
 This block will show the last modification date of an entity if that entity
 provides a callback in the "last update callback" property.
+
+This block works with these following entities:
+- node
+- comment (if the module comments is enabled)
+- user
+- file

--- a/profiles/common/modules/custom/nexteuropa_lastupdate/nexteuropa_lastupdate.module
+++ b/profiles/common/modules/custom/nexteuropa_lastupdate/nexteuropa_lastupdate.module
@@ -84,6 +84,11 @@ function _nexteuropa_lastupdate_supported_core_entities() {
 /**
  * Return the entity that is being loaded in the page (if any).
  *
+ * This function comes from _datalayer_menu_get_any_object(),
+ * but I would replace that function with:
+ * https://api.drupal.org/comment/63163#comment-63163
+ * which seems more advanced.
+ *
  * @return mixed
  *   On failure false.
  *   On success the loaded entity object.

--- a/profiles/common/modules/custom/nexteuropa_lastupdate/nexteuropa_lastupdate.module
+++ b/profiles/common/modules/custom/nexteuropa_lastupdate/nexteuropa_lastupdate.module
@@ -96,6 +96,9 @@ function _nexteuropa_lastupdate_menu_get_any_entity() {
   // Non-entities may not have load functions.
   if (is_array($item['load_functions'])) {
     $vals = array_values($item['load_functions']);
+
+    // @todo We only load the first load function, we should analyze the case
+    // @todo where we have multiple load_functions in this array().
     $load_function = $vals[0];
     $arg_position = array_search($load_function, $item['load_functions']);
 

--- a/tests/features/last_update.feature
+++ b/tests/features/last_update.feature
@@ -14,14 +14,14 @@ Scenario: Administrators can add the last update block in a region
   When I visit "admin/structure/block"
   Then I should see the text "Last update date"
 
-Scenario: Check that the last update block is not showed if a node is not published
+Scenario: Check that the last update block is not shown if a node is not published
   Given that the block "last_update" from module "nexteuropa_lastupdate" is assigned to the region "footer"
   When I go to "node/add/page"
   And I fill in "Title" with "Page title"
   And I press "Save"
   Then I should not see an ".last-update" element
 
-Scenario: Check that the last update block is showed if a node is published
+Scenario: Check that the last update block is shown if a node is published
   Given that the block "last_update" from module "nexteuropa_lastupdate" is assigned to the region "footer"
   When I go to "node/add/page"
   And I fill in "Title" with "Page title"
@@ -29,7 +29,7 @@ Scenario: Check that the last update block is showed if a node is published
   And I press "Save"
   Then I should see "Last published" in the ".last-update" element
 
-Scenario Outline: Check that the last update block is showed in other cases (user/file)
+Scenario Outline: Check that the last update block is shown in other cases (user/file)
   Given that the block "last_update" from module "nexteuropa_lastupdate" is assigned to the region "footer"
   When I go to "<url>"
   Then I should see "<sentence>" in the ".last-update" element

--- a/tests/features/last_update.feature
+++ b/tests/features/last_update.feature
@@ -14,16 +14,14 @@ Scenario: Administrators can add the last update block in a region
   When I visit "admin/structure/block"
   Then I should see the text "Last update date"
 
-@RevertBlockConfiguration
-Scenario: The last update doesn't show if a node is not published
+Scenario: Check that the last update block is not showed if a node is not published
   Given that the block "last_update" from module "nexteuropa_lastupdate" is assigned to the region "footer"
   When I go to "node/add/page"
   And I fill in "Title" with "Page title"
   And I press "Save"
   Then I should not see an ".last-update" element
 
-@RevertBlockConfiguration
-Scenario: The last update shows if a node is published
+Scenario: Check that the last update block is showed if a node is published
   Given that the block "last_update" from module "nexteuropa_lastupdate" is assigned to the region "footer"
   When I go to "node/add/page"
   And I fill in "Title" with "Page title"
@@ -31,4 +29,12 @@ Scenario: The last update shows if a node is published
   And I press "Save"
   Then I should see "Last published" in the ".last-update" element
 
+Scenario Outline: Check that the last update block is showed in other cases (user/file)
+  Given that the block "last_update" from module "nexteuropa_lastupdate" is assigned to the region "footer"
+  When I go to "<url>"
+  Then I should see "<sentence>" in the ".last-update" element
 
+  Examples:
+    | url                 | sentence      |
+    | user                | Last accessed |
+    | file/userdefaultpng | Last uploaded |


### PR DESCRIPTION
## NEPT-1271

### Description

Review nexteuropa_lastupdate:
Also I have doubts on the accuracy of this module. What if a block is placed on a menu item that takes more than one object in it's load functions.
Then you only load the first one you find? I'm aware of this issue because I've worked with the menu_token module that I've also tried to implement logic like this in. So at least I would document this modules behavior and provide a test for each implemented entity.
https://github.com/ec-europa/platform-dev/blob/2.4.0/profiles/common/modules/custom/nexteuropa_lastupdate/nexteuropa_lastupdate.module#L91

### Change log

- Added: Behat test for last_update module to check user and file entities.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
No commands

```

