### PR TITLE
NEPT-1252: Release 2.4: QA feedback application for blockers

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_lastupdate/README.md
+++ b/profiles/common/modules/custom/nexteuropa_lastupdate/README.md
@@ -16,3 +16,9 @@ configure and place as they see fit in their site.
 
 This block will show the last modification date of an entity if that entity
 provides a callback in the "last update callback" property.
+
+This block works with these following entities:
+- node
+- comment (if the module comments is enabled)
+- user
+- file

--- a/profiles/common/modules/custom/nexteuropa_lastupdate/nexteuropa_lastupdate.module
+++ b/profiles/common/modules/custom/nexteuropa_lastupdate/nexteuropa_lastupdate.module
@@ -94,6 +94,11 @@ function _nexteuropa_lastupdate_supported_core_entities() {
 /**
  * Return the entity that is being loaded in the page (if any).
  *
+ * This function comes from _datalayer_menu_get_any_object(),
+ * but I would replace that function with:
+ * https://api.drupal.org/comment/63163#comment-63163
+ * which seems more advanced.
+ *
  * @return mixed
  *   On failure false.
  *   On success the loaded entity object.
@@ -106,6 +111,9 @@ function _nexteuropa_lastupdate_menu_get_any_entity() {
   // Non-entities may not have load functions.
   if (is_array($item['load_functions'])) {
     $vals = array_values($item['load_functions']);
+
+    // @todo We only load the first load function, we should analyze the case
+    // @todo where we have multiple load_functions in this array().
     $load_function = $vals[0];
     $arg_position = array_search($load_function, $item['load_functions']);
 

--- a/profiles/common/modules/custom/nexteuropa_lastupdate/nexteuropa_lastupdate.module
+++ b/profiles/common/modules/custom/nexteuropa_lastupdate/nexteuropa_lastupdate.module
@@ -23,22 +23,28 @@ function nexteuropa_lastupdate_block_view($delta = '') {
   $block = array();
   switch ($delta) {
     case 'last_update':
-      if ($entity = _nexteuropa_lastupdate_menu_get_any_entity()) {
-        $info = entity_get_info($entity->entity_type);
-        if (isset($info['last update callback']) && function_exists($info['last update callback'])) {
-          $last_update_variables = $info['last update callback']($entity);
-          if (!empty($last_update_variables)) {
-            $block_content = theme('nexteuropa_last_update_block', $last_update_variables);
-          }
-        }
-      }
-      if (!isset($block_content)) {
-        $block_content = '';
-      }
-      $block['content'] = $block_content;
+      $block['content'] = array(
+        '#theme' => 'nexteuropa_last_update_block',
+      );
       break;
   }
   return $block;
+}
+
+/**
+ * Implements hook_preprocess_hook().
+ */
+function nexteuropa_lastupdate_preprocess_nexteuropa_last_update_block(&$variables, $hook) {
+  if ($entity = _nexteuropa_lastupdate_menu_get_any_entity()) {
+    $info = entity_get_info($entity->entity_type);
+    if (isset($info['last update callback']) && function_exists($info['last update callback'])) {
+      $last_update_variables = $info['last update callback']($entity);
+      if (!empty($last_update_variables)) {
+        $variables['label'] = $last_update_variables['label'];
+        $variables['date'] = $last_update_variables['date'];
+      }
+    }
+  }
 }
 
 /**
@@ -58,6 +64,10 @@ function nexteuropa_lastupdate_theme($existing, $type, $theme, $path) {
     'nexteuropa_last_update_block' => array(
       'template' => 'nexteuropa-last-update-block',
       'path' => $path . '/theme',
+      'variables' => array(
+        'label' => NULL,
+        'date' => NULL,
+      ),
     ),
   );
 }

--- a/profiles/common/modules/custom/nexteuropa_lastupdate/nexteuropa_lastupdate.module
+++ b/profiles/common/modules/custom/nexteuropa_lastupdate/nexteuropa_lastupdate.module
@@ -38,7 +38,7 @@ function nexteuropa_lastupdate_preprocess_nexteuropa_last_update_block(&$variabl
   if ($entity = _nexteuropa_lastupdate_menu_get_any_entity()) {
     $info = entity_get_info($entity->entity_type);
     if (isset($info['last update callback']) && function_exists($info['last update callback'])) {
-      $last_update_variables = $info['last update callback']($entity);
+      $last_update_variables = call_user_func($info['last update callback'], $entity);
       if (!empty($last_update_variables)) {
         $variables['label'] = $last_update_variables['label'];
         $variables['date'] = $last_update_variables['date'];

--- a/profiles/common/modules/custom/nexteuropa_lastupdate/theme/nexteuropa-last-update-block.tpl.php
+++ b/profiles/common/modules/custom/nexteuropa_lastupdate/theme/nexteuropa-last-update-block.tpl.php
@@ -5,8 +5,8 @@
  * Default implementation of the last update block.
  *
  * Available variables:
- * - $label: the language list.
- * - $date: optional language icon.
+ * - $label: the language label.
+ * - $date: the date.
  *
  * @see template_preprocess()
  * @see template_preprocess_block()

--- a/profiles/common/modules/custom/nexteuropa_lastupdate/theme/nexteuropa-last-update-block.tpl.php
+++ b/profiles/common/modules/custom/nexteuropa_lastupdate/theme/nexteuropa-last-update-block.tpl.php
@@ -7,14 +7,14 @@
  * Available variables:
  * - $label: the language list.
  * - $date: optional language icon.
- * - $close_button: optional close button.
  *
  * @see template_preprocess()
- * @see template_preprocess_splash()
+ * @see template_preprocess_block()
  * @see template_process()
  */
 ?>
-
-<div class="last-update">
-  <?php print $label; ?> : <?php print $date; ?>
-</div>
+<?php if (!empty($label) && !empty($date)) : ?>
+  <div class="last-update">
+    <?php print $label; ?> : <?php print $date; ?>
+  </div>
+<?php endif; ?>

--- a/profiles/common/modules/custom/nexteuropa_lastupdate/theme/nexteuropa-last-update-block.tpl.php
+++ b/profiles/common/modules/custom/nexteuropa_lastupdate/theme/nexteuropa-last-update-block.tpl.php
@@ -5,7 +5,7 @@
  * Default implementation of the last update block.
  *
  * Available variables:
- * - $label: the language label.
+ * - $label: the label.
  * - $date: the date.
  *
  * @see template_preprocess()

--- a/profiles/common/modules/features/ec_embedded_video/ec_embedded_video.install
+++ b/profiles/common/modules/features/ec_embedded_video/ec_embedded_video.install
@@ -4,6 +4,8 @@
  * Install, update and uninstall functions for the ec_embedded_video module.
  */
 
+module_load_include('inc', 'ec_embedded_video', 'ec_embedded_video.install');
+
 /**
  * Implements hook_install().
  */
@@ -14,150 +16,6 @@ function ec_embedded_video_install() {
     variable_set('media__wysiwyg_browser_plugins', $plugins);
   }
   _ec_embedded_video_install_soft_configured_file_display();
-}
-
-/**
- * Soft configure media assets video display for the WYSIWYG view mode.
- *
- * Implied media assets are YouTube, Vimeo, Dailymotion and AV portal.
- */
-function _ec_embedded_video_install_soft_configured_file_display() {
-
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__no_wrapper_media_avportal_video';
-  $file_display->weight = -39;
-  $file_display->status = TRUE;
-  $file_display->settings = array(
-    'width' => '640',
-    'height' => '390',
-  );
-  file_display_save($file_display);
-
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__no_wrapper_media_dailymotion_video';
-  $file_display->weight = -43;
-  $file_display->status = TRUE;
-  $file_display->settings = array(
-    'width' => '560',
-    'height' => '340',
-    'autoplay' => 0,
-    'iframe' => 1,
-  );
-  file_display_save($file_display);
-
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__no_wrapper_media_vimeo_video';
-  $file_display->weight = -49;
-  $file_display->status = TRUE;
-  $file_display->settings = array(
-    'width' => '640',
-    'height' => '360',
-    'color' => '',
-    'protocol_specify' => 0,
-    'protocol' => 'https://',
-    'autoplay' => 0,
-    'loop' => 0,
-    'title' => 1,
-    'byline' => 1,
-    'portrait' => 1,
-    'api' => 0,
-  );
-  file_display_save($file_display);
-
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__no_wrapper_media_youtube_video';
-  $file_display->weight = -46;
-  $file_display->status = TRUE;
-  $file_display->settings = array(
-    'width' => '640',
-    'height' => '390',
-    'theme' => 'dark',
-    'color' => 'red',
-    'autohide' => '2',
-    'autoplay' => 0,
-    'loop' => 0,
-    'showinfo' => 1,
-    'modestbranding' => 0,
-    'rel' => 1,
-    'nocookie' => 0,
-    'protocol_specify' => 0,
-    'protocol' => 'https:',
-    'enablejsapi' => 0,
-    'origin' => '',
-  );
-  file_display_save($file_display);
-
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__media_avportal_video';
-  $file_display->weight = -41;
-  $file_display->status = FALSE;
-  $file_display->settings = array(
-    'width' => '640',
-    'height' => '390',
-  );
-  file_display_save($file_display);
-
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__media_dailymotion_video';
-  $file_display->weight = -40;
-  $file_display->status = FALSE;
-  $file_display->settings = array(
-    'width' => '560',
-    'height' => '340',
-    'autoplay' => 0,
-    'iframe' => 1,
-  );
-  file_display_save($file_display);
-
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__media_vimeo_video';
-  $file_display->weight = -47;
-  $file_display->status = FALSE;
-  $file_display->settings = array(
-    'width' => '640',
-    'height' => '360',
-    'color' => '',
-    'protocol_specify' => 0,
-    'protocol' => 'https://',
-    'autoplay' => 0,
-    'loop' => 0,
-    'title' => 1,
-    'byline' => 1,
-    'portrait' => 1,
-    'api' => 0,
-  );
-  file_display_save($file_display);
-
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__media_youtube_video';
-  $file_display->weight = -46;
-  $file_display->status = FALSE;
-  $file_display->settings = array(
-    'width' => '640',
-    'height' => '390',
-    'theme' => 'dark',
-    'color' => 'red',
-    'autohide' => '2',
-    'autoplay' => 0,
-    'loop' => 0,
-    'showinfo' => 1,
-    'modestbranding' => 0,
-    'rel' => 1,
-    'nocookie' => 0,
-    'protocol_specify' => 0,
-    'protocol' => 'https:',
-    'enablejsapi' => 0,
-    'origin' => '',
-  );
-  file_display_save($file_display);
 }
 
 /**

--- a/profiles/common/modules/features/ec_embedded_video/ec_embedded_video.install.inc
+++ b/profiles/common/modules/features/ec_embedded_video/ec_embedded_video.install.inc
@@ -10,7 +10,6 @@
  * Implied media assets are YouTube, Vimeo, Dailymotion and AV portal.
  */
 function _ec_embedded_video_install_soft_configured_file_display() {
-
   $file_display = new stdClass();
   $file_display->api_version = 1;
   $file_display->name = 'video__wysiwyg__no_wrapper_media_avportal_video';

--- a/profiles/common/modules/features/ec_embedded_video/ec_embedded_video.install.inc
+++ b/profiles/common/modules/features/ec_embedded_video/ec_embedded_video.install.inc
@@ -1,0 +1,149 @@
+<?php
+/**
+ * @file
+ * Code for the ec_embedded_video module.
+ */
+
+/**
+ * Soft configure media assets video display for the WYSIWYG view mode.
+ *
+ * Implied media assets are YouTube, Vimeo, Dailymotion and AV portal.
+ */
+function _ec_embedded_video_install_soft_configured_file_display() {
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__wysiwyg__no_wrapper_media_avportal_video';
+  $file_display->weight = -39;
+  $file_display->status = TRUE;
+  $file_display->settings = array(
+    'width' => '640',
+    'height' => '390',
+  );
+  file_display_save($file_display);
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__wysiwyg__no_wrapper_media_dailymotion_video';
+  $file_display->weight = -43;
+  $file_display->status = TRUE;
+  $file_display->settings = array(
+    'width' => '560',
+    'height' => '340',
+    'autoplay' => 0,
+    'iframe' => 1,
+  );
+  file_display_save($file_display);
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__wysiwyg__no_wrapper_media_vimeo_video';
+  $file_display->weight = -49;
+  $file_display->status = TRUE;
+  $file_display->settings = array(
+    'width' => '640',
+    'height' => '360',
+    'color' => '',
+    'protocol_specify' => 0,
+    'protocol' => 'https://',
+    'autoplay' => 0,
+    'loop' => 0,
+    'title' => 1,
+    'byline' => 1,
+    'portrait' => 1,
+    'api' => 0,
+  );
+  file_display_save($file_display);
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__wysiwyg__no_wrapper_media_youtube_video';
+  $file_display->weight = -46;
+  $file_display->status = TRUE;
+  $file_display->settings = array(
+    'width' => '640',
+    'height' => '390',
+    'theme' => 'dark',
+    'color' => 'red',
+    'autohide' => '2',
+    'autoplay' => 0,
+    'loop' => 0,
+    'showinfo' => 1,
+    'modestbranding' => 0,
+    'rel' => 1,
+    'nocookie' => 0,
+    'protocol_specify' => 0,
+    'protocol' => 'https:',
+    'enablejsapi' => 0,
+    'origin' => '',
+  );
+  file_display_save($file_display);
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__wysiwyg__media_avportal_video';
+  $file_display->weight = -41;
+  $file_display->status = FALSE;
+  $file_display->settings = array(
+    'width' => '640',
+    'height' => '390',
+  );
+  file_display_save($file_display);
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__wysiwyg__media_dailymotion_video';
+  $file_display->weight = -40;
+  $file_display->status = FALSE;
+  $file_display->settings = array(
+    'width' => '560',
+    'height' => '340',
+    'autoplay' => 0,
+    'iframe' => 1,
+  );
+  file_display_save($file_display);
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__wysiwyg__media_vimeo_video';
+  $file_display->weight = -47;
+  $file_display->status = FALSE;
+  $file_display->settings = array(
+    'width' => '640',
+    'height' => '360',
+    'color' => '',
+    'protocol_specify' => 0,
+    'protocol' => 'https://',
+    'autoplay' => 0,
+    'loop' => 0,
+    'title' => 1,
+    'byline' => 1,
+    'portrait' => 1,
+    'api' => 0,
+  );
+  file_display_save($file_display);
+
+  $file_display = new stdClass();
+  $file_display->api_version = 1;
+  $file_display->name = 'video__wysiwyg__media_youtube_video';
+  $file_display->weight = -46;
+  $file_display->status = FALSE;
+  $file_display->settings = array(
+    'width' => '640',
+    'height' => '390',
+    'theme' => 'dark',
+    'color' => 'red',
+    'autohide' => '2',
+    'autoplay' => 0,
+    'loop' => 0,
+    'showinfo' => 1,
+    'modestbranding' => 0,
+    'rel' => 1,
+    'nocookie' => 0,
+    'protocol_specify' => 0,
+    'protocol' => 'https:',
+    'enablejsapi' => 0,
+    'origin' => '',
+  );
+  file_display_save($file_display);
+}

--- a/profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.helpers.inc
+++ b/profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.helpers.inc
@@ -59,7 +59,7 @@ function _nexteuropa_metatags_create_metatag_config() {
         0 => 'format',
       ),
     ),
-    'locked' => 0,
+    'locked' => 1,
     'module' => 'text',
     'settings' => array(
       'entity_translation_sync' => FALSE,
@@ -89,7 +89,7 @@ function _nexteuropa_metatags_create_metatag_config() {
         0 => 'format',
       ),
     ),
-    'locked' => 0,
+    'locked' => 1,
     'module' => 'text',
     'settings' => array(
       'entity_translation_sync' => FALSE,

--- a/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.install
+++ b/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.install
@@ -4,9 +4,11 @@
  * Nexteuropa_multilingual install file.
  */
 
- /**
-  * Implements hook_requirements().
-  */
+module_load_include('inc', 'nexteuropa_multilingual', 'nexteuropa_multilingual.install');
+
+/**
+ * Implements hook_requirements().
+ */
 function nexteuropa_multilingual_requirements() {
   $requirements = [];
   if (module_exists('multisite_drupal_language_negociation')) {
@@ -113,42 +115,6 @@ function nexteuropa_multilingual_disable() {
   // Disable modules.
   module_disable(array('language_selector_site'), FALSE);
   module_disable(array('language_selector_page'), FALSE);
-}
-
-/**
- * Helper function to make all file types translatable.
- */
-function _nexteuropa_multilingual_make_files_translatable() {
-  // Make default image title and alt fields translatable.
-  $image_fields = array('field_file_image_alt_text', 'field_file_image_title_text');
-  foreach ($image_fields as $image_field_name) {
-    $image_field = field_info_field($image_field_name);
-    if (isset($image_field['translatable'])) {
-      $image_field['translatable'] = TRUE;
-      field_update_field($image_field);
-    }
-  }
-
-  // Add files as translatable entities.
-  $translatable_entities = variable_get('entity_translation_entity_types', array('node' => 'node'));
-  $translatable_entities['file'] = 'file';
-  variable_set('entity_translation_entity_types', $translatable_entities);
-
-  // Add entity_translation configuration for the default file entities.
-  $default_file_types = array(
-    'audio',
-    'document',
-    'image',
-    'video',
-  );
-  foreach ($default_file_types as $default_file_type) {
-    $file_type_configuration = variable_get('entity_translation_settings_file__' . $default_file_type, array());
-    $file_type_configuration['hide_language_selector'] = 0;
-    variable_set('entity_translation_settings_file__' . $default_file_type, $file_type_configuration);
-    if (title_field_replacement_toggle('file', $default_file_type, 'filename')) {
-      title_field_replacement_batch_set('file', $default_file_type, 'filename');
-    }
-  }
 }
 
 /**

--- a/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.install.inc
+++ b/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.install.inc
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @file
+ * Code for the Nexteuropa Multilingual module.
+ */
+
+/**
+ * Helper function to make all file types translatable.
+ */
+function _nexteuropa_multilingual_make_files_translatable() {
+  // Make default image title and alt fields translatable.
+  $image_fields = array('field_file_image_alt_text', 'field_file_image_title_text');
+  foreach ($image_fields as $image_field_name) {
+    $image_field = field_info_field($image_field_name);
+    if (isset($image_field['translatable'])) {
+      $image_field['translatable'] = TRUE;
+      field_update_field($image_field);
+    }
+  }
+
+  // Add files as translatable entities.
+  $translatable_entities = variable_get('entity_translation_entity_types', array('node' => 'node'));
+  $translatable_entities['file'] = 'file';
+  variable_set('entity_translation_entity_types', $translatable_entities);
+
+  // Add entity_translation configuration for the default file entities.
+  $default_file_types = array(
+    'audio',
+    'document',
+    'image',
+    'video',
+  );
+  foreach ($default_file_types as $default_file_type) {
+    $file_type_configuration = variable_get('entity_translation_settings_file__' . $default_file_type, array());
+    $file_type_configuration['hide_language_selector'] = 0;
+    variable_set('entity_translation_settings_file__' . $default_file_type, $file_type_configuration);
+    if (title_field_replacement_toggle('file', $default_file_type, 'filename')) {
+      title_field_replacement_batch_set('file', $default_file_type, 'filename');
+    }
+  }
+}

--- a/tests/features/last_update.feature
+++ b/tests/features/last_update.feature
@@ -14,16 +14,14 @@ Scenario: Administrators can add the last update block in a region
   When I visit "admin/structure/block"
   Then I should see the text "Last update date"
 
-@RevertBlockConfiguration
-Scenario: The last update doesn't show if a node is not published
+Scenario: Check that the last update block is not shown if a node is not published
   Given that the block "last_update" from module "nexteuropa_lastupdate" is assigned to the region "footer"
   When I go to "node/add/page"
   And I fill in "Title" with "Page title"
   And I press "Save"
   Then I should not see an ".last-update" element
 
-@RevertBlockConfiguration
-Scenario: The last update shows if a node is published
+Scenario: Check that the last update block is shown if a node is published
   Given that the block "last_update" from module "nexteuropa_lastupdate" is assigned to the region "footer"
   When I go to "node/add/page"
   And I fill in "Title" with "Page title"
@@ -31,4 +29,12 @@ Scenario: The last update shows if a node is published
   And I press "Save"
   Then I should see "Last published" in the ".last-update" element
 
+Scenario Outline: Check that the last update block is shown in other cases (user/file)
+  Given that the block "last_update" from module "nexteuropa_lastupdate" is assigned to the region "footer"
+  When I go to "<url>"
+  Then I should see "<sentence>" in the ".last-update" element
 
+  Examples:
+    | url                 | sentence      |
+    | user                | Last accessed |
+    | file/userdefaultpng | Last uploaded |


### PR DESCRIPTION
## NEPT-1252

### Description

Release 2.4: QA feedback application for blockers

### Change log

Changed: NEPT-1271: Add behat test for last_update module and update the readme.
Changed: NEPT-1267: Move helper functions outside of install file.
Changed: NEPT-1268: Locked metatag files.
Changed: NEPT-1269: Move helper functions outside of install file.
Changed: NEPT-1270: Clean tpl for the nexteuropa_lastupdate module.
Changed: NEPT-1270: Refactor the preprocess method.

### Commands

```sh
drush cc all

```

