### PR TITLE
NEPT-1290: Remove check plain on string literals in multisite_block_carousel delete link

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -208,12 +208,6 @@
         <exclude-pattern>profiles/common/modules/features/multisite_metatags/multisite_metatags.module</exclude-pattern>
     </rule>
 
-    <!-- Do not use check_plain() on string literals. -->
-    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
-    <rule ref="DrupalPractice.FunctionCalls.CheckPlain.CheckPlainLiteral">
-        <exclude-pattern>profiles/common/modules/custom/multisite_block_carousel/multisite_block_carousel.module</exclude-pattern>
-    </rule>
-
     <!-- Incorrect doc comment. -->
     <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
     <rule ref="DrupalPractice.FunctionDefinitions.FormAlterDoc.Different">

--- a/profiles/common/modules/custom/multisite_block_carousel/multisite_block_carousel.module
+++ b/profiles/common/modules/custom/multisite_block_carousel/multisite_block_carousel.module
@@ -141,7 +141,7 @@ function multisite_block_carousel_form_block_admin_display_form_alter(&$form, $f
     if (empty($blocks[$delta])) {
       $form['blocks']['block_carousel_' . $delta]['delete'] = array(
         '#type' => 'link',
-        '#title' => check_plain('delete'),
+        '#title' => t('delete'),
         '#href' => 'admin/structure/block/delete-block-carousel/' . $delta,
       );
     }


### PR DESCRIPTION
## NEPT-1290

### Description

Removed check plain on string literals in multisite_block_carousel delete link

### Change log

- Changed: Removed check plain() on link title and replaced with t()


