### PR TITLE
NEPT-1453: Fix text format filters

### DIFF
--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
@@ -22,6 +22,7 @@ function multisite_drupal_toolbox_enable() {
   multisite_config_service('filter')->enableTextFilter('basic_html', 'toolbox_sanitize');
   multisite_config_service('filter')->enableTextFilter('filtered_html', 'toolbox_sanitize');
   multisite_config_service('filter')->enableTextFilter('full_html', 'toolbox_sanitize');
+  multisite_config_service('filter')->enableTextFilter('full_html_track', 'toolbox_sanitize');
 }
 
 /**

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.features.filter.inc
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.features.filter.inc
@@ -179,6 +179,16 @@ function cce_basic_config_filter_default_formats() {
           'filter_url_length' => 72,
         ),
       ),
+      'toolbox_sanitize' => array(
+        'weight' => 0,
+        'status' => 1,
+        'settings' => array(),
+      ),
+      'filter_tokens' => array(
+        'weight' => 20,
+        'status' => 1,
+        'settings' => array(),
+      ),
       'filter_autop' => array(
         'weight' => 1,
         'status' => 1,

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.features.user_permission.inc
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.features.user_permission.inc
@@ -491,7 +491,6 @@ function cce_basic_config_user_default_permissions() {
     'name' => 'use text format full_html',
     'roles' => array(
       'administrator' => 'administrator',
-      'authenticated user' => 'authenticated user',
       'contributor' => 'contributor',
       'editor' => 'editor',
     ),

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -829,7 +829,6 @@ function _cce_basic_config_post_install_user_roles_perms() {
     'access user contact forms',
     'access user profiles',
     'access workbench',
-    'use text format full_html',
     'view moderation history',
     'view moderation messages',
     'view own unpublished content',


### PR DESCRIPTION
## NEPT-1453

### Description

Add the "Sanitize HTML" filter to full html formats and remove a permission at installation time.

### Change log

- Changed: Sanitize html filter to formats.
- Changed: Change format permissions.

### Commands

The changes are only for fresh install and does not imply the existing site.

