### PR TITLE
NEPT-804: Addition of qa-automation tools.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,7 @@ void executeStages(String label) {
         }
 
         stage('Check & Test ' + label) {
-            sh './bin/phpcs'
+            sh './bin/phpcs --report=full --report=source --report=summary -s'
             sh './bin/phpunit -c tests/phpunit.xml'
             wrap([$class: 'AnsiColorBuildWrapper', colorMapName: 'xterm']) {
                 timeout(time: 2, unit: 'HOURS') {

--- a/build.properties.dist
+++ b/build.properties.dist
@@ -177,10 +177,20 @@ phpcs.extensions = php inc module install info test profile theme css js
 # The default configuration file to generate.
 phpcs.config = ${project.basedir}/phpcs.xml
 
-# The coding standard to use.
-phpcs.standard = ${project.basedir}/phpcs-ruleset.xml
+# The default path of qa-automation.
+phpcs.qa_automation.path = ${project.basedir}/vendor/ec-europa/qa-automation
 
-# Paths to check, delimited by semicolons.
+# The locations for installed standards, delimited by spaces, commas or semicolons.
+phpcs.installed.paths = ${phpcs.qa_automation.path}/phpcs/SubStandards
+
+# The coding standards to use, delimited by spaces, commas or semicolons.
+phpcs.standards = Platform;${project.basedir}/phpcs-ruleset.xml
+
+# Returns a 0 error code when only warnings are found if enabled. Meant for CI.
+# Set to 1 for ignoring warnings, 0 for showing warnings.
+phpcs.ignore.warnings = 0
+
+# Paths to check, delimited by spaces, commas or semicolons.
 phpcs.files = ${platform.resources.profiles.dir};${platform.resources.source.dir};${behat.dir};
 
 # Paths to ignore, delimited by semicolons.

--- a/build.test.xml
+++ b/build.test.xml
@@ -48,10 +48,12 @@
             files="${phpcs.files}"
             globalConfig="${phpcs.global.config}"
             ignorePatterns="${phpcs.ignore}"
+            installedPaths="${phpcs.installed.paths}"
+            ignoreWarnings = "${phpcs.ignore.warnings}"
             report="${phpcs.report}"
             showProgress="${phpcs.progress}"
             showSniffCodes="${phpcs.sniffcodes}"
-            standard="${phpcs.standard}"
+            standards="${phpcs.standards}"
         />
     </target>
 

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
   "require": {
     "php": ">=5.4.0",
-    "drupal/coder": "8.2.6",
     "drupal/phingdrushtask": "^1.1",
     "drupol/phingbehattask": "^1.0",
     "drush/drush": "8.0.5",
+    "ec-europa/qa-automation": "^3.0",
     "ext-json": "*",
     "ext-phar": "*",
     "ext-xml": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,63 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cca1b5c3190e51d5a2b8057c0f1db633",
+    "content-hash": "16ef4c043a1bc908e961aeeb72e1dc52",
     "packages": [
+        {
+            "name": "cpliakas/git-wrapper",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cpliakas/git-wrapper.git",
+                "reference": "1a2f1131ec9ebe04a0b729b141396fa55f992d44"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cpliakas/git-wrapper/zipball/1a2f1131ec9ebe04a0b729b141396fa55f992d44",
+                "reference": "1a2f1131ec9ebe04a0b729b141396fa55f992d44",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "symfony/event-dispatcher": "~2.3|~3.0",
+                "symfony/process": "~2.3|~3.0"
+            },
+            "require-dev": {
+                "pdepend/pdepend": "~1.0",
+                "phploc/phploc": "~2.0",
+                "phpmd/phpmd": "~1.0",
+                "phpunit/phpunit": "~3.0",
+                "psr/log": "~1.0",
+                "scrutinizer/ocular": "~1.0",
+                "sebastian/phpcpd": "~2.0",
+                "symfony/filesystem": "~2.0"
+            },
+            "suggest": {
+                "monolog/monolog": "Enables logging of executed git commands"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "GitWrapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Pliakas",
+                    "email": "opensource@chrispliakas.com"
+                }
+            ],
+            "description": "A PHP wrapper around the Git command line utility.",
+            "homepage": "https://github.com/cpliakas/git-wrapper",
+            "keywords": [
+                "git"
+            ],
+            "time": "2016-04-19T16:12:33+00:00"
+        },
         {
             "name": "dnoegel/php-xdg-base-dir",
             "version": "0.1",
@@ -41,27 +96,28 @@
         },
         {
             "name": "drupal/coder",
-            "version": "8.2.6",
+            "version": "8.2.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/klausi/coder.git",
-                "reference": "717cb8b6cb64a0e2b701542f26ee59b4d1e4ab57"
+                "reference": "984c54a7b1e8f27ff1c32348df69712afd86b17f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/klausi/coder/zipball/717cb8b6cb64a0e2b701542f26ee59b4d1e4ab57",
-                "reference": "717cb8b6cb64a0e2b701542f26ee59b4d1e4ab57",
+                "url": "https://api.github.com/repos/klausi/coder/zipball/984c54a7b1e8f27ff1c32348df69712afd86b17f",
+                "reference": "984c54a7b1e8f27ff1c32348df69712afd86b17f",
                 "shasum": ""
             },
             "require": {
+                "ext-mbstring": "*",
                 "php": ">=5.4.0",
-                "squizlabs/php_codesniffer": ">=2.5.1",
+                "squizlabs/php_codesniffer": ">=2.8.1 <3.0",
                 "symfony/yaml": ">=2.0.0"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=3.7"
+                "phpunit/phpunit": ">=3.7 <6"
             },
-            "type": "library",
+            "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0+"
@@ -73,7 +129,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-02-07T12:15:20+00:00"
+            "time": "2017-03-18T10:28:49+00:00"
         },
         {
             "name": "drupal/phingdrushtask",
@@ -320,6 +376,43 @@
             "time": "2016-03-08T21:00:41+00:00"
         },
         {
+            "name": "ec-europa/qa-automation",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ec-europa/qa-automation.git",
+                "reference": "28a1c4d9eeab90f7d419641c3b0439a577054ba0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ec-europa/qa-automation/zipball/28a1c4d9eeab90f7d419641c3b0439a577054ba0",
+                "reference": "28a1c4d9eeab90f7d419641c3b0439a577054ba0",
+                "shasum": ""
+            },
+            "require": {
+                "cpliakas/git-wrapper": "^1.7",
+                "drupal/coder": "8.2.12",
+                "php": ">=5.2.0",
+                "symfony/console": "~2.3.10|^2.4.2|~3.0",
+                "symfony/finder": "^3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=3.7 <5.0"
+            },
+            "bin": [
+                "bin/qa"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "QualityAssurance\\Component\\Console\\": "src/Console"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "description": "Performs automated QA checks and extra php codesniffs for the subsite starterkit.",
+            "time": "2017-08-11T13:44:36+00:00"
+        },
+        {
             "name": "jakub-onderka/php-console-color",
             "version": "0.1",
             "source": {
@@ -408,16 +501,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v3.0.2",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "adf44419c0fc014a0f191db6f89d3e55d4211744"
+                "reference": "4d4896e553f2094e657fe493506dc37c509d4e2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/adf44419c0fc014a0f191db6f89d3e55d4211744",
-                "reference": "adf44419c0fc014a0f191db6f89d3e55d4211744",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4d4896e553f2094e657fe493506dc37c509d4e2b",
+                "reference": "4d4896e553f2094e657fe493506dc37c509d4e2b",
                 "shasum": ""
             },
             "require": {
@@ -455,7 +548,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2016-12-06T11:30:35+00:00"
+            "time": "2017-07-28T14:45:09+00:00"
         },
         {
             "name": "pear/console_getopt",
@@ -561,20 +654,20 @@
         },
         {
             "name": "pear/pear-core-minimal",
-            "version": "v1.10.1",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/pear-core-minimal.git",
-                "reference": "cae0f1ce0cb5bddb611b0a652d322905a65a5896"
+                "reference": "070f0b600b2caca2501e2c9b7e553016e4b0d115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/pear-core-minimal/zipball/cae0f1ce0cb5bddb611b0a652d322905a65a5896",
-                "reference": "cae0f1ce0cb5bddb611b0a652d322905a65a5896",
+                "url": "https://api.github.com/repos/pear/pear-core-minimal/zipball/070f0b600b2caca2501e2c9b7e553016e4b0d115",
+                "reference": "070f0b600b2caca2501e2c9b7e553016e4b0d115",
                 "shasum": ""
             },
             "require": {
-                "pear/console_getopt": "~1.3",
+                "pear/console_getopt": "~1.4",
                 "pear/pear_exception": "~1.0"
             },
             "replace": {
@@ -601,7 +694,7 @@
                 }
             ],
             "description": "Minimal set of PEAR core files to be used as composer dependency",
-            "time": "2015-10-17T11:41:19+00:00"
+            "time": "2017-02-28T16:46:11+00:00"
         },
         {
             "name": "pear/pear_exception",
@@ -700,7 +793,7 @@
                 }
             ],
             "description": "VersionControl_Git is a library that provides OO interface to handle Git repository.",
-            "time": "2015-11-04 13:03:54"
+            "time": "2015-11-04T13:03:54+00:00"
         },
         {
             "name": "pfrenssen/phpcs-pre-push",
@@ -854,16 +947,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.8.1",
+            "version": "v0.8.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "701e8a1cc426ee170f1296f5d9f6b8a26ad25c4a"
+                "reference": "b193cd020e8c6b66cea6457826ae005e94e6d2c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/701e8a1cc426ee170f1296f5d9f6b8a26ad25c4a",
-                "reference": "701e8a1cc426ee170f1296f5d9f6b8a26ad25c4a",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/b193cd020e8c6b66cea6457826ae005e94e6d2c0",
+                "reference": "b193cd020e8c6b66cea6457826ae005e94e6d2c0",
                 "shasum": ""
             },
             "require": {
@@ -893,7 +986,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-develop": "0.9.x-dev"
+                    "dev-develop": "0.8.x-dev"
                 }
             },
             "autoload": {
@@ -923,20 +1016,20 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2017-01-15T17:54:13+00:00"
+            "time": "2017-07-29T19:30:02+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.7.1",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f"
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9b324f3a1132459a7274a0ace2e1b766ba80930f",
-                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
                 "shasum": ""
             },
             "require": {
@@ -1001,20 +1094,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-11-30T04:02:31+00:00"
+            "time": "2017-05-22T02:43:20+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.2.2",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "4f9e449e76996adf310498a8ca955c6deebe29dd"
+                "reference": "b0878233cb5c4391347e5495089c7af11b8e6201"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/4f9e449e76996adf310498a8ca955c6deebe29dd",
-                "reference": "4f9e449e76996adf310498a8ca955c6deebe29dd",
+                "url": "https://api.github.com/repos/symfony/console/zipball/b0878233cb5c4391347e5495089c7af11b8e6201",
+                "reference": "b0878233cb5c4391347e5495089c7af11b8e6201",
                 "shasum": ""
             },
             "require": {
@@ -1022,10 +1115,16 @@
                 "symfony/debug": "~2.8|~3.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3"
+            },
             "require-dev": {
                 "psr/log": "~1.0",
+                "symfony/config": "~3.3",
+                "symfony/dependency-injection": "~3.3",
                 "symfony/event-dispatcher": "~2.8|~3.0",
                 "symfony/filesystem": "~2.8|~3.0",
+                "symfony/http-kernel": "~2.8|~3.0",
                 "symfony/process": "~2.8|~3.0"
             },
             "suggest": {
@@ -1037,7 +1136,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -1064,20 +1163,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-08T20:47:33+00:00"
+            "time": "2017-07-29T21:27:59+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.2.2",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "810ba5c1c5352a4ddb15d4719e8936751dff0b05"
+                "reference": "7c13ae8ce1e2adbbd574fc39de7be498e1284e13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/810ba5c1c5352a4ddb15d4719e8936751dff0b05",
-                "reference": "810ba5c1c5352a4ddb15d4719e8936751dff0b05",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/7c13ae8ce1e2adbbd574fc39de7be498e1284e13",
+                "reference": "7c13ae8ce1e2adbbd574fc39de7be498e1284e13",
                 "shasum": ""
             },
             "require": {
@@ -1088,13 +1187,12 @@
                 "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
             },
             "require-dev": {
-                "symfony/class-loader": "~2.8|~3.0",
                 "symfony/http-kernel": "~2.8|~3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -1121,20 +1219,132 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-02T20:32:22+00:00"
+            "time": "2017-07-28T15:27:31+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.3.0",
+            "name": "symfony/event-dispatcher",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "67535f1e3fd662bdc68d7ba317c93eecd973617e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
-                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/67535f1e3fd662bdc68d7ba317c93eecd973617e",
+                "reference": "67535f1e3fd662bdc68d7ba317c93eecd973617e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.8|~3.0",
+                "symfony/dependency-injection": "~3.3",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/stopwatch": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-06-09T14:53:08+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v3.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "baea7f66d30854ad32988c11a09d7ffd485810c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/baea7f66d30854ad32988c11a09d7ffd485810c4",
+                "reference": "baea7f66d30854ad32988c11a09d7ffd485810c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-06-01T21:01:25+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
                 "shasum": ""
             },
             "require": {
@@ -1146,7 +1356,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -1180,36 +1390,90 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2017-06-14T15:44:48+00:00"
         },
         {
-            "name": "symfony/var-dumper",
-            "version": "v3.2.2",
+            "name": "symfony/process",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "b54b23f9a19b465e76fdaac0f6732410467c83b2"
+                "url": "https://github.com/symfony/process.git",
+                "reference": "07432804942b9f6dd7b7377faf9920af5f95d70a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/b54b23f9a19b465e76fdaac0f6732410467c83b2",
-                "reference": "b54b23f9a19b465e76fdaac0f6732410467c83b2",
+                "url": "https://api.github.com/repos/symfony/process/zipball/07432804942b9f6dd7b7377faf9920af5f95d70a",
+                "reference": "07432804942b9f6dd7b7377faf9920af5f95d70a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-07-13T13:05:09+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v3.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "b2623bccb969ad595c2090f9be498b74670d0663"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/b2623bccb969ad595c2090f9be498b74670d0663",
+                "reference": "b2623bccb969ad595c2090f9be498b74670d0663",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9",
                 "symfony/polyfill-mbstring": "~1.0"
             },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
             "require-dev": {
-                "twig/twig": "~1.20|~2.0"
+                "ext-iconv": "*",
+                "twig/twig": "~1.34|~2.4"
             },
             "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
                 "ext-symfony_debug": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -1243,20 +1507,20 @@
                 "debug",
                 "dump"
             ],
-            "time": "2017-01-03T08:53:57+00:00"
+            "time": "2017-07-28T06:06:09+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.2.2",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "50eadbd7926e31842893c957eca362b21592a97d"
+                "reference": "ddc23324e6cfe066f3dd34a37ff494fa80b617ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/50eadbd7926e31842893c957eca362b21592a97d",
-                "reference": "50eadbd7926e31842893c957eca362b21592a97d",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/ddc23324e6cfe066f3dd34a37ff494fa80b617ed",
+                "reference": "ddc23324e6cfe066f3dd34a37ff494fa80b617ed",
                 "shasum": ""
             },
             "require": {
@@ -1271,7 +1535,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -1298,7 +1562,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-03T13:51:32+00:00"
+            "time": "2017-07-23T12:43:26+00:00"
         },
         {
             "name": "wimg/php-compatibility",

--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -1,0 +1,783 @@
+<?xml version="1.0"?>
+
+<ruleset name="QA">
+
+    <description>QA Roadmap</description>
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-804 -->
+
+    <!-- Check if variable is actually used. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-814 -->
+    <rule ref="DrupalPractice.CodeAnalysis.VariableAnalysis.UnusedVariable">
+        <exclude-pattern>profiles/multisite_drupal_communities/modules/custom/og_content_type_admin/og_content_type_admin.module</exclude-pattern>
+        <exclude-pattern>profiles/multisite_drupal_communities/modules/custom/og_content_type_admin/og_content_type_admin.install</exclude-pattern>
+        <exclude-pattern>profiles/multisite_drupal_communities/modules/custom/multisite_drupal_access/multisite_drupal_access.module</exclude-pattern>
+        <exclude-pattern>profiles/common/themes/ec_resp/template.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_og_navigation_tree/multisite_og_navigation_tree.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_og_navigation_tree/views/multisite_og_navigation_tree.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_og_navigation_tree/multisite_og_navigation_tree.theme.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.admin.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/tmgmt_workbench/tmgmt_workbench.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/tmgmt_workbench/includes/tmgmt_workbench.ui.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_ief_views_widget/views/nexteuropa_ief_views_widget.views.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_ief_views_widget/views/nexteuropa_ief_views_widget_handler_field_selection.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_dynamic_basetheme/multisite_dynamic_basetheme.drush.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_dynamic_basetheme/multisite_dynamic_basetheme.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/tmgmt_og/tmgmt_og.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_block_carousel/multisite_block_carousel.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/media_avportal/includes/media_avportal.formatters.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/NodeViewModeType.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/ViewModeTypeBase.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_token/src/Entity/UrlTokenHandler.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_token/src/Entity/LinkTokenHandler.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeTokenHandler.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/views/nexteuropa_token_ckeditor.views.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_cookie_consent/multisite_cookie_consent.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_cookie_consent/modules/connections/multisite_cookie_rest.testing.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/tmgmt_mtec/tmgmt_mtec.plugin.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/tmgmt_mtec/tmgmt_mtec.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_config/tests/Drupal/field/InstanceField/DefaultFieldHandlerTest.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/ecas/includes/ecas.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/ecas/ecas_import_users/ecas_import_users.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/ecas/ecas_import_users/ecas_import_users.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/ecas/ecas_group_sync/ecas_group_sync.admin.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/ecas/ecas_group_sync/ecas_group_sync_group.admin.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/ecas/ecas_group_sync/tests/ecas_group_sync.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_readspeaker/multisite_readspeaker.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/wiki/wiki_core/wiki_core.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/wiki/wiki_core/wiki_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/wiki/wiki_og/tests/wiki_og.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_twitterblock/multisite_twitterblock.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/plugins/tmgmt_poetry.plugin.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/survey/survey_core/survey_core.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/survey/survey_core/survey_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_notifications/multisite_notifications_core/includes/multisite_notifications_core.settings.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_notifications/multisite_notifications_core/multisite_notifications_core.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/links/links_core/links_core.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/links/links_core/links_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.helper.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_trackedchanges/views/nexteuropa_trackedchanges.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_audio/multisite_audio.field.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_audio/tests/multisite_audio_extra.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/social_bookmark/tests/social_bookmark.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_settings/multisite_settings_core/multisite_settings_core.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_forum_community/multisite_forum_community.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/e_library/e_library_core/e_library_core.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/e_library/e_library_core/e_library_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_subscriptions/includes/nexteuropa_subscriptions.settings.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_subscriptions/nexteuropa_subscriptions.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/taxonomy_browser/taxonomy_browser.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/taxonomy_browser/taxonomy_browser.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/taxonomy_browser/taxonomy_browser.admin.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/taxonomy_browser/tests/taxonomy_browser.extra.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multi_user_blog/multi_user_blog.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multi_user_blog/multi_user_blog.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_crop_and_resize/multisite_crop_and_resize.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/fat_footer/fat_footer.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_autosave/multisite_autosave.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/ec_content_slider/ec_content_slider.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_translations/multisite_translations.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_translations/multisite_translations.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.callbacks.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/f_a_q/f_a_q.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/node_pager/node_pager.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/events/events_resources/events_resources.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/events/events_core/events_core.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/events/events_core/events_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/events/events_core/events_core.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_notices/nexteuropa_notices.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_business_indicators/multisite_business_indicators_standard/multisite_business_indicators_standard.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_business_indicators/multisite_business_indicators_community/multisite_business_indicators_community.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/idea/idea_core/idea_core.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/idea/idea_core/idea_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/sitemap/tests/sitemap.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_metatags/multisite_metatags.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/newsletters/newsletters.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_forum_core/multisite_forum_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/ec_world_countries/ec_world_countries.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/ec_world_countries/ec_world_countries.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/ec_world_countries/ec_world_countries.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_charts/multisite_charts.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_communities/nexteuropa_communities.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_maps/multisite_maps.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/communities/communities.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/communities/communities.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/communities/test/communities.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/news/news_core/news_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/news/news_core/news_core.views_default.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/news/news_og/tests/news_og.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/news/news_core/news_core.install</exclude-pattern>
+        <exclude-pattern>tests/src/Context/MinkContext.php</exclude-pattern>
+        <exclude-pattern>tests/features/bootstrap/FeatureContext.php</exclude-pattern>
+    </rule>
+
+    <!-- Check if variable is actually used. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-815 -->
+    <rule ref="DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable">
+        <exclude-pattern>common/modules/custom/multisite_og_navigation_tree/multisite_og_navigation_tree.taxonomy.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_token/tests/TokenHandlerTest.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_dynamic_basetheme/multisite_dynamic_basetheme.drush.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_cookie_consent/modules/connections/multisite_cookie_rest.testing.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/tmgmt_mtec/tmgmt_mtec.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/ecas/includes/ecas.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/ecas/ecas_import_users/ecas_import_users.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters.field_group</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/social_bookmark/tests/social_bookmark.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.tokens.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/events/events_resources/events_resources.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/ec_world_countries/nuts_regions/nuts_regions.views_default.inc</exclude-pattern>
+    </rule>
+
+    <!-- Remove re-declaration. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
+    <rule ref="DrupalPractice.CodeAnalysis.VariableAnalysis.VariableRedeclaration">
+        <exclude-pattern>profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.module</exclude-pattern>
+    </rule>
+
+    <!-- Fix spacing. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
+    <rule ref="DrupalPractice.Commenting.CommentEmptyLine.SpacingAfter">
+        <exclude-pattern>profiles/common/modules/custom/multisite_drupal_wiki_toc/multisite_drupal_wiki_toc.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_config/src/ConfigBase.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/feed_rss_core/feed_rss_core.module</exclude-pattern>
+    </rule>
+
+    <!-- Check if changes can be made or a more generalized exclusion can be set. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-816 -->
+    <rule ref="DrupalPractice.General.ClassName.ClassPrefix">
+        <exclude-pattern>profiles/common/modules/custom/multisite_og_navigation_tree/multisite_og_navigation_tree.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/media_avportal/includes/MediaInternetAvportalHandler.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_varnish/includes/cache_purge_rule.ui.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_cookie_consent/modules/connections/multisite_cookie_rest.testing.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_cookie_consent/modules/connections/multisite_cookie_rest.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_og_button/multisite_og_button.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_create_button/multisite_create_button.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_readspeaker/tests/multisite_readspeaker.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/wiki/wiki_core/tests/wiki_core.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_html/inc/tmgmt_dgt.format.html.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_notifications/multisite_notifications_core/includes/multisite_notifications_core.behat.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/ec_embedded_video/tests/ec_embedded_video.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/e_library/e_library_standard/tests/e_library_standard.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_multilingual/includes/translation.handler.file.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/f_a_q/views/views_handler_area_f_a_q_collapsible_menu.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_custom_error/tests/multisite_custom_error.extra.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_business_indicators/multisite_business_indicators_standard/includes/views_handler_filter_ecas_user_roles.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_business_indicators/multisite_business_indicators_standard/includes/views_handler_field_ecas_user_roles.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_business_indicators/multisite_business_indicators_standard/includes/views_handler_field_business_indicators_ext_uuid.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_business_indicators/multisite_business_indicators_standard/tests/multisite_business_indicators_standard.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_business_indicators/multisite_business_indicators_community/tests/multisite_business_indicators_community.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_business_indicators/multisite_business_indicators_core/tests/multisite_business_indicators_core.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/ec_world_countries/nuts_regions/nuts_regions.migrate.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/communities/views/views_handler_area_communities_create_new_community_link.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/communities/views/views_handler_area_communities_glossary.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_faq/views/views_handler_area_f_a_q_collapsible_menu.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_faq/views/views_handler_area_nexteuropa_faq_collapsible_menu.inc</exclude-pattern>
+    </rule>
+
+
+    <!-- Use more descriptive variable names. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-817 -->
+    <rule ref="DrupalPractice.General.VariableName.VariableName">
+        <exclude-pattern>profiles/common/modules/custom/multisite_og_navigation_tree/multisite_og_navigation_tree.settings.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_drupal_language_negociation/multisite_drupal_language_negociation.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_cookie_consent/multisite_cookie_consent.admin.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_readspeaker/multisite_readspeaker.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_twitterblock/multisite_twitterblock.admin.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_path_override/multisite_path_override.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_notifications/multisite_notifications_core/includes/multisite_notifications_core.settings.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/social_bookmark/social_bookmark.admin.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/social_bookmark/social_bookmark_bar.admin.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_subscriptions/includes/nexteuropa_subscriptions.settings.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_crop_and_resize/multisite_crop_and_resize.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/likedislike/likedislike.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_metatags/multisite_metatags.module</exclude-pattern>
+    </rule>
+
+    <!-- Do not use check_plain() on string literals. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
+    <rule ref="DrupalPractice.FunctionCalls.CheckPlain.CheckPlainLiteral">
+        <exclude-pattern>profiles/common/modules/custom/multisite_block_carousel/multisite_block_carousel.module</exclude-pattern>
+    </rule>
+
+    <!-- Incorrect doc comment. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
+    <rule ref="DrupalPractice.FunctionDefinitions.FormAlterDoc.Different">
+        <exclude-pattern>profiles/common/modules/features/multisite_mediagallery_community/multisite_mediagallery_community.module</exclude-pattern>
+    </rule>
+
+    <!-- Make error message translatable. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
+    <rule ref="DrupalPractice.FunctionCalls.FormErrorT.ErrorMessage">
+        <exclude-pattern>/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module</exclude-pattern>
+    </rule>
+
+    <!-- Remove checkplain and use correct placeholder. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
+    <rule ref="DrupalPractice.FunctionCalls.TCheckPlain.CheckPlain">
+        <exclude-pattern>profiles/common/modules/custom/ecas/ecas_import_users/ecas_import_users.module</exclude-pattern>
+    </rule>
+
+    <!-- Please make error message translatable. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
+    <rule ref="DrupalPractice.FunctionCalls.MessageT.ErrorMessage">
+        <exclude-pattern>profiles/common/modules/custom/multisite_cookie_consent/modules/connections/multisite_cookie_rest.testing.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/controller/tmgmt_poetry.controller.job.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/e_library/e_library_og/e_library_og.install</exclude-pattern>
+    </rule>
+
+    <!-- Please use the get_t(). -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-819 -->
+    <rule ref="DrupalPractice.FunctionDefinitions.InstallT.TranslationFound">
+        <exclude-pattern>profiles/common/modules/custom/ecas/ecas.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_og_button/multisite_og_button.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_crop_and_resize/multisite_crop_and_resize.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/f_a_q/f_a_q.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_charts/multisite_charts.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_maps/multisite_maps.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/solr_config/solr_config.install</exclude-pattern>
+    </rule>
+
+    <!-- Make message translatable. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
+    <rule ref="DrupalPractice.FunctionCalls.MessageT.ErrorMessage">
+        <exclude-pattern>profiles/common/modules/custom/ecas/ecas_import_users/ecas_import_users.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/ecas/ecas_group_sync/ecas_group_sync.install</exclude-pattern>
+    </rule>
+
+    <!-- Make description translatable. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
+    <rule ref="DrupalPractice.General.DescriptionT">
+        <exclude-pattern>profiles/common/modules/custom/multisite_drupal_language_negociation/multisite_drupal_language_negociation.module</exclude-pattern>
+    </rule>
+
+    <!-- Use correct permission. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
+    <rule ref="DrupalPractice.General.AccessAdminPages.PermissionFound">
+        <exclude-pattern>profiles/common/modules/features/likedislike/likedislike.module</exclude-pattern>
+    </rule>
+
+    <!-- Please provide justification in code and use @codingStandardsIgnoreLine if needed. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-818 -->
+    <rule ref="DrupalPractice.FunctionCalls.DbQuery.DbQuery">
+        <exclude-pattern>profiles/common/modules/custom/multisite_og_navigation_tree/multisite_og_navigation_tree.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_config/lib/Drupal/locale/Config.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/controller/tmgmt_poetry.controller.job.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_notifications/multisite_notifications_core/multisite_notifications_core.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.install</exclude-pattern>
+    </rule>
+
+    <!-- Use the LANGUAGE_NONE constant. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-821 -->
+    <rule ref="DrupalPractice.General.LanguageNone.Und">
+        <exclude-pattern>profiles/common/themes/ec_resp/template.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_block_carousel/multisite_block_carousel.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/subscriptions_og/subscriptions_og.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_forum_community/multisite_forum_community.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/events/events_core/events_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/news/news_core/news_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/news/news_og/news_og.module</exclude-pattern>
+    </rule>
+
+    <!-- Remove these functions from hook_init(). -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-822 -->
+    <rule ref="DrupalPractice.FunctionDefinitions.HookInitCss.AddFunctionFound">
+        <exclude-pattern>profiles/common/modules/custom/language_selector_page/language_selector_page.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_cookie_consent/multisite_cookie_consent.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/social_bookmark/social_bookmark.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/likedislike/likedislike.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_notices/nexteuropa_notices.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/communities/communities.module</exclude-pattern>
+    </rule>
+
+    <!-- Do not call theming functions directly. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-823 -->
+    <rule ref="DrupalPractice.FunctionCalls.Theme.ThemeFunctionDirect">
+        <exclude-pattern>profiles/multisite_drupal_communities/modules/custom/og_content_type_admin/og_content_type_admin.module</exclude-pattern>
+        <exclude-pattern>profiles/common/themes/ec_resp/template.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters.theme.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module</exclude-pattern>
+    </rule>
+
+    <!-- Provide a reason in a comment on the line above as to why it should be open. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-824 -->
+    <rule ref="DrupalPractice.FunctionDefinitions.AccessHookMenu.OpenCallback">
+        <exclude-pattern>profiles/common/modules/custom/tmgmt_mtec/tmgmt_mtec.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/wiki/wiki_og/wiki_og.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/tmgmt_poetry_mock.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/survey/survey_core/survey_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/survey/survey_og/survey_og.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/links/links_og/links_og.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_forum_community/multisite_forum_community.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/e_library/e_library_og/e_library_og.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_subscriptions/nexteuropa_subscriptions.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_mediagallery_community/multisite_mediagallery_community.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_crop_and_resize/multisite_crop_and_resize.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/events/events_og/events_og.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/newsletters/newsletters.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/communities/communities.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/news/news_og/news_og.module</exclude-pattern>
+    </rule>
+
+    <!-- Check if there is no security risk in using the input and add a @codingStandardsIgnoreLine tag if it's not. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-825 -->
+    <rule ref="DrupalPractice.General.FormStateInput.Input">
+        <exclude-pattern>profiles/common/modules/custom/multisite_og_navigation_tree/multisite_og_navigation_tree.taxonomy.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/tmgmt_workbench/tmgmt_workbench.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_audio/multisite_audio.field.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/taxonomy_browser/taxonomy_browser.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_autosave/multisite_autosave.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_metatags/multisite_metatags.module</exclude-pattern>
+    </rule>
+
+
+    <!-- Check if the value that is being returned should not be sanitized. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-813 -->
+    <rule ref="DrupalSecure.General.Helper.XSS.CallbackOutput">
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/nexteuropa_token_ckeditor.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_forum_community/multisite_forum_community.module</exclude-pattern>
+    </rule>
+
+
+    <!-- Unlocked fields that need to be locked. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-812 -->
+    <rule ref="QualityAssurance.FeaturesFiles.LockedFields.UnlockedFields">
+        <exclude-pattern>profiles/common/modules/custom/multisite_config/tests/multisite_config_test/multisite_config_test.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_data_export/tests/nexteuropa_data_export_test/nexteuropa_data_export_test.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_data_export/tests/nexteuropa_data_export_test/nexteuropa_data_export_test.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_core/nexteuropa_core.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_activity/multisite_activity_core/multisite_activity_core.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_event/nexteuropa_event.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_webtools/nexteuropa_webtools.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/ec_content_slider/ec_content_slider.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_notices/nexteuropa_notices.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_metatags/multisite_metatags.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_mediagallery/nexteuropa_mediagallery.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/communities/communities.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_news/nexteuropa_news.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/news/news_og/news_og.features.field_base.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_faq/nexteuropa_faq.features.field_base.inc</exclude-pattern>
+    </rule>
+
+    <!-- Replace functions with Drupal Wrappers if possible -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-805 -->
+    <rule ref="QualityAssurance.Functions.DrupalWrappers.FoundWithAlternative">
+        <exclude-pattern>profiles/common/modules/custom/ecas/includes/ecas.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/language_selector_site/language_selector_site.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/media_avportal/includes/MediaAvportalStreamWrapper.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_config/tests/ConfigBaseTest.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_cookie_consent/modules/connections/multisite_cookie_rest.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_cookie_consent/multisite_cookie_consent.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.sanitize.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_laco/src/LanguageCoverageService.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/nexteuropa_token/src/HashTokenHandler.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/tmgmt_mtec/tmgmt_mtec.plugin.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/tmgmt_mtec/tmgmt_mtec.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/news/news_core/news_core.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/ec_world_countries/nuts_regions/nuts_regions.migrate.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.behat.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/events/events_core/events_core.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_translations/multisite_translations.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_webtools/nexteuropa_webtools.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_multilingual_references/multisite_multilingual_references.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/taxonomy_browser/taxonomy_browser.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/ec_embedded_video/tests/ec_embedded_video.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_audio/tests/multisite_audio_extra.test</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_audio/multisite_audio.field.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.module</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/inc/tmgmt_poetry.webservice.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/templates/tmgmt-poetry-progress-field.tpl.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/src/Mock/PoetryMock.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/tmgmt_poetry_mock.behat.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_html/inc/tmgmt_dgt.format.html.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_html/templates/tmgmt_dgt_html_template.tpl.php</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_twitterblock/multisite_twitterblock.module</exclude-pattern>
+        <exclude-pattern>profiles/common/themes/ec_resp/template.php</exclude-pattern>
+        <exclude-pattern>tests/src/Context/BeanContext.php</exclude-pattern>
+        <exclude-pattern>tests/src/Context/MultilingualContext.php</exclude-pattern>
+        <exclude-pattern>tests/src/Context/TaxonomyContext.php</exclude-pattern>
+        <exclude-pattern>tests/src/Context/CKEditorContext.php</exclude-pattern>
+        <exclude-pattern>tests/src/Context/IntegrationLayerContext.php</exclude-pattern>
+        <exclude-pattern>tests/src/Context/FrontendCacheContext.php</exclude-pattern>
+        <exclude-pattern>tests/src/Component/Utility/Transliterate.php</exclude-pattern>
+        <exclude-pattern>tests/src/Component/PyStringYamlParser.php</exclude-pattern>
+    </rule>
+
+    <!-- Make paths dynamic -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-811 -->
+    <rule ref="QualityAssurance.Generic.HardcodedPath">
+        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.features.ckeditor_profile.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.strongarm.inc</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_html/tmgmt_dgt_html.info</exclude-pattern>
+
+    </rule>
+
+    <!-- Move custom modules to custom folder IF it's not a submodule of a feature. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-810 -->
+    <rule ref="QualityAssurance.InfoFiles.Features.CustomModule">
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_html/tmgmt_dgt_html.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/tmgmt_poetry_mock.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_path_override/multisite_path_override.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_feature_set/multisite_drupal_features_set_standard/multisite_drupal_features_set_standard.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/ec_world_countries/nuts_regions/nuts_regions.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/solr_config/solr_config.info</exclude-pattern>
+    </rule>
+
+    <!-- Upgrade these features to api:2. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-809 -->
+    <rule ref="QualityAssurance.InfoFiles.Features.FeaturesAPI">
+        <exclude-pattern>profiles/common/modules/custom/multisite_block_carousel/multisite_block_carousel.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_notifications/multisite_notifications_core/multisite_notifications_core.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_notifications/multisite_notifications_og/multisite_notifications_og.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_europa_search/nexteuropa_europa_search.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/social_bookmark/social_bookmark.info</exclude-pattern>
+        <exclude-pattern>profiles/multisite_drupal_communities/modules/custom/og_content_type_admin/og_content_type_admin.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/solr_config/solr_config.info</exclude-pattern>
+    </rule>
+
+    <!-- Remove useless attribute -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-808 -->
+    <rule ref="QualityAssurance.InfoFiles.Forbidden.ProjectPath">
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_event/nexteuropa_event.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_mediagallery/nexteuropa_mediagallery.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_communities/nexteuropa_communities.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_news/nexteuropa_news.info</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_faq/nexteuropa_faq.info</exclude-pattern>
+    </rule>
+
+    <!-- Move helper functions for install file out of install file. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-807 -->
+    <rule ref="QualityAssurance.InstallFiles.FunctionDeclarations.NonHookFound">
+        <exclude-pattern>profiles/common/modules/custom/ecas/ecas_extra/ecas_extra.install</exclude-pattern>
+        <exclude-pattern>profiles/multisite_drupal_communities/multisite_drupal_communities.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/custom/tmgmt_mtec/tmgmt_mtec.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/wiki/wiki_og/wiki_og.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/links/links_og/links_og.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/social_bookmark/social_bookmark.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_settings/multisite_settings_core/multisite_settings_core.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/e_library/e_library_og/e_library_og.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_mediagallery_community/multisite_mediagallery_community.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_webtools/nexteuropa_webtools.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/f_a_q/f_a_q.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/events/events_og/events_og.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_notices/nexteuropa_notices.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_mediagallery/nexteuropa_mediagallery.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/communities/communities.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_megamenu/multisite_megamenu.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/news/news_og/news_og.install</exclude-pattern>
+    </rule>
+
+    <!-- Update the description of the update hooks. -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-806 -->
+    <rule ref="QualityAssurance.InstallFiles.HookUpdateN">
+        <exclude-pattern>profiles/common/modules/features/links/links_og/links_og.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/e_library/e_library_core/e_library_core.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/taxonomy_browser/taxonomy_browser.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/events/events_core/events_core.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/multisite_business_indicators/multisite_business_indicators_standard/multisite_business_indicators_standard.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/idea/idea_core/idea_core.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/solr_config/solr_config.install</exclude-pattern>
+        <exclude-pattern>profiles/common/modules/features/news/news_core/news_core.install</exclude-pattern>
+        <exclude-pattern>profiles/multisite_drupal_standard/multisite_drupal_standard.install</exclude-pattern>
+    </rule>
+
+    <!-- Line exceeds 80 characters. -->
+    <rule ref="Drupal.Files.TxtFileLineLength.TooLong">
+        <exclude-pattern>profiles/common/modules/custom/ecas/README.md</exclude-pattern>
+        <exclude-pattern>*</exclude-pattern>
+     </rule>
+
+    <!-- Line exceeds 80 characters. -->
+    <rule ref="Drupal.Files.EndFileNewline.TooMany">
+        <exclude-pattern>profiles/common/modules/custom/ecas/README.md</exclude-pattern>
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- The PHP open tag must be followed by exactly one blank line. -->
+    <rule ref="Drupal.WhiteSpace.OpenTagNewline.BlankLine">
+        <exclude-pattern>profiles/common/modules/custom/ecas/ecas.module</exclude-pattern>
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Object operator not indented correctly. -->
+    <rule ref="Drupal.WhiteSpace.ObjectOperatorIndent.Indent">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Return comment indentation must be 3 spaces. -->
+    <rule ref="Drupal.Commenting.FunctionComment.ReturnCommentIndentation">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Equals sign not aligned with surrounding assignments. -->
+    <rule ref="Drupal.Formatting.MultipleStatementAlignment.NotSame">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Equals sign not aligned correctly. -->
+    <rule ref="Drupal.Formatting.MultipleStatementAlignment.Incorrect">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Expected "false|\stdClass" but found "FALSE|\stdClass" for function return type. -->
+    <rule ref="Drupal.Commenting.FunctionComment.InvalidReturn">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Type hint "array" missing for ... -->
+    <rule ref="Drupal.Commenting.FunctionComment.TypeHintMissing">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Closing brace must be on a line by itself ... -->
+    <rule ref="Drupal.WhiteSpace.ScopeClosingBrace.Line">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Namespaced classes, interfaces and traits should not begin with a file doc comment. -->
+    <rule ref="Drupal.Commenting.FileComment.NamespaceNoFileDoc">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Parameter comment indentation must be 3 spaces. -->
+    <rule ref="Drupal.Commenting.FunctionComment.ParamCommentIndentation">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Return type must not contain variable name "$this". -->
+    <rule ref="Drupal.Commenting.FunctionComment.ReturnVarName">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Unused use statement. -->
+    <rule ref="Drupal.Classes.UnusedUseStatement.UnusedUse">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Tags should not be used. -->
+    <rule ref="DrupalPractice.Commenting.ExpectedException.TagFound">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Function return type is not void, but function is returning void here. -->
+    <rule ref="Drupal.Commenting.FunctionComment.InvalidReturnNotVoid">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Expected 1 newline at end of file. -->
+    <rule ref="Drupal.Files.EndFileNewline.NoneFound">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Return type must not contain variable name. -->
+    <rule ref="Drupal.Commenting.FunctionComment.ReturnVarName">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- The static declaration must come after the visibility declaration. -->
+    <rule ref="Drupal.Methods.MethodDeclaration.StaticBeforeVisibility">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Data types in @param tags need to be fully namespaced. -->
+    <rule ref="Drupal.Commenting.DataTypeNamespace.DataTypeNamespace">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Namespaced classes/interfaces/traits should be referenced with use statements. -->
+    <rule ref="Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- When importing a class with "use", do not include a leading. -->
+    <rule ref="Drupal.Classes.UseLeadingBackslash.SeparatorStart">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Parameter $entity_id is not described in comment. -->
+    <rule ref="Drupal.Commenting.FunctionComment.ParamMissingDefinition">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Missing @var tag in member variable comment. -->
+    <rule ref="Drupal.Commenting.VariableComment.MissingVar">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Return type "int | NULL" must not contain spaces. -->
+    <rule ref="Drupal.Commenting.FunctionComment.ReturnTypeSpaces">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Line indented incorrectly. -->
+    <rule ref="Drupal.WhiteSpace.ScopeIndent.IncorrectExact">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- You must use "/**" style comments for a member variable comment. -->
+    <rule ref="Drupal.Commenting.VariableComment.WrongStyle">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Expected "\Drupal\DrupalDriverManager" but found "\Drupal\DrupalDriverManager;" for @var tag in member variable comment. -->
+    <rule ref="Drupal.Commenting.VariableComment.IncorrectVarType">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Expected "bool|false" but found "bool|FALSE" for parameter type. -->
+    <rule ref="Drupal.Commenting.FunctionComment.IncorrectParamVarName">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Do not concatenate strings to translatable strings, they should be part of the t() argument and you should use placeholders. -->
+    <rule ref="Drupal.Semantics.FunctionT.ConcatString">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Closing brace indented incorrectly. -->
+    <rule ref="Drupal.WhiteSpace.ScopeClosingBrace.Indent">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Missing file doc comment. -->
+    <rule ref="Drupal.Commenting.FileComment.Missing">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Doc comment short description must start with a capital letter. -->
+    <rule ref="Drupal.Commenting.DocComment.ShortNotCapital">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Values usually have to run through t() for translation. -->
+    <rule ref="DrupalPractice.General.OptionsT.TforValue">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Variable $column is undefined. -->
+    <rule ref="DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Unused private method. -->
+    <rule ref="DrupalPractice.Objects.UnusedPrivateMethod.UnusedMethod">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Do not use the raw $form_state['input'], use $form_state['values'] instead where possible. -->
+    <rule ref="DrupalPractice.General.FormStateInput.Input">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Are you accessing field values here? Then you should use LANGUAGE_NONE instead of 'und'. -->
+    <rule ref="DrupalPractice.General.LanguageNone.Und">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- The @var tag must be the first tag in a member variable comment. -->
+    <rule ref="Drupal.Commenting.VariableComment.VarOrder">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Content missing for @var tag in member variable comment. -->
+    <rule ref="Drupal.Commenting.VariableComment.EmptyVar">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Expected 1 blank line after function. -->
+    <rule ref="Squiz.WhiteSpace.FunctionSpacing.After">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Expected 1 blank line before function. -->
+    <rule ref="Squiz.WhiteSpace.FunctionSpacing.Before">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Expected 1 space after FUNCTION keyword. -->
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Expected 1 space before opening brace. -->
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceBeforeBrace">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Opening brace should be on the same line as the declaration. -->
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnNewLine">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- There must be one blank line after the namespace declaration. -->
+    <rule ref="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- There must be one blank line after the last USE statement. -->
+    <rule ref="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- The use of function strlen() is forbidden; use drupal_strlen() instead. -->
+    <rule ref="QualityAssurance.Functions.DrupalWrappers.FoundWithAlternative">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Internal hardcoded paths are not allowed. Please use variable_get('file_public|private|temporary_path'). -->
+    <rule ref="QualityAssurance.Generic.HardcodedPath.HardcodedPath">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Empty strongarm settings for 'pathauto_node_blog_pattern' are not allowed. -->
+    <rule ref="QualityAssurance.Generic.EmptySettings.Strongarm">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Move the "multisite_drupal_standard_install_tasks" function declaration in to a file named multisite_drupal_standard.install.inc and include that file in multisite_drupal_standard.install. -->
+    <rule ref="QualityAssurance.InstallFiles.FunctionDeclarations.NonHookFound">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- File appears to be minified and cannot be processed. -->
+    <rule ref="Internal.Tokenizer.Exception">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+    <!-- Possible useless method overriding detected. -->
+    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod.Found">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
+
+</ruleset>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -4,6 +4,10 @@
 <ruleset name="NextEuropa">
     <description>Drupal coding standard for NextEuropa</description>
 
+    <!-- Plan with exceptions for modules that need to be fixed gradually -->
+    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-804 -->
+    <rule ref="./phpcs-qa-roadmap.xml"/>
+
     <!-- Exclude unsupported file types. -->
     <exclude-pattern>*\.gif</exclude-pattern>
     <exclude-pattern>*\.less</exclude-pattern>
@@ -12,40 +16,29 @@
     <!-- Minified files don't have to comply with coding standards. -->
     <exclude-pattern>*\.min\.css</exclude-pattern>
     <exclude-pattern>*\.min\.js</exclude-pattern>
-    <exclude-pattern>profiles/common/modules/features/multisite_readspeaker/js/ReadSpeaker/</exclude-pattern>
 
-    <!-- Legacy modules which are not compliant with coding standards. These are
-         being fixed in NEXTEUROPA-3575. Whenever a module is fixed, please
-         remove it from this list so it can be tested. -->
-    <exclude-pattern>profiles/multisite_drupal_communities/inject_data.php</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_communities/themes/bootstrap</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_standard/themes/bootstrap</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_standard/themes/ec_europa</exclude-pattern>
+    <exclude-pattern>build/vendor/</exclude-pattern>
+
+    <exclude-pattern>profiles/common/themes/</exclude-pattern>
+    <exclude-pattern>profiles/multisite_drupal_*/themes/</exclude-pattern>
 
     <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal" />
 
     <!-- Exclude third party code. -->
     <exclude-pattern>profiles/common/libraries/</exclude-pattern>
+    <exclude-pattern>profiles/multisite_drupal_*/libraries/</exclude-pattern>
+    <exclude-pattern>profiles/multisite_drupal_*/modules/contrib/</exclude-pattern>
+
     <exclude-pattern>profiles/common/modules/custom/ecas/libraries/</exclude-pattern>
-    <exclude-pattern>profiles/common/themes/ec_europa</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_communities/libraries/</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_communities/modules/contrib/</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_standard/libraries/</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_standard/modules/contrib/</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_standard/modules/custom/nexteuropa_newsroom/</exclude-pattern>
-    <exclude-pattern>profiles/common/modules/features/multisite_wysiwyg/ckeditor/skins</exclude-pattern>
     <exclude-pattern>profiles/common/modules/custom/tmgmt_poetry/tests/</exclude-pattern>
-    <exclude-pattern>build/vendor/</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_standard/themes/atomium</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_standard/themes/ec_europa</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_communities/themes/atomium</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_communities/themes/ec_europa</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_standard/themes/ec_resp/scripts</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_communities/themes/ec_resp/scripts</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_standard/themes/ec_resp/css</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_communities/themes/ec_resp/css</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_standard/themes/ec_resp/bootstrap</exclude-pattern>
-    <exclude-pattern>profiles/multisite_drupal_communities/themes/ec_resp/bootstrap</exclude-pattern>
+    <exclude-pattern>profiles/common/modules/features/multisite_wysiwyg/ckeditor/skins</exclude-pattern>
+    <exclude-pattern>profiles/common/modules/features/multisite_readspeaker/js/ReadSpeaker/</exclude-pattern>
+    <exclude-pattern>profiles/common/modules/custom/multisite_drupal_toolbox/icons</exclude-pattern>
+
+    <!-- Legacy modules which are not compliant with coding standards. These are
+         being fixed in NEXTEUROPA-3575. Whenever a module is fixed, please
+         remove it from this list so it can be tested. -->
+    <exclude-pattern>profiles/multisite_drupal_communities/inject_data.php</exclude-pattern>
 
     <!-- Views handlers/plugins not strictly follow Drupal class name conventions. -->
     <rule ref="Drupal.NamingConventions.ValidClassName">
@@ -94,9 +87,6 @@
     <rule ref="Drupal.NamingConventions.ValidFunctionName.ScopeNotCamelCaps">
         <exclude-pattern>profiles/common/modules/custom/nexteuropa_piwik/src/EntityDefaultUIController/PiwikRuleEntityUIController.php</exclude-pattern>
     </rule>
-
-    <!-- Exclude third party code which is not following Drupal coding standards. -->
-    <exclude-pattern>profiles/common/modules/custom/multisite_drupal_toolbox/icons</exclude-pattern>
 
     <!-- Phing tasks require to use CamelCaps for argument names. -->
     <rule ref="Drupal.NamingConventions.ValidVariableName">

--- a/resources/multisite_drupal_communities.make
+++ b/resources/multisite_drupal_communities.make
@@ -1,4 +1,15 @@
+api = 2
+core = 7.x
+
+; =========================
+; Multisite Drupal Standard
+; =========================
+
 includes[] = "multisite_drupal_standard.make"
+
+; ===================
+; Contributed modules
+; ===================
 
 projects[og-delete][download][revision] = "c759e354d89b7ec280836047569acc75843eed38"
 projects[og-delete][download][type] = "git"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -7,7 +7,6 @@ core = 7.x
 
 includes[] = "drupal-core.make"
 
-
 ; ===================
 ; Contributed modules
 ; ===================

--- a/src/Phing/PhpCodeSnifferConfigurationTask.php
+++ b/src/Phing/PhpCodeSnifferConfigurationTask.php
@@ -50,6 +50,13 @@ class PhpCodeSnifferConfigurationTask extends \Task {
   private $ignorePatterns = array();
 
   /**
+   * Whether or not to pass with warnings.
+   *
+   * @var bool
+   */
+  private $ignoreWarnings = FALSE;
+
+  /**
    * The report format to use.
    *
    * @var string
@@ -71,11 +78,19 @@ class PhpCodeSnifferConfigurationTask extends \Task {
   private $showSniffCodes = FALSE;
 
   /**
-   * The coding standard to use.
+   * The coding standards to use.
+   *
+   * @var array
+   */
+  private $standards = array();
+
+  /**
+   * The install paths of standards.
    *
    * @var string
    */
-  private $standard;
+  private $installedPaths = '';
+
 
   /**
    * Configures PHP CodeSniffer.
@@ -93,13 +108,32 @@ class PhpCodeSnifferConfigurationTask extends \Task {
     $document->appendChild($root_element);
 
     // Add the description.
-    $element = $document->createElement('description', 'Default PHP CodeSniffer configuration for NextEuropa.');
+    $element = $document->createElement('description', 'Default PHP CodeSniffer configuration for NextEuropa Platform.');
     $root_element->appendChild($element);
 
-    // Add the coding standard.
-    $element = $document->createElement('rule');
-    $element->setAttribute('ref', $this->standard);
-    $root_element->appendChild($element);
+    // Add the coding standards.
+    foreach ($this->standards as $standard) {
+
+      $installedPaths = $this->explodeToken($this->installedPaths);
+      // @codingStandardsIgnoreLine
+      if (substr($standard, -4) === '.xml') {
+        if (file_exists($standard)) {
+          $element = $document->createElement('rule');
+          $element->setAttribute('ref', $standard);
+          $root_element->appendChild($element);
+        }
+      }
+      else {
+        foreach ($installedPaths as $installedPath) {
+          $ruleset = $installedPath . '/' . $standard . '/ruleset.xml';
+          if (file_exists($ruleset)) {
+            $element = $document->createElement('rule');
+            $element->setAttribute('ref', $ruleset);
+            $root_element->appendChild($element);
+          }
+        }
+      }
+    }
 
     // Add the files to check.
     foreach ($this->files as $file) {
@@ -143,10 +177,13 @@ class PhpCodeSnifferConfigurationTask extends \Task {
 
     // If a global configuration file is passed, update this too.
     if (!empty($this->globalConfig)) {
+      $ignore_warnings_on_exit = $this->ignoreWarnings ? 1 : 0;
       $global_config = <<<PHP
 <?php
  \$phpCodeSnifferConfig = array (
   'default_standard' => '$this->configFile',
+  'ignore_warnings_on_exit' => '$ignore_warnings_on_exit',
+  'installed_paths' => '$this->installedPaths'
 );
 PHP;
       file_put_contents($this->globalConfig, $global_config);
@@ -173,7 +210,9 @@ PHP;
     if (!empty($name)) {
       $argument->setAttribute('name', $name);
     }
-    $argument->setAttribute('value', $value);
+    if (!empty($value)) {
+      $argument->setAttribute('value', $value);
+    }
     $element->appendChild($argument);
   }
 
@@ -184,7 +223,7 @@ PHP;
    *   Thrown when a required property is not present.
    */
   protected function checkRequirements() {
-    $required_properties = array('configFile', 'files', 'standard');
+    $required_properties = array('configFile', 'files', 'standards');
     foreach ($required_properties as $required_property) {
       if (empty($this->$required_property)) {
         throw new \BuildException("Missing required property '$required_property'.");
@@ -210,13 +249,7 @@ PHP;
    *   semicolons.
    */
   public function setExtensions($extensions) {
-    $this->extensions = array();
-    $token = ' ,;';
-    $extension = strtok($extensions, $token);
-    while ($extension !== FALSE) {
-      $this->extensions[] = $extension;
-      $extension = strtok($token);
-    }
+    $this->extensions = $this->explodeToken($extensions);
   }
 
   /**
@@ -226,13 +259,7 @@ PHP;
    *   A list of paths, delimited by spaces, commas or semicolons.
    */
   public function setFiles($files) {
-    $this->files = array();
-    $token = ' ,;';
-    $file = strtok($files, $token);
-    while ($file !== FALSE) {
-      $this->files[] = $file;
-      $file = strtok($token);
-    }
+    $this->files = $this->explodeToken($files);
   }
 
   /**
@@ -246,19 +273,33 @@ PHP;
   }
 
   /**
+   * Sets the installed_paths configuration.
+   *
+   * @param string $installedPaths
+   *   The paths in which the standards are installed.
+   */
+  public function setInstalledPaths($installedPaths) {
+    $this->installedPaths = $installedPaths;
+  }
+
+  /**
    * Sets the list of patterns to ignore.
    *
    * @param string $ignorePatterns
    *   The list of patterns, delimited by spaces, commas or semicolons.
    */
   public function setIgnorePatterns($ignorePatterns) {
-    $this->ignorePatterns = array();
-    $token = ' ,;';
-    $pattern = strtok($ignorePatterns, $token);
-    while ($pattern !== FALSE) {
-      $this->ignorePatterns[] = $pattern;
-      $pattern = strtok($token);
-    }
+    $this->ignorePatterns = $this->explodeToken($ignorePatterns);
+  }
+
+  /**
+   * Sets whether or not to pass with warnings.
+   *
+   * @param bool $ignoreWarnings
+   *   Whether or not to pass with warnings.
+   */
+  public function setIgnoreWarnings($ignoreWarnings) {
+    $this->ignoreWarnings = (bool) $ignoreWarnings;
   }
 
   /**
@@ -292,13 +333,34 @@ PHP;
   }
 
   /**
-   * Sets the coding standard to use.
+   * Sets the coding standards to use.
    *
-   * @param string $standard
-   *   The coding standard to use.
+   * @param string $standards
+   *   A list of paths, delimited by spaces, commas or semicolons.
    */
-  public function setStandard($standard) {
-    $this->standard = $standard;
+  public function setStandards($standards) {
+    $this->standards = $this->explodeToken($standards);
+  }
+
+  /**
+   * Transform a String to Array with strtok().
+   *
+   * @param string $string
+   *   A list of items.
+   * @param string $token
+   *   A list of token, by default is space, comma and semicolon.
+   *
+   * @return array $array
+   *   A list of items in an array.
+   */
+  private function explodeToken($string, $token = ' ,;') {
+    $array = array();
+    $item = strtok($string, $token);
+    while ($item !== FALSE) {
+      $array[] = $item;
+      $item = strtok($token);
+    }
+    return $array;
   }
 
 }

--- a/tests/src/Context/MessageContext.php
+++ b/tests/src/Context/MessageContext.php
@@ -16,7 +16,6 @@ use Drupal\DrupalExtension\Context\MessageContext as DrupalExtensionMessageConte
  * @package Drupal\nexteuropa\Context
  */
 class MessageContext extends DrupalExtensionMessageContext {
-
   /**
    * Checks if the current page contains the given error message.
    *


### PR DESCRIPTION
## NEPT-804

### Description

Addition of qa-automation tools

### Change log

* NEPT-804: Addition of qa-automation tools
* NEPT-804: Change permission
* NEPT-804: Make release of qa-automation
* NEPT-804: Add exceptions for tests
* NEPT-804: Test, composer.json qa-automation is not released yet.
* NEPT-804: Full PHPCBF run, test site install
* NEPT-804: Add codingstandardsignore to fix build
* NEPT-804: Update composer.json and lock
* NEPT-804: Add more exclusions.
* NEPT-804: Update Makefile for the profile communities.
* NEPT-804: Add the option -s to phpcs in jenkins.
* NEPT-804: Add exclusions for the profil communities.
* NEPT-804: Remove duplicate exclusions.
* NEPT-804: Update QA-Automation and changes requested.

### Commands

```sh
drush cc all

```

