### PR TITLE
NEPT-1453: Enforce sanitisation on text formats

### DIFF
--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
@@ -22,6 +22,7 @@ function multisite_drupal_toolbox_enable() {
   multisite_config_service('filter')->enableTextFilter('basic_html', 'toolbox_sanitize');
   multisite_config_service('filter')->enableTextFilter('filtered_html', 'toolbox_sanitize');
   multisite_config_service('filter')->enableTextFilter('full_html', 'toolbox_sanitize');
+  multisite_config_service('filter')->enableTextFilter('full_html_track', 'toolbox_sanitize');
 }
 
 /**
@@ -51,4 +52,28 @@ function multisite_drupal_toolbox_update_7201() {
   multisite_config_service('filter')->enableTextFilter('basic_html', 'toolbox_sanitize');
   multisite_config_service('filter')->enableTextFilter('filtered_html', 'toolbox_sanitize');
   multisite_config_service('filter')->enableTextFilter('full_html', 'toolbox_sanitize');
+}
+
+/**
+ * NEPT-1453: Enable HTML sanitize filter for all "non-checkplain" formats.
+ */
+function multisite_drupal_toolbox_update_7202() {
+  $formats = filter_formats();
+  $format_machine_names = array_keys($formats);
+  foreach ($format_machine_names as $format_machine_name) {
+    $format = multisite_config_service('filter')->getFormatFilters($format_machine_name, TRUE);
+
+    // Check 'filter_html_escape' filter
+    if (!empty($format['filter_html_escape']) && ($format['filter_html_escape']->status)) {
+      continue;
+    }
+
+    // Check 'toolbox_sanitize' filter
+    if (!empty($format['toolbox_sanitize']) && ($format['toolbox_sanitize']->status)) {
+      continue;
+    }
+
+    multisite_config_service('filter')->enableTextFilter($format_machine_name, 'toolbox_sanitize');
+    multisite_config_service('filter')->setTextFilterWeight($format_machine_name, 'toolbox_sanitize', 0);
+  }
 }

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
@@ -97,6 +97,6 @@ function multisite_drupal_toolbox_update_7202() {
 
     // If $filter_html_escape is enabled no need to use toolbox_sanitize.
     multisite_config_service('filter')->disableTextFilter($format_machine_name, 'toolbox_sanitize');
-    watchdog('mmultisite drupal toolbox', '"Updatedb process: toolbox_sanitize" has been disabled for @text_format.', array('@text_format' => $format_machine_name), WATCHDOG_INFO);
+    watchdog('multisite drupal toolbox', '"Updatedb process: toolbox_sanitize" has been disabled for @text_format.', array('@text_format' => $format_machine_name), WATCHDOG_INFO);
   }
 }

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
@@ -61,18 +61,18 @@ function multisite_drupal_toolbox_update_7202() {
   $formats = filter_formats();
   $format_machine_names = array_keys($formats);
   foreach ($format_machine_names as $format_machine_name) {
-    $format = multisite_config_service('filter')->getFormatFilters($format_machine_name, TRUE);
+    $filters = multisite_config_service('filter')->getFormatFilters($format_machine_name, TRUE);
 
     $filter_html_escape_status = 0;
     $toolbox_sanitize_status = 0;
     // Set the actual value of the 'filter_html_escape' filter.
-    if (!empty($format['filter_html_escape']) && ($format['filter_html_escape']->status)) {
-      $filter_html_escape_status = $format['filter_html_escape']->status;
+    if (!empty($filters['filter_html_escape']) && ($filters['filter_html_escape']->status)) {
+      $filter_html_escape_status = $filters['filter_html_escape']->status;
     }
 
     // Set the actual value of the 'toolbox_sanitize' filter.
-    if (!empty($format['toolbox_sanitize']) && ($format['toolbox_sanitize']->status)) {
-      $toolbox_sanitize_status = $format['toolbox_sanitize']->status;
+    if (!empty($filters['toolbox_sanitize']) && ($filters['toolbox_sanitize']->status)) {
+      $toolbox_sanitize_status = $filters['toolbox_sanitize']->status;
     }
 
     // If both are different, nothing to do then.
@@ -82,13 +82,16 @@ function multisite_drupal_toolbox_update_7202() {
 
     if (!$toolbox_sanitize_status) {
       multisite_config_service('filter')->enableTextFilter($format_machine_name, 'toolbox_sanitize');
-      multisite_config_service('filter')->setTextFilterWeight($format_machine_name, 'toolbox_sanitize', 0);
-      watchdog('multisite_drupal_toolbox_update_7202', '"toolbox_sanitize" has been enabled for @text_format.', array('@text_format' => $format_machine_name), WATCHDOG_INFO);
+      // Put below the Drupal standard minimum value for the weight;
+      // It is a one shot and no exotic value has been detected in sub-sites;
+      // no need to complicating more.
+      multisite_config_service('filter')->setTextFilterWeight($format_machine_name, 'toolbox_sanitize', -51);
+      watchdog('multisite drupal toolbox', '"Updatedb process: toolbox_sanitize" has been enabled for @text_format.', array('@text_format' => $format_machine_name), WATCHDOG_INFO);
       continue;
     }
 
     // If $filter_html_escape is enabled no need to use toolbox_sanitize.
     multisite_config_service('filter')->disableTextFilter($format_machine_name, 'toolbox_sanitize');
-    watchdog('multisite_drupal_toolbox_update_7202', '"toolbox_sanitize" has been disabled for @text_format.', array('@text_format' => $format_machine_name), WATCHDOG_INFO);
+    watchdog('mmultisite drupal toolbox', '"Updatedb process: toolbox_sanitize" has been disabled for @text_format.', array('@text_format' => $format_machine_name), WATCHDOG_INFO);
   }
 }

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
@@ -63,17 +63,32 @@ function multisite_drupal_toolbox_update_7202() {
   foreach ($format_machine_names as $format_machine_name) {
     $format = multisite_config_service('filter')->getFormatFilters($format_machine_name, TRUE);
 
-    // Check 'filter_html_escape' filter
+    $filter_html_escape_status = 0;
+    $toolbox_sanitize_status = 0;
+    // Set the actual value of the 'filter_html_escape' filter.
     if (!empty($format['filter_html_escape']) && ($format['filter_html_escape']->status)) {
-      continue;
+      $filter_html_escape_status = $format['filter_html_escape']->status;
     }
 
-    // Check 'toolbox_sanitize' filter
+    // Set the actual value of the 'toolbox_sanitize' filter.
     if (!empty($format['toolbox_sanitize']) && ($format['toolbox_sanitize']->status)) {
+      $toolbox_sanitize_status = $format['toolbox_sanitize']->status;
+    }
+
+    // If both are different, nothing to do then.
+    if ($filter_html_escape_status != $toolbox_sanitize_status) {
       continue;
     }
 
-    multisite_config_service('filter')->enableTextFilter($format_machine_name, 'toolbox_sanitize');
-    multisite_config_service('filter')->setTextFilterWeight($format_machine_name, 'toolbox_sanitize', 0);
+    if (!$toolbox_sanitize_status) {
+      multisite_config_service('filter')->enableTextFilter($format_machine_name, 'toolbox_sanitize');
+      multisite_config_service('filter')->setTextFilterWeight($format_machine_name, 'toolbox_sanitize', 0);
+      watchdog('multisite_drupal_toolbox_update_7202', '"toolbox_sanitize" has been enabled for @text_format.', array('@text_format' => $format_machine_name), WATCHDOG_INFO);
+      continue;
+    }
+
+    // If $filter_html_escape is enabled no need to use toolbox_sanitize.
+    multisite_config_service('filter')->disableTextFilter($format_machine_name, 'toolbox_sanitize');
+    watchdog('multisite_drupal_toolbox_update_7202', '"toolbox_sanitize" has been disabled for @text_format.', array('@text_format' => $format_machine_name), WATCHDOG_INFO);
   }
 }

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
@@ -18,11 +18,16 @@ function multisite_drupal_toolbox_enable() {
     ->condition('delta', 'block', '=')
     ->execute();
 
-  // Enable toolbox_sanitize on all text filters.
+  // Enable toolbox_sanitize on all text filters and set their weight to the
+  // Drupal minimum value.
   multisite_config_service('filter')->enableTextFilter('basic_html', 'toolbox_sanitize');
+  multisite_config_service('filter')->setTextFilterWeight('basic_html', 'toolbox_sanitize', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT);
   multisite_config_service('filter')->enableTextFilter('filtered_html', 'toolbox_sanitize');
+  multisite_config_service('filter')->setTextFilterWeight('filtered_html', 'toolbox_sanitize', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT);
   multisite_config_service('filter')->enableTextFilter('full_html', 'toolbox_sanitize');
+  multisite_config_service('filter')->setTextFilterWeight('full_html', 'toolbox_sanitize', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT);
   multisite_config_service('filter')->enableTextFilter('full_html_track', 'toolbox_sanitize');
+  multisite_config_service('filter')->setTextFilterWeight('full_html_track', 'toolbox_sanitize', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT);
 }
 
 /**

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
@@ -85,7 +85,7 @@ function multisite_drupal_toolbox_update_7202() {
       // Put below the Drupal standard minimum value for the weight;
       // It is a one shot and no exotic value has been detected in sub-sites;
       // no need to complicating more.
-      multisite_config_service('filter')->setTextFilterWeight($format_machine_name, 'toolbox_sanitize', -51);
+      multisite_config_service('filter')->setTextFilterWeight($format_machine_name, 'toolbox_sanitize', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT);
       watchdog('multisite drupal toolbox', '"Updatedb process: toolbox_sanitize" has been enabled for @text_format.', array('@text_format' => $format_machine_name), WATCHDOG_INFO);
       continue;
     }

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
@@ -511,25 +511,11 @@ function multisite_drupal_toolbox_filter_format_update($format) {
   }
 
   if (!$toolbox_sanitize_status) {
-    // Set a weight below the minimal existing value.
-    // The weight setting is only the filter is enforce. After, site builders
-    // can set the weight freely.
-    // The goal is to reduce a maximum negative impacts during the enforcing.
-    $weight_list = array_map(
-      function($o) {
-        return $o['weight'];
-      },
-      $filters
-    );
-    $min_weight = min($weight_list);
-    // Do not go below -50; the standard minimum value set for the weight.
-    $min_weight = (($min_weight - 1) < MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT) ? MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT : ($min_weight - 1);
-
     // Save the enforcing. Cannot pass by a normal save because that causes an
     // infinitive loop.
     $fields = array(
       'status' => 1,
-      'weight' => $min_weight,
+      'weight' => MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT,
     );
 
     db_merge('filter')

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
@@ -463,6 +463,79 @@ function multisite_drupal_toolbox_form_user_pass_alter(&$form, &$form_state, $fo
 }
 
 /**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Adds important block in the description of toolbox_sanitize and
+ * filter_html_escape filter fields.
+ */
+function multisite_drupal_toolbox_form_filter_admin_format_form_alter(&$form, &$form_state, $form_id) {
+  $filter_html_escape = &$form['filters']['status']['filter_html_escape'];
+  $toolbox_sanitize = &$form['filters']['status']['toolbox_sanitize'];
+
+  // Initial case; the text format is not created yet.
+  $toolbox_sanitize['#default_value'] = (!$filter_html_escape['#default_value']);
+
+  $addendum = '<span style="font-weight: bold;color: red;">' . t('Important:') . '</span> ';
+  $filter_html_escape['#description'] .= $addendum;
+  $addendum = '<br />' . $addendum;
+  $toolbox_sanitize['#description'] .= $addendum;
+
+  $filter_title = $toolbox_sanitize['#title'];
+  $filter_html_escape['#description'] .= t('The "@title" filter is <strong>enforced automatically</strong> if this one is not enabled.', array('@title' => $filter_title));
+  $filter_title = $filter_html_escape['#title'];
+  $toolbox_sanitize['#description'] .= t('This filter is <strong>enforced automatically</strong> if the "@title" one is not enabled.', array('@title' => $filter_title));
+}
+
+/**
+ * Implements hook_filter_format_insert().
+ */
+function multisite_drupal_toolbox_filter_format_insert($format) {
+  multisite_drupal_toolbox_filter_format_update($format);
+}
+
+/**
+ * Implements hook_filter_format_update().
+ *
+ * Enforces the activation of 'toolbox_sanitize' filter, if
+ * 'filter_html_escape' is not.
+ */
+function multisite_drupal_toolbox_filter_format_update($format) {
+  $filters = &$format->filters;
+  $filter_html_escape_status = $filters['filter_html_escape']['status'];
+  $toolbox_sanitize_status = $filters['toolbox_sanitize']['status'];
+
+  // If the both status are different, configuration is safe.
+  // Then, nothing to do.
+  if ($filter_html_escape_status != $toolbox_sanitize_status) {
+    return;
+  }
+
+  if (!$toolbox_sanitize_status) {
+    // Save the enforcing. Cannot pass by a normal save because that causes an
+    // infinitive loop.
+    $fields = array(
+      'status' => 1,
+      'weight' => -10,
+    );
+
+    db_merge('filter')
+      ->key(array(
+        'format' => $format->format,
+        'name' => 'toolbox_sanitize',
+      ))
+      ->fields($fields)
+      ->execute();
+
+    $watchdog_variables = array(
+      '@text_format' => $format->format,
+      '@value' => (!$filter_html_escape_status),
+    );
+    watchdog('multisite_drupal_toolbox_update_7202', '"toolbox_sanitize" status has been set to @value for @text_format.', $watchdog_variables, WATCHDOG_INFO);
+
+  }
+}
+
+/**
  * Implements hook_filter_info_alter().
  */
 function multisite_drupal_toolbox_filter_info() {

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
@@ -511,11 +511,23 @@ function multisite_drupal_toolbox_filter_format_update($format) {
   }
 
   if (!$toolbox_sanitize_status) {
+    // Set a weight below the minimal existing value.
+    // The weight setting is only the filter is enforce. After, site builders
+    // can set the weight freely.
+    // The goal is to reduce a maximum negative impacts during the enforcing.
+    $weight_list = array_map(
+      function($o) {
+        return $o['weight'];
+      },
+      $filters
+    );
+    $min_weight = min($weight_list);
+
     // Save the enforcing. Cannot pass by a normal save because that causes an
     // infinitive loop.
     $fields = array(
       'status' => 1,
-      'weight' => -10,
+      'weight' => ($min_weight - 1),
     );
 
     db_merge('filter')
@@ -530,8 +542,7 @@ function multisite_drupal_toolbox_filter_format_update($format) {
       '@text_format' => $format->format,
       '@value' => (!$filter_html_escape_status),
     );
-    watchdog('multisite_drupal_toolbox_update_7202', '"toolbox_sanitize" status has been set to @value for @text_format.', $watchdog_variables, WATCHDOG_INFO);
-
+    watchdog('multisite drupal toolbox', '"toolbox_sanitize" status has been set to @value for @text_format.', $watchdog_variables, WATCHDOG_INFO);
   }
 }
 

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
@@ -5,7 +5,10 @@
  * Multisite Toolbox definition module.
  */
 
- define('MULTISITE_DRUPAL_TOOLBOX_FEATURES_REVERT_BLACKLISTED', 'cce_basic_config,multisite_settings_core');
+define('MULTISITE_DRUPAL_TOOLBOX_FEATURES_REVERT_BLACKLISTED', 'cce_basic_config,multisite_settings_core');
+define('MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT', -50);
+define('MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MAX_WEIGHT', 50);
+
 /**
  * Implements hook_permission().
  */
@@ -472,9 +475,6 @@ function multisite_drupal_toolbox_form_filter_admin_format_form_alter(&$form, &$
   $filter_html_escape = &$form['filters']['status']['filter_html_escape'];
   $toolbox_sanitize = &$form['filters']['status']['toolbox_sanitize'];
 
-  // Initial case; the text format is not created yet.
-  $toolbox_sanitize['#default_value'] = (!$filter_html_escape['#default_value']);
-
   $addendum = '<span style="font-weight: bold;color: red;">' . t('Important:') . '</span> ';
   $filter_html_escape['#description'] .= $addendum;
   $addendum = '<br />' . $addendum;
@@ -522,12 +522,14 @@ function multisite_drupal_toolbox_filter_format_update($format) {
       $filters
     );
     $min_weight = min($weight_list);
+    // Do not go below -50; the standard minimum value set for the weight.
+    $min_weight = (($min_weight - 1) < MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT) ? MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT : ($min_weight - 1);
 
     // Save the enforcing. Cannot pass by a normal save because that causes an
     // infinitive loop.
     $fields = array(
       'status' => 1,
-      'weight' => ($min_weight - 1),
+      'weight' => $min_weight,
     );
 
     db_merge('filter')

--- a/tests/features/security/xss_vulnerability.feature
+++ b/tests/features/security/xss_vulnerability.feature
@@ -32,3 +32,17 @@ Feature: Xss Vulnerability
     And I click "Article with xss Code in an image"
     And the response should contain "&lt;script&gt;alert('xss alert');&lt;/script&gt;"
     And the response should not contain "<script>alert('xss alert');</script>"
+
+   Scenario: Test the "Sanitize HTML" filter is never disabled if the "Display any HTML as plain text" one is in a "text format"
+     When I go to "/admin/config/content/formats/filtered_html"
+     And I uncheck the box "Sanitize HTML"
+     And I press "Save configuration"
+     Then I should see the success message "The text format Filtered HTML has been updated."
+     And the "Sanitize HTML" checkbox should be checked
+     When I go to "admin/config/content/formats/plain_text"
+     And the "Display any HTML as plain text" checkbox should be checked
+     And the "Sanitize HTML" checkbox should not be checked
+     And I press "Save configuration"
+     Then I should see the success message "The text format Plain text has been updated."
+     And the "Sanitize HTML" checkbox should not be checked
+     And the "Display any HTML as plain text" checkbox should be checked

--- a/tests/features/security/xss_vulnerability.feature
+++ b/tests/features/security/xss_vulnerability.feature
@@ -33,16 +33,42 @@ Feature: Xss Vulnerability
     And the response should contain "&lt;script&gt;alert('xss alert');&lt;/script&gt;"
     And the response should not contain "<script>alert('xss alert');</script>"
 
-   Scenario: Test the "Sanitize HTML" filter is never disabled if the "Display any HTML as plain text" one is in a "text format"
+   Scenario: With existing text formats, test the "Sanitize HTML" filter is never disabled if
+   the "Display any HTML as plain text" one is not in a "text format"
      When I go to "/admin/config/content/formats/filtered_html"
      And I uncheck the box "Sanitize HTML"
      And I press "Save configuration"
      Then I should see the success message "The text format Filtered HTML has been updated."
      And the "Sanitize HTML" checkbox should be checked
      When I go to "admin/config/content/formats/plain_text"
-     And the "Display any HTML as plain text" checkbox should be checked
-     And the "Sanitize HTML" checkbox should not be checked
+     And I check the box "Display any HTML as plain text"
+     And I uncheck the box "Sanitize HTML"
      And I press "Save configuration"
      Then I should see the success message "The text format Plain text has been updated."
      And the "Sanitize HTML" checkbox should not be checked
      And the "Display any HTML as plain text" checkbox should be checked
+
+  @javascript
+  Scenario: With new text formats, test the "Sanitize HTML" filter is never disabled if
+  the "Display any HTML as plain text" one is not in a "text format"
+    When I go to "admin/config/content/formats/add"
+    And I fill in "Name" with "Dummy format"
+    And I uncheck the box "Sanitize HTML"
+    And I check "Convert URLs into links"
+    And I check "Convert all characters to US-ASCII"
+    And I press "Save configuration"
+    Then I should see the success message "Added text format Dummy format."
+    When I go to "admin/config/content/formats/dummy_format"
+    Then the "Sanitize HTML" checkbox should be checked
+    When I go to "admin/config/content/formats/add"
+    And I fill in "Name" with "Dummy format 2"
+    And I uncheck the box "Sanitize HTML"
+    And I check "Display any HTML as plain text"
+    And I check "Convert URLs into links"
+    And I check "Convert all characters to US-ASCII"
+    And I press "Save configuration"
+    Then I should see the success message "Added text format Dummy format 2."
+    When I go to "admin/config/content/formats/dummy_format_2"
+    And the "Sanitize HTML" checkbox should not be checked
+    And the "Display any HTML as plain text" checkbox should be checked
+


### PR DESCRIPTION
## NEPT-1453

### Description

Enforcing the activation of the "Sanitize HTML" filters in all text formats where "Display any HTML as plain text" one is not enabled

### Change log

- Added: Enforce the activation of the "Sanitize HTML" filters when a text format is saved.
- Added: "hook_updatedb" that enforces the activation of the "Sanitize HTML" filters for already existing formats.
- Changed: Add notification messages in the descriptions of inputs of the "text format" admin interface.

### Commands

```sh
drush updatedb

```

