### PR TITLE
NEPT-1329: Update views to 3.17 - support-2.3

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -702,10 +702,7 @@ projects[views][version] = 3.17
 
 ; Error when configuring exposed group filter: "The value is required if title for this item is defined."
 ; https://www.drupal.org/node/1818176
-projects[views][patch][] = https://www.drupal.org/files/views-1818176-11.patch
-; Fatal error: Unsupported operand types in [path to drupal]/sites/all/modules/views/includes/handlers.inc on line 1032
-; https://www.drupal.org/node/1752062
-projects[views][patch][] = https://www.drupal.org/files/includes_handlers.inc_.git_.patch
+projects[views][patch][] = https://www.drupal.org/files/issues/views-erroneous_empty_not_empty_filter_error-1818176-37.patch
 ; Default argument not skipped in breadcrumbs
 ; https://www.drupal.org/node/1201160
 projects[views][patch][] = https://www.drupal.org/files/issues/views-contextual_filter_exception_breadcrumbs-1201160-17.patch

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -698,7 +698,7 @@ projects[video][patch][] = patches/video-revert_issue-1891012-0.patch
 projects[video][patch][] = patches/video-security-883.patch
 
 projects[views][subdir] = "contrib"
-projects[views][version] = 3.15
+projects[views][version] = 3.17
 
 ; Error when configuring exposed group filter: "The value is required if title for this item is defined."
 ; https://www.drupal.org/node/1818176


### PR DESCRIPTION
## NEPT-1329

### Description

Update views from 3.15 to 3.17 .

3.16 is a rather major bug fix release. It is strongly recommended to thoroughly test this release before uploading to production sites in case there are any regressions. There are two changes since 7.x-3.15 which affect how CSS classes are generated, so please pay particular attention to the themed output. Please report regressions immediately so that we can rectify them in a future release.

### Change log

- Changed: Views version from 3.15 to 3.17
- Changed: Patches for views

### Commands

No extra commands are required.
