### PR TITLE
NEPT-1295: Replaced t() with get_t().

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -240,19 +240,6 @@
         <exclude-pattern>profiles/common/modules/features/e_library/e_library_og/e_library_og.install</exclude-pattern>
     </rule>
 
-    <!-- Please use the get_t(). -->
-    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-819 -->
-    <rule ref="DrupalPractice.FunctionDefinitions.InstallT.TranslationFound">
-        <exclude-pattern>profiles/common/modules/custom/ecas/ecas.install</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/custom/multisite_og_button/multisite_og_button.install</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/multisite_crop_and_resize/multisite_crop_and_resize.install</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.install</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/f_a_q/f_a_q.install</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/multisite_charts/multisite_charts.install</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/multisite_maps/multisite_maps.install</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/solr_config/solr_config.install</exclude-pattern>
-    </rule>
-
     <!-- Make message translatable. -->
     <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
     <rule ref="DrupalPractice.FunctionCalls.MessageT.ErrorMessage">

--- a/profiles/common/modules/custom/ecas/ecas.install
+++ b/profiles/common/modules/custom/ecas/ecas.install
@@ -62,7 +62,7 @@ function ecas_requirements($phase) {
   $requirements = array();
   if ($phase == 'runtime') {
     $t = get_t();
-    $requirements['ecas_library']['title'] = t('CAS Library');
+    $requirements['ecas_library']['title'] = $t('CAS Library');
     $cas_version = constant('PHPCAS_VERSION');
     $min_version = constant('ECAS_MIN_PHPCAS_VERSION');
     if (!$cas_version) {

--- a/profiles/common/modules/custom/multisite_og_button/multisite_og_button.install
+++ b/profiles/common/modules/custom/multisite_og_button/multisite_og_button.install
@@ -9,12 +9,14 @@
  * Implements hook_install().
  */
 function multisite_og_button_install() {
-  drupal_set_message(st("Organic groups buttons installed"));
+  $t = get_t();
+  drupal_set_message($t("Organic groups buttons installed"));
 }
 
 /**
  * Implements hook_uninstall().
  */
 function multisite_og_button_uninstall() {
-  drupal_set_message(st("Organic groups buttons uninstalled"));
+  $t = get_t();
+  drupal_set_message($t("Organic groups buttons uninstalled"));
 }

--- a/profiles/common/modules/features/f_a_q/f_a_q.install
+++ b/profiles/common/modules/features/f_a_q/f_a_q.install
@@ -9,8 +9,9 @@
  */
 function f_a_q_install() {
   // Create a vocabulary dedicated to the faq.
+  $t = get_t();
   $vocabulary = (object) array(
-    'name' => st('FAQ categories'),
+    'name' => $t('FAQ categories'),
     'machine_name' => 'faq_categories',
     'module' => 'faq',
   );
@@ -29,7 +30,8 @@ function f_a_q_uninstall() {
  * Implements hook_enable().
  */
 function f_a_q_enable() {
-  drupal_set_message(t('FAQ enabled'));
+  $t = get_t();
+  drupal_set_message($t('FAQ enabled'));
 
   // SolR configuration add bundle.
   multisite_drupal_toolbox_config_solr_bundle('f_a_q', 'add');

--- a/profiles/common/modules/features/multisite_charts/multisite_charts.install
+++ b/profiles/common/modules/features/multisite_charts/multisite_charts.install
@@ -9,11 +9,12 @@
  * Implements hook_enable().
  */
 function multisite_charts_enable() {
+  $t = get_t();
   multisite_drupal_toolbox_config_solr_bundle('chart', 'add');
 
   multisite_drupal_toolbox_content_type_linkchecker('chart', 'add');
 
-  drupal_set_message(t('Multisite Charts feature is now active on your site.'));
+  drupal_set_message($t('Multisite Charts feature is now active on your site.'));
 }
 
 /**
@@ -32,8 +33,9 @@ function multisite_charts_disable() {
  * Implements hook_requirements().
  */
 function multisite_charts_requirements($phase) {
+  $t = get_t();
   $requirements = array();
-  $requirements['multisite_charts']['title'] = t('Multisite Charts');
+  $requirements['multisite_charts']['title'] = $t('Multisite Charts');
   if ($phase == 'runtime') {
     // Fusionchart PHP file.
     $file_exists = file_exists(multisite_charts_get_library_path() . 'Code/PHP/Includes/FusionCharts.php');
@@ -42,9 +44,9 @@ function multisite_charts_requirements($phase) {
       $requirements['multisite_charts']['severity'] = REQUIREMENT_OK;
     }
     else {
-      $requirements['multisite_charts']['value'] = t('FusionCharts PHP file not found.');
+      $requirements['multisite_charts']['value'] = $t('FusionCharts PHP file not found.');
       $requirements['multisite_charts']['severity'] = REQUIREMENT_ERROR;
-      $requirements['multisite_charts']['description'] = t('Please download these files from <a href="@url">http://www.fusioncharts.com</a> and copy them into the fusioncharts library directory as per instructions in the readme.txt file.', array('@url' => 'http://www.fusioncharts.com'));
+      $requirements['multisite_charts']['description'] = $t('Please download these files from <a href="@url">http://www.fusioncharts.com</a> and copy them into the fusioncharts library directory as per instructions in the readme.txt file.', array('@url' => 'http://www.fusioncharts.com'));
     }
 
   }

--- a/profiles/common/modules/features/multisite_crop_and_resize/multisite_crop_and_resize.install
+++ b/profiles/common/modules/features/multisite_crop_and_resize/multisite_crop_and_resize.install
@@ -13,6 +13,7 @@ function multisite_crop_and_resize_requirements($phase) {
   $lpath = libraries_get_path('jquery.imgareaselect');
 
   if ($phase == 'runtime') {
+    $t = get_t();
     if (!empty($lpath)) {
       $requirements['multisite_crop_and_resize']['severity'] = REQUIREMENT_OK;
       $requirements['multisite_crop_and_resize']['value'] = 'imgAreaSelect library found.';
@@ -20,9 +21,9 @@ function multisite_crop_and_resize_requirements($phase) {
     else {
       $requirements['multisite_crop_and_resize']['severity'] = REQUIREMENT_ERROR;
       $requirements['multisite_crop_and_resize']['value'] = 'imgAreaSelect library not found.';
-      $requirements['multisite_crop_and_resize']['description'] = t('Please download this library from <a href="@url">Odyniet site</a> and copy it into the library directory.', array('@url' => 'http://odyniec.net/projects/imgareaselect/'));
+      $requirements['multisite_crop_and_resize']['description'] = $t('Please download this library from <a href="@url">Odyniet site</a> and copy it into the library directory.', array('@url' => 'http://odyniec.net/projects/imgareaselect/'));
     }
-    $requirements['multisite_crop_and_resize']['title'] = t('Multisite Crop and Resize');
+    $requirements['multisite_crop_and_resize']['title'] = $t('Multisite Crop and Resize');
   }
   return $requirements;
 }
@@ -32,7 +33,8 @@ function multisite_crop_and_resize_requirements($phase) {
  */
 function multisite_crop_and_resize_enable() {
   // Activation message.
-  drupal_set_message(t('Multisite Crop and Resize feature is now active on your site.'));
+  $t = get_t();
+  drupal_set_message($t('Multisite Crop and Resize feature is now active on your site.'));
 
 }
 

--- a/profiles/common/modules/features/multisite_maps/multisite_maps.install
+++ b/profiles/common/modules/features/multisite_maps/multisite_maps.install
@@ -11,18 +11,19 @@
 function multisite_maps_requirements($phase) {
   $requirements = array();
   if ($phase == 'runtime') {
+    $t = get_t();
     // FusionMaps PHP file.
     $file_exists = file_exists(multisite_maps_get_library_path() . '/Code/PHP/Includes/FusionMaps.php');
     if ($file_exists) {
       $requirements['multisite_maps']['severity'] = REQUIREMENT_OK;
-      $requirements['multisite_maps']['value'] = t('FusionMaps PHP file found.');
+      $requirements['multisite_maps']['value'] = $t('FusionMaps PHP file found.');
     }
     else {
       $requirements['multisite_maps']['severity'] = REQUIREMENT_ERROR;
-      $requirements['multisite_maps']['value'] = t('FusionMaps PHP file not found.');
-      $requirements['multisite_maps']['description'] = t('Please download these files from <a href="@url">http://www.fusioncharts.com</a> and copy them into the FusionMaps library directory as per instructions in the readme.txt file.', array('@url' => 'http://www.fusioncharts.com/charts/fusionmaps/'));
+      $requirements['multisite_maps']['value'] = $t('FusionMaps PHP file not found.');
+      $requirements['multisite_maps']['description'] = $t('Please download these files from <a href="@url">http://www.fusioncharts.com</a> and copy them into the FusionMaps library directory as per instructions in the readme.txt file.', array('@url' => 'http://www.fusioncharts.com/charts/fusionmaps/'));
     }
-    $requirements['multisite_maps']['title'] = t('FusionMaps');
+    $requirements['multisite_maps']['title'] = $t('FusionMaps');
   }
   return $requirements;
 }
@@ -31,6 +32,7 @@ function multisite_maps_requirements($phase) {
  * Implements hook_enable().
  */
 function multisite_maps_enable() {
+  $t = get_t();
   // SolR configuration add bundle.
   config_solr_bundle('map', 'add');
 
@@ -38,7 +40,7 @@ function multisite_maps_enable() {
   _content_type_linkchecker('map', 'add');
 
   // Activation message.
-  drupal_set_message(t('Multisite Maps feature is now active on your site.'));
+  drupal_set_message($t('Multisite Maps feature is now active on your site.'));
 }
 
 /**

--- a/profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.install
+++ b/profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.install
@@ -38,11 +38,12 @@ function nexteuropa_metatags_requirements($phase) {
   $requirements = array();
 
   if ($messages = _nexteuropa_metatags_check_metatag_config()) {
+    $t = get_t();
     $requirements['nexteuropa_metatags'] = array(
       'title' => 'Nexteuropa Metatags',
       'value' => implode('<br/>', $messages),
       'severity' => REQUIREMENT_WARNING,
-      'description' => t('Check against empty meta tags.'),
+      'description' => $t('Check against empty meta tags.'),
     );
   }
 

--- a/profiles/common/modules/features/solr_config/solr_config.install
+++ b/profiles/common/modules/features/solr_config/solr_config.install
@@ -154,6 +154,7 @@ function solr_config_update_7122() {
  * Implements hook_install().
  */
 function solr_config_install() {
+  $t = get_t();
   // Add a menu link for the solr facets settings.
   $mlid_parent = db_select('menu_links', 'ml')
     ->condition('ml.link_path', 'admin/config/search')
@@ -162,11 +163,11 @@ function solr_config_install() {
     ->fetchField();
 
   $options = array();
-  $options['attributes']['title'] = t('Configure SolR facets');
+  $options['attributes']['title'] = $t('Configure SolR facets');
 
   $item = array(
     'link_path' => 'admin/config/search/apachesolr/settings/solr/facets',
-    'link_title' => t('SolR facets'),
+    'link_title' => $t('SolR facets'),
     'menu_name' => 'management',
     'options' => $options,
     'plid' => $mlid_parent,


### PR DESCRIPTION
## NEPT-1295

### Description

Replaced t() with get_t() in ecas, multisite_og_button, multisite_crop_and_resize, nexteuropa_metatags, f_a_q, multisite_charts, multisite_maps, solr_config

### Change log

- Fixed: Replaced t() with get_t().

