### PR TITLE
NEPT-1429: Update variable for platform version 2.4

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -2463,3 +2463,10 @@ function cce_basic_config_update_7219() {
     module_enable(array('nexteuropa_europa_search'));
   }
 }
+
+/**
+ * Update platform version to 2.4.
+ */
+function cce_basic_config_update_7220() {
+  variable_set('multisite_version', '2.4');
+}

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -998,7 +998,7 @@ libraries[respond][download][url] = https://raw.githubusercontent.com/scottjehl/
 projects[ec_resp][type] = theme
 projects[ec_resp][download][type] = git
 projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
-projects[ec_resp][download][tag] = 2.3
+projects[ec_resp][download][tag] = 2.3.1
 
 projects[atomium][type] = theme
 projects[atomium][download][type] = git


### PR DESCRIPTION
## NEPT-1429

### Description

NEPT-1429: Update variable for platform version.
NEPT-1339: Upgrade ec_resp to 2.3.1

### Change log

- Added: hook_update_N in cce_basic_config to update the variable for platform version.
- Added: Maintenance offline page

### Commands

```sh
drush updb
```