### PR TITLE
NEPT-1255: Remove the check_plain from the ecas_import_users.

### DIFF
--- a/profiles/common/modules/custom/ecas/ecas_import_users/ecas_import_users.module
+++ b/profiles/common/modules/custom/ecas/ecas_import_users/ecas_import_users.module
@@ -460,9 +460,9 @@ function ecas_import_users_show_user_content_form($form, &$form_state, $argument
           '|',
           array(
             check_plain($uid),
-            check_plain($mail),
-            check_plain($firstname),
-            check_plain($lastname),
+            $mail,
+            $firstname,
+            $lastname,
             check_plain($row['domain']),
             check_plain($row['departmentnumber']),
           )


### PR DESCRIPTION
## NEPT-NEPT-1255

### Description

Remove the check_plain from the ecas_import_users.

### Change log

- Removed: Unnecessary check_plain

### Commands

```sh
no command
```

