### PR TITLE
NEPT-1412: Fix QA automation rules - There must be one blank line after the last USE statement

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -549,12 +549,7 @@
     <rule ref="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter">
         <exclude-pattern>*</exclude-pattern>
     </rule>
-
-    <!-- There must be one blank line after the last USE statement. -->
-    <rule ref="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
+    
     <!-- The use of function strlen() is forbidden; use drupal_strlen() instead. -->
     <rule ref="QualityAssurance.Functions.DrupalWrappers.FoundWithAlternative">
         <exclude-pattern>*</exclude-pattern>

--- a/profiles/common/modules/custom/nexteuropa_laco/tests/LanguageCoverageServiceTest.php
+++ b/profiles/common/modules/custom/nexteuropa_laco/tests/LanguageCoverageServiceTest.php
@@ -9,7 +9,6 @@ namespace Drupal\nexteuropa_laco\Tests;
 
 use Drupal\nexteuropa_laco\LanguageCoverageService as Service;
 
-
 /**
  * Class LanguageCoverageServiceTest.
  *

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -7,6 +7,7 @@
 module_load_include('inc', 'nexteuropa_varnish', 'nexteuropa_varnish.helper');
 
 use Drupal\nexteuropa_varnish\PurgeRuleType;
+
 define('NEXTEUROPA_VARNISH_CACHE_TABLE', 'cache_nexteuropa_varnish');
 
 /**


### PR DESCRIPTION
## NEPT-1412

### Description

There must be one blank line after the last USE statement

### Change log

- Changed: line spacing after use statement

### Commands

```sh
no command

```

