### PR TITLE
NEPT-1339: Upgrade ec_resp to 2.3.1.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -998,7 +998,7 @@ libraries[respond][download][url] = https://raw.githubusercontent.com/scottjehl/
 projects[ec_resp][type] = theme
 projects[ec_resp][download][type] = git
 projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
-projects[ec_resp][download][tag] = 2.3
+projects[ec_resp][download][tag] = 2.3.1
 
 projects[atomium][type] = theme
 projects[atomium][download][type] = git


### PR DESCRIPTION
## NEPT-1339

### Description

Upgrade ec_resp to release 2.3.1

### Change log

- Added: Maintenance offline page
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
no command

```

