### PR TITLE
NEPT-411: Update the module ctools from 1.11 to latest commit.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -161,7 +161,9 @@ projects[context_og][subdir] = "contrib"
 projects[context_og][version] = "2.1" 
 
 projects[ctools][subdir] = "contrib"
-projects[ctools][version] = "1.12"
+projects[ctools][download][branch] = 7.x-1.x
+projects[ctools][download][revision] = e94ba64a8e8a0afbc4d6d231d09f040ebd1177d4
+projects[ctools][download][type] = git
 
 projects[customerror][subdir] = "contrib"
 projects[customerror][version] = "1.4"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -161,7 +161,7 @@ projects[context_og][subdir] = "contrib"
 projects[context_og][version] = "2.1" 
 
 projects[ctools][subdir] = "contrib"
-projects[ctools][version] = "1.11"
+projects[ctools][version] = "1.12"
 
 projects[customerror][subdir] = "contrib"
 projects[customerror][version] = "1.4"


### PR DESCRIPTION
## NEPT-411

### Description

Update the module ctools from 1.11 to last commit.

### Change log

- Changed: Update the module ctools from 1.11 to last commit - 07/2017.

### Commands

```sh
drush cc all

```

