### PR TITLE
NEPT-1384 Fix QA automation rules - Data types in @param tags

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -578,11 +578,6 @@
         <exclude-pattern>*</exclude-pattern>
     </rule>
 
-    <!-- Data types in @param tags need to be fully namespaced. -->
-    <rule ref="Drupal.Commenting.DataTypeNamespace.DataTypeNamespace">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
     <!-- Namespaced classes/interfaces/traits should be referenced with use statements. -->
     <rule ref="Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing">
         <exclude-pattern>*</exclude-pattern>

--- a/profiles/common/modules/custom/nexteuropa_laco/src/nexteuropa_laco.behat.inc
+++ b/profiles/common/modules/custom/nexteuropa_laco/src/nexteuropa_laco.behat.inc
@@ -31,7 +31,7 @@ class NextEuropaLacoSubContext extends RawDrupalContext implements DrupalSubCont
   /**
    * Constructs a NextEuropaLacoSubContext object.
    *
-   * @param DrupalDriverManager $drupal
+   * @param Drupal\DrupalDriverManager $drupal
    *   The Drupal driver manager.
    */
   public function __construct(DrupalDriverManager $drupal) {

--- a/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.module
+++ b/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.module
@@ -497,7 +497,7 @@ function _nexteuropa_piwik_filter_results($results, $path, $lang_code) {
  * @param array $rules_array
  *   An array with the PiwikRule objects keyed by the id.
  *
- * @return PiwikRule
+ * @return Drupal\nexteuropa_piwik\Entity\PiwikRule
  *   PiwikRule entity.
  */
 function _nexteuropa_piwik_get_latest_rule($rules_array) {

--- a/profiles/common/modules/custom/nexteuropa_varnish/src/Entity/PurgeRule.php
+++ b/profiles/common/modules/custom/nexteuropa_varnish/src/Entity/PurgeRule.php
@@ -26,7 +26,7 @@ class PurgeRule extends Entity {
   /**
    * Get the type of the purge rule.
    *
-   * @return PurgeRuleType
+   * @return Drupal\nexteuropa_varnish\PurgeRuleType
    *   The type of the purge rule.
    */
   public function type() {

--- a/profiles/common/modules/features/multisite_maxlength/src/multisite_maxlength.behat.inc
+++ b/profiles/common/modules/features/multisite_maxlength/src/multisite_maxlength.behat.inc
@@ -22,7 +22,7 @@ class MultisiteMaxlengthSubContext extends RawDrupalContext implements DrupalSub
   /**
    * Constructs a MultisiteMaxlengthSubContext object.
    *
-   * @param DrupalDriverManager $drupal
+   * @param Drupal\DrupalDriverManager $drupal
    *   The Drupal driver manager.
    */
   public function __construct(DrupalDriverManager $drupal) {

--- a/profiles/common/modules/features/multisite_notifications/multisite_notifications_core/includes/multisite_notifications_core.behat.inc
+++ b/profiles/common/modules/features/multisite_notifications/multisite_notifications_core/includes/multisite_notifications_core.behat.inc
@@ -33,7 +33,7 @@ class MultisiteNotificationsSubContext extends RawDrupalContext implements Drupa
   /**
    * Constructs a NexteuropaSubContext object.
    *
-   * @param DrupalDriverManager $drupal
+   * @param Drupal\DrupalDriverManager $drupal
    *   The Drupal driver manager.
    */
   public function __construct(DrupalDriverManager $drupal) {

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.behat.inc
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.behat.inc
@@ -24,7 +24,7 @@ class MultisiteWysiwygSubContext extends RawDrupalContext implements DrupalSubCo
   /**
    * Constructs a NextEuropaTokenSubContext object.
    *
-   * @param DrupalDriverManager $drupal
+   * @param Drupal\DrupalDriverManager $drupal
    *   The Drupal driver manager.
    */
   public function __construct(DrupalDriverManager $drupal) {

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/src/tmgmt_poetry.behat.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/src/tmgmt_poetry.behat.inc
@@ -31,7 +31,7 @@ class TmgmtPoetrySubContext extends RawDrupalContext implements DrupalSubContext
   /**
    * Constructs a TmgmtPoetrySubContext object.
    *
-   * @param DrupalDriverManager $drupal
+   * @param Drupal\DrupalDriverManager $drupal
    *   The Drupal driver manager.
    */
   public function __construct(DrupalDriverManager $drupal) {
@@ -212,7 +212,7 @@ class TmgmtPoetrySubContext extends RawDrupalContext implements DrupalSubContext
    * @Then I see the date of the last change in the ":rowText" row
    */
   public function assertLastChangeDateInTableRow($row_text) {
-    /** @var DrupalContext $drupal_context */
+    /** @var Drupal\DrupalExtension\Context\DrupalContext $drupal_context */
     $drupal_context = $this->getContext(DrupalContext::class);
     $row = $drupal_context->getTableRow($this->getSession()
       ->getPage(), $row_text);
@@ -277,7 +277,7 @@ class TmgmtPoetrySubContext extends RawDrupalContext implements DrupalSubContext
    * @BeforeScenario cleanup-tmgmt-poetry-website-identifier
    */
   public function prepareCleanupWebsiteIdentifier() {
-    /** @var VariableContext $variable_context */
+    /** @var Drupal\nexteuropa\Context\VariableContext $variable_context */
     $variable_context = $this->getContext(VariableContext::class);
     $variable_context->setVariable('website_identifier', '');
   }

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/tmgmt_poetry_mock.behat.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/tmgmt_poetry_mock.behat.inc
@@ -24,7 +24,7 @@ class TMGMTPoetryMockSubContext extends RawDrupalContext implements DrupalSubCon
   /**
    * The Drupal driver manager.
    *
-   * @var DrupalDriverManager
+   * @var Drupal\DrupalDriverManager
    */
   protected $drupal;
 
@@ -45,7 +45,7 @@ class TMGMTPoetryMockSubContext extends RawDrupalContext implements DrupalSubCon
   /**
    * Constructs a TMGMTPoetryMockSubContext object.
    *
-   * @param DrupalDriverManager $drupal
+   * @param Drupal\DrupalDriverManager $drupal
    *   The Drupal driver manager.
    */
   public function __construct(DrupalDriverManager $drupal) {

--- a/profiles/common/modules/features/nexteuropa_editorial/src/nexteuropa_editorial.behat.inc
+++ b/profiles/common/modules/features/nexteuropa_editorial/src/nexteuropa_editorial.behat.inc
@@ -24,7 +24,7 @@ class NextEuropaEditorialSubContext extends RawDrupalContext implements DrupalSu
   /**
    * Constructs a NextEuropaEditorialSubContext object.
    *
-   * @param DrupalDriverManager $drupal
+   * @param Drupal\DrupalDriverManager $drupal
    *   The Drupal driver manager.
    */
   public function __construct(DrupalDriverManager $drupal) {

--- a/profiles/common/modules/features/nexteuropa_integration/nexteuropa_integration.module
+++ b/profiles/common/modules/features/nexteuropa_integration/nexteuropa_integration.module
@@ -75,7 +75,7 @@ function _nexteuropa_integration_language_code_replacement_map() {
 /**
  * Replaces occurrences of language codes.
  *
- * @param DocumentInterface $document
+ * @param Drupal\integration\Document\DocumentInterface $document
  *   The document to perform the replacements in.
  * @param array $replacements
  *   Replacements to perform.

--- a/profiles/common/modules/features/nexteuropa_integration/src/ClosureDecoratedMigrateSourceBackend.php
+++ b/profiles/common/modules/features/nexteuropa_integration/src/ClosureDecoratedMigrateSourceBackend.php
@@ -7,7 +7,7 @@
 namespace Drupal\nexteuropa_integration;
 
 use Drupal\integration_consumer\Migrate\MigrateSourceBackend;
-use Closure;
+use \Closure;
 
 /**
  * Decorates the documents from another MigrateSourceBackend with a closure.
@@ -17,23 +17,23 @@ class ClosureDecoratedMigrateSourceBackend extends MigrateSourceBackend {
   /**
    * The actual MigrateSourceBackend to decorate.
    *
-   * @var MigrateSourceBackend
+   * @var Drupal\integration_consumer\Migrate\MigrateSourceBackend
    */
   protected $wrappedSource;
 
   /**
    * Closure to replace each document from the MigrateSourceBackend.
    *
-   * @var Closure
+   * @var \Closure
    */
   protected $closure;
 
   /**
    * ClosureDecoratedMigrateSourceBackend constructor.
    *
-   * @param MigrateSourceBackend $wrapped_source
+   * @param Drupal\integration_consumer\Migrate\MigrateSourceBackend $wrapped_source
    *   The actual MigrateSourceBackend to decorate.
-   * @param Closure $closure
+   * @param \Closure $closure
    *   The closure which will be used to decorate the documents.
    */
   public function __construct(MigrateSourceBackend $wrapped_source, Closure $closure) {

--- a/profiles/common/modules/features/nexteuropa_trackedchanges/src/nexteuropa_trackedchanges.behat.inc
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/src/nexteuropa_trackedchanges.behat.inc
@@ -23,7 +23,7 @@ class NextEuropaTrackedChangesSubContext extends RawDrupalContext implements Dru
   /**
    * Constructs a NextEuropaTrackedChangesSubContext object.
    *
-   * @param DrupalDriverManager $drupal
+   * @param Drupal\DrupalDriverManager $drupal
    *   The Drupal driver manager.
    */
   public function __construct(DrupalDriverManager $drupal) {

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -113,7 +113,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   /**
    * Checks that the given element is of the given type.
    *
-   * @param NodeElement $element
+   * @param Behat\Mink\Element\NodeElement $element
    *   The element to check.
    * @param string $type
    *   The expected type.
@@ -153,7 +153,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
    *
    * @param string $filename
    *   Name of the file (relative path).
-   * @param PyStringNode $content
+   * @param Behat\Gherkin\Node\PyStringNode $content
    *   PyString string instance.
    *
    * @Given /^(?:there is )?a file named "([^"]*)" with:$/
@@ -179,10 +179,10 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   /**
    * Transforms human readable field labels for Articles into machine names.
    *
-   * @param TableNode $article_table
+   * @param Behat\Gherkin\Node\TableNode $article_table
    *   The original table.
    *
-   * @return TableNode
+   * @return Behat\Gherkin\Node\TableNode
    *   The transformed table.
    *
    * @Transform rowtable:title,body,tags,moderation state
@@ -201,10 +201,10 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   /**
    * Transforms human readable field labels for Users into machine names.
    *
-   * @param TableNode $user_table
+   * @param Behat\Gherkin\Node\TableNode $user_table
    *   The original table.
    *
-   * @return TableNode
+   * @return Behat\Gherkin\Node\TableNode
    *   The transformed table.
    *
    * @Transform rowtable:first name,last name
@@ -258,7 +258,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   /**
    * Check for PHP errors log.
    *
-   * @param AfterStepScope $scope
+   * @param Behat\Behat\Hook\Scope\AfterStepScope $scope
    *    AfterStep hook scope object.
    *
    * @throws \Exception

--- a/tests/src/Component/PyStringYamlParser.php
+++ b/tests/src/Component/PyStringYamlParser.php
@@ -20,7 +20,7 @@ class PyStringYamlParser {
   /**
    * PyStringNode object.
    *
-   * @var PyStringNode;
+   * @var Behat\Gherkin\Node\PyStringNode;
    */
   protected $node;
 

--- a/tests/src/Context/ApacheSolrContext.php
+++ b/tests/src/Context/ApacheSolrContext.php
@@ -40,14 +40,14 @@ class ApacheSolrContext implements Context {
   /**
    * The mocked HTTP server.
    *
-   * @var Server
+   * @var InterNations\Component\HttpMock\Server
    */
   protected $server;
 
   /**
    * Facade to access requests made to the mocked HTTP server.
    *
-   * @var RequestCollectionFacade
+   * @var InterNations\Component\HttpMock\RequestCollectionFacade
    */
   protected $requests;
 
@@ -66,7 +66,7 @@ class ApacheSolrContext implements Context {
    *
    * Initializes the server if it was not used before.
    *
-   * @return Server
+   * @return InterNations\Component\HttpMock\Server
    *   The mocked HTTP server.
    */
   protected function getServer() {
@@ -111,7 +111,7 @@ class ApacheSolrContext implements Context {
   /**
    * Gets the requests made to the mocked Integration backend.
    *
-   * @return RequestCollectionFacade
+   * @return InterNations\Component\HttpMock\RequestCollectionFacade
    *   The requests facade.
    */
   protected function getRequests() {

--- a/tests/src/Context/ContentTypeContext.php
+++ b/tests/src/Context/ContentTypeContext.php
@@ -51,7 +51,7 @@ class ContentTypeContext implements Context {
    *
    * @param string $arg1
    *    The machine name of the content type to which attaching the field.
-   * @param TableNode $settings
+   * @param Behat\Gherkin\Node\TableNode $settings
    *    Two columns table containing field settings.
    *
    * @Given a field with the following settings is added to the :arg1 type:
@@ -149,7 +149,7 @@ class ContentTypeContext implements Context {
    *
    * @param string $arg1
    *    The machine name of the content type to which attaching the field.
-   * @param TableNode $settings
+   * @param Behat\Gherkin\Node\TableNode $settings
    *    Two columns table containing field settings.
    *
    * @Given a field group with the following settings is added to the :arg1 type view:

--- a/tests/src/Context/DrupalContext.php
+++ b/tests/src/Context/DrupalContext.php
@@ -192,7 +192,7 @@ class DrupalContext extends DrupalExtensionDrupalContext {
    *
    * @param string $text_format
    *    The filter format name or its machine name.
-   * @param TableNode $table
+   * @param Behat\Gherkin\Node\TableNode $table
    *    List of available content property.
    *
    * @return array

--- a/tests/src/Context/DrupalMailContext.php
+++ b/tests/src/Context/DrupalMailContext.php
@@ -25,7 +25,7 @@ class DrupalMailContext extends RawDrupalContext implements DrupalSubContextInte
   /**
    * The Drupal driver manager.
    *
-   * @var DrupalDriverManager
+   * @var Drupal\DrupalDriverManager
    */
   protected $drupal;
 
@@ -53,7 +53,7 @@ class DrupalMailContext extends RawDrupalContext implements DrupalSubContextInte
   /**
    * Constructs a DrupalMailContext object.
    *
-   * @param DrupalDriverManager $drupal
+   * @param Drupal\DrupalDriverManager $drupal
    *   The Drupal driver manager.
    */
   public function __construct(DrupalDriverManager $drupal) {

--- a/tests/src/Context/FrontendCacheContext.php
+++ b/tests/src/Context/FrontendCacheContext.php
@@ -51,14 +51,14 @@ class FrontendCacheContext implements Context {
   /**
    * The mocked HTTP server.
    *
-   * @var Server
+   * @var InterNations\Component\HttpMock\Server
    */
   protected $server;
 
   /**
    * Facade to access requests made to the mocked HTTP server.
    *
-   * @var RequestCollectionFacade
+   * @var InterNations\Component\HttpMock\RequestCollectionFacade
    */
   protected $requests;
 
@@ -79,7 +79,7 @@ class FrontendCacheContext implements Context {
    * By default it responds to any POST requests to /invalidate with 200 OK,
    * additional behavior can be added in further steps.
    *
-   * @return Server
+   * @return InterNations\Component\HttpMock\Server
    *   The mocked HTTP server.
    */
   protected function getServer() {
@@ -106,7 +106,7 @@ class FrontendCacheContext implements Context {
   /**
    * Gets the requests made to the mocked Integration backend.
    *
-   * @return RequestCollectionFacade
+   * @return InterNations\Component\HttpMock\RequestCollectionFacade
    *   The requests facade.
    */
   protected function getRequests() {
@@ -213,7 +213,7 @@ class FrontendCacheContext implements Context {
 
     \bovigo\assert\assert($rows, isOfSize(count($expected_rules)));
 
-    /** @var Element $row */
+    /** @var Behat\Mink\Element\Element $row */
     foreach (array_values($rows) as $i => $row) {
       $expected_rule = $expected_rules[$i];
 
@@ -224,7 +224,7 @@ class FrontendCacheContext implements Context {
   /**
    * Gets the cache purge rules overview.
    *
-   * @return Element
+   * @return Behat\Mink\Element\Element
    *   The table body.
    */
   protected function getCachePurgeRulesOverview() {
@@ -234,13 +234,13 @@ class FrontendCacheContext implements Context {
   /**
    * Asserts a particular row from the cache purge rules overview.
    *
-   * @param Element $row
+   * @param Behat\Mink\Element\Element $row
    *   The table row.
    * @param array $expected_rule
    *   The expected values for the cache purge rule.
    */
   protected function assertOverviewCachePurgeRule(Element $row, array $expected_rule) {
-    /** @var Element[] $cells */
+    /** @var Behat\Mink\Element\Element[] $cells */
     $cells = $row->findAll('css', 'td');
 
     assert($cells[0]->getText(), equals($expected_rule['Content Type']));
@@ -452,7 +452,7 @@ class FrontendCacheContext implements Context {
   /**
    * Retrieve the values in the 'Path' column.
    *
-   * @param TableNode $table
+   * @param Behat\Gherkin\Node\TableNode $table
    *   The Behat Gherkin table node.
    *
    * @return string[]

--- a/tests/src/Context/IntegrationLayerContext.php
+++ b/tests/src/Context/IntegrationLayerContext.php
@@ -56,14 +56,14 @@ class IntegrationLayerContext implements Context {
   /**
    * The mocked central Integration HTTP server.
    *
-   * @var Server
+   * @var InterNations\Component\HttpMock\Server
    */
   protected $server;
 
   /**
    * Facade to access requests made to the mocked HTTP server.
    *
-   * @var RequestCollectionFacade
+   * @var InterNations\Component\HttpMock\RequestCollectionFacade
    */
   protected $requests;
 
@@ -84,7 +84,7 @@ class IntegrationLayerContext implements Context {
    * By default it responds to any POST requests with 201 Created response,
    * additional behavior can be added in further steps.
    *
-   * @return Server
+   * @return InterNations\Component\HttpMock\Server
    *   The mocked central Integration HTTP server.
    */
   protected function getServer() {
@@ -110,7 +110,7 @@ class IntegrationLayerContext implements Context {
   /**
    * Gets the requests made to the mocked Integration backend.
    *
-   * @return RequestCollectionFacade
+   * @return InterNations\Component\HttpMock\RequestCollectionFacade
    *   The requests facade.
    */
   protected function getRequests() {

--- a/tests/src/Context/MessageContext.php
+++ b/tests/src/Context/MessageContext.php
@@ -19,7 +19,7 @@ class MessageContext extends DrupalExtensionMessageContext {
   /**
    * Checks if the current page contains the given error message.
    *
-   * @param PyStringNode $message
+   * @param Behat\Gherkin\Node\PyStringNode $message
    *   PyStringNode containing the text to be checked.
    *
    * @Then I should see this following error message:

--- a/tests/src/Context/MinkContext.php
+++ b/tests/src/Context/MinkContext.php
@@ -243,10 +243,10 @@ class MinkContext extends DrupalExtensionMinkContext {
    *
    * @param callable $matcher
    *   Callable which returns if the element matches or not.
-   * @param NodeElement[] $elements
+   * @param Behat\Mink\Element\NodeElement[] $elements
    *   Array of elements to search through.
    *
-   * @return NodeElement|NULL
+   * @return Behat\Mink\Element\NodeElement|NULL
    *   The matching element, or NULL if no matching element was found.
    */
   protected function findElementMatching(callable $matcher, array $elements) {
@@ -372,7 +372,7 @@ class MinkContext extends DrupalExtensionMinkContext {
   /**
    * Retrieve a table row containing specified text from a given element.
    *
-   * @param Element $element
+   * @param Behat\Mink\Element\Element $element
    *    Mink element object.
    * @param string $search
    *    Table row text.
@@ -380,7 +380,7 @@ class MinkContext extends DrupalExtensionMinkContext {
    * @throws \Exception
    *    Throw exception if class table row was not found.
    *
-   * @return NodeElement
+   * @return Behat\Mink\Element\NodeElement
    *    Table row node element.
    */
   public function getTableRow(Element $element, $search) {
@@ -389,7 +389,7 @@ class MinkContext extends DrupalExtensionMinkContext {
       throw new \Exception(sprintf('No rows found on the page %s', $this->getSession()
         ->getCurrentUrl()));
     }
-    /** @var NodeElement $row */
+    /** @var Behat\Mink\Element\NodeElement $row */
     foreach ($rows as $row) {
       if (strpos($row->getText(), $search) !== FALSE) {
         return $row;

--- a/tests/src/Context/ModuleContext.php
+++ b/tests/src/Context/ModuleContext.php
@@ -37,7 +37,7 @@ class ModuleContext extends RawDrupalContext {
    * | blog     |
    * | book     |
    *
-   * @param TableNode $modules_table
+   * @param Behat\Gherkin\Node\TableNode $modules_table
    *   The table listing modules.
    *
    * @Given the/these module/modules is/are enabled
@@ -72,7 +72,7 @@ class ModuleContext extends RawDrupalContext {
    * | Events      |
    * | Links       |
    *
-   * @param TableNode $featureset_table
+   * @param Behat\Gherkin\Node\TableNode $featureset_table
    *   The table listing feature set titles.
    *
    * @Given the/these featureSet/FeatureSets is/are enabled

--- a/tests/src/Context/MultilingualContext.php
+++ b/tests/src/Context/MultilingualContext.php
@@ -60,7 +60,7 @@ class MultilingualContext extends RawDrupalContext implements DrupalSubContextIn
   /**
    * Constructs a NextEuropaMultilingualSubContext object.
    *
-   * @param DrupalDriverManager $drupal
+   * @param Drupal\DrupalDriverManager $drupal
    *   The Drupal driver manager.
    */
   public function __construct(DrupalDriverManager $drupal) {
@@ -84,7 +84,7 @@ class MultilingualContext extends RawDrupalContext implements DrupalSubContextIn
    *
    * @param string $type
    *    Content type machine name.
-   * @param TableNode $table
+   * @param Behat\Gherkin\Node\TableNode $table
    *    List of available languages and field translations.
    *
    * @return object
@@ -143,7 +143,7 @@ class MultilingualContext extends RawDrupalContext implements DrupalSubContextIn
    *    Content type machine name.
    * @param string $title
    *    Source node title.
-   * @param TableNode $table
+   * @param Behat\Gherkin\Node\TableNode $table
    *    List of available languages and field translations.
    *
    * @Then I create the following translations for :type content with title :arg2:
@@ -231,7 +231,7 @@ class MultilingualContext extends RawDrupalContext implements DrupalSubContextIn
    *
    * @param string $type
    *    Content type machine name.
-   * @param TableNode $table
+   * @param Behat\Gherkin\Node\TableNode $table
    *    List of available languages and title translations.
    *
    * @throws \InvalidArgumentException

--- a/tests/src/Context/PiwikRulesContext.php
+++ b/tests/src/Context/PiwikRulesContext.php
@@ -94,7 +94,7 @@ class PiwikRulesContext implements Context {
 
     \bovigo\assert\assert($rows, isOfSize(count($expected_rules)));
 
-    /** @var Element $row */
+    /** @var Behat\Mink\Element\Element $row */
     foreach (array_values($rows) as $i => $row) {
       $expected_rule = $expected_rules[$i];
 
@@ -105,7 +105,7 @@ class PiwikRulesContext implements Context {
   /**
    * Gets the PIWIK rules overview.
    *
-   * @return Element
+   * @return Behat\Mink\Element\Element
    *   The table body.
    */
   protected function getPiwikRulesOverview() {
@@ -117,13 +117,13 @@ class PiwikRulesContext implements Context {
   /**
    * Asserts a particular row from the PIWIK rules overview.
    *
-   * @param Element $row
+   * @param Behat\Mink\Element\Element $row
    *   The table row.
    * @param array $expected_rule
    *   The expected values for the PIWIK rule.
    */
   protected function assertOverviewPiwikRule(Element $row, array $expected_rule) {
-    /** @var Element[] $cells */
+    /** @var Behat\Mink\Element\Element[] $cells */
     $cells = $row->findAll('css', 'td');
     assert($cells[1]->getText(), equals($expected_rule['Rule section']));
     assert($cells[2]->getText(), equals($expected_rule['Rule language']));


### PR DESCRIPTION
## [NEPT-1384](https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1384)

### Description
 Fix QA automation rules be fully namespaced.
 ISSUE:
   - To follow the QA suggestion rule Drupal.Commenting.DataTypeNamespace.DataTypeNamespace  
   we should be removed.
   - By running phpcs fire up some errors regarding Coding standard and best practices

### Changed log
   - Changed: Remove the rule mention above.

   - Fixed: 
       Run phpcs and address all outcome issue.
       The solution to the most of the issues are the params, vars full namespacing and typo missing
       -  Fixed on behat context files.

       -  Fixed on common features files.

       -  Fixed on common custom modules files.

### Commands

[No commands]


