### PR TITLE
Merge master into release-2.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,19 @@ env.slackMessage = "<${env.BUILD_URL}|${env.RELEASE_NAME} build ${env.BUILD_NUMB
 slackSend color: "good", message: "${env.slackMessage} started."
 
 try {
+    node('master') {
+        stage('Check') {
+            deleteDir()
+            checkout scm
+            sh 'COMPOSER_CACHE_DIR=/dev/null composer install --no-suggest'
+            sh './bin/phing setup-php-codesniffer'
+            sh './bin/phpcs --report=full --report=source --report=summary -s'
+        }
+    }
     parallel (
         'standard-ec-resp' : {
             // Build and test the standard profile with ec_resp theme
-            node('php5') {
+            node('slave') {
                 try {
                     withEnv([
                         "BEHAT_PROFILE=standard_ec_resp",
@@ -21,7 +30,7 @@ try {
         },
         'standard-ec-europa' : {
             // Build and test the standard profile with europa theme
-            node('php5') {
+            node('slave') {
                 try {
                     withEnv([
                         "THEME_DEFAULT=ec_europa"
@@ -35,7 +44,7 @@ try {
         },
         'communities-ec-resp' : {
             // Build and test the communities profile with ec_resp theme
-            node('php5') {
+            node('slave') {
                 try {
                     withEnv([
                         "BEHAT_PROFILE=communities_ec_resp",
@@ -50,7 +59,7 @@ try {
         },
         'communities-ec-europa' : {
             // Build and test the communities profile with europa theme
-            node('php5') {
+            node('slave') {
                 try {
                     withEnv([
                         "BEHAT_PROFILE=communities",
@@ -63,7 +72,8 @@ try {
                     throw(err)
                 }
             }
-        }
+        },
+        failFast: true
     )
 } catch(err) {
     slackSend color: "danger", message: "${env.slackMessage} failed."
@@ -91,7 +101,7 @@ void executeStages(String label) {
     env.WD_HOST_URL = "http://${env.WD_HOST}:${env.WD_PORT}/wd/hub"
 
     try {
-        stage('Init & Build ' + label) {
+        stage('Build & Install ' + label) {
             deleteDir()
             checkout scm
             sh 'COMPOSER_CACHE_DIR=/dev/null composer install --no-suggest'
@@ -104,8 +114,7 @@ void executeStages(String label) {
             }
         }
 
-        stage('Check & Test ' + label) {
-            sh './bin/phpcs --report=full --report=source --report=summary -s'
+        stage('Test ' + label) {
             sh './bin/phpunit -c tests/phpunit.xml'
             wrap([$class: 'AnsiColorBuildWrapper', colorMapName: 'xterm']) {
                 timeout(time: 2, unit: 'HOURS') {

--- a/README.md
+++ b/README.md
@@ -253,9 +253,8 @@ $ ./bin/phpunit -c tests/phpunit.xml
 
 ## Checking for coding standards violations
 
-When a development build is created by executing the 'build-platform-dev' Phing
-target PHP CodeSniffer will be set up and can be run with the following
-command:
+After executing the 'setup-php-codesniffer' Phing target,
+PHP CodeSniffer will be set up and can be run with the following command:
 
 ```
 # Scan all files for coding standards violations.

--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -202,12 +202,6 @@
         <exclude-pattern>profiles/common/modules/features/multisite_metatags/multisite_metatags.module</exclude-pattern>
     </rule>
 
-    <!-- Do not use check_plain() on string literals. -->
-    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
-    <rule ref="DrupalPractice.FunctionCalls.CheckPlain.CheckPlainLiteral">
-        <exclude-pattern>profiles/common/modules/custom/multisite_block_carousel/multisite_block_carousel.module</exclude-pattern>
-    </rule>
-
     <!-- Incorrect doc comment. -->
     <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
     <rule ref="DrupalPractice.FunctionDefinitions.FormAlterDoc.Different">

--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -140,12 +140,6 @@
         <exclude-pattern>profiles/common/modules/features/ec_world_countries/nuts_regions/nuts_regions.views_default.inc</exclude-pattern>
     </rule>
 
-    <!-- Remove re-declaration. -->
-    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
-    <rule ref="DrupalPractice.CodeAnalysis.VariableAnalysis.VariableRedeclaration">
-        <exclude-pattern>profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.module</exclude-pattern>
-    </rule>
-
     <!-- Fix spacing. -->
     <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-826 -->
     <rule ref="DrupalPractice.Commenting.CommentEmptyLine.SpacingAfter">

--- a/profiles/common/modules/custom/multisite_block_carousel/multisite_block_carousel.module
+++ b/profiles/common/modules/custom/multisite_block_carousel/multisite_block_carousel.module
@@ -141,7 +141,7 @@ function multisite_block_carousel_form_block_admin_display_form_alter(&$form, $f
     if (empty($blocks[$delta])) {
       $form['blocks']['block_carousel_' . $delta]['delete'] = array(
         '#type' => 'link',
-        '#title' => check_plain('delete'),
+        '#title' => t('delete'),
         '#href' => 'admin/structure/block/delete-block-carousel/' . $delta,
       );
     }

--- a/profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.module
+++ b/profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.module
@@ -86,7 +86,6 @@ function multisite_mediagallery_core_preprocess_node(&$variables) {
 
     // If no pictures display empty_pic.
     if (!isset($sorted_media_items) || count($sorted_media_items) == 0) {
-      global $base_url;
       $empty_pic = array(
         'type' => 'empty',
         'uri' => $base_url . '/' . path_to_theme() . '/images/empty_gallery.png',


### PR DESCRIPTION
## NEPT-1484

### Description

NEPT-1484: Execute CS checks earlier in the pipeline
NEPT-1290: Remove check plain on string literals in multisite_block_carousel delete link
NEPT-1286: Removed redeclaration of global variable

### Change log

- Changed: Pipeline updated to execute CS checks earlier
- Changed: Removed check plain() on link title and replaced with t()
- Fixed: removed redeclaration of global variable

### Commands

No command to execute