### PR TITLE
NEPT-1383: Fix QA automation rules - The static declaration must come…

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -573,11 +573,6 @@
         <exclude-pattern>*</exclude-pattern>
     </rule>
 
-    <!-- The static declaration must come after the visibility declaration. -->
-    <rule ref="Drupal.Methods.MethodDeclaration.StaticBeforeVisibility">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
     <!-- Data types in @param tags need to be fully namespaced. -->
     <rule ref="Drupal.Commenting.DataTypeNamespace.DataTypeNamespace">
         <exclude-pattern>*</exclude-pattern>

--- a/profiles/common/modules/custom/nexteuropa_laco/src/LanguageCoverageService.php
+++ b/profiles/common/modules/custom/nexteuropa_laco/src/LanguageCoverageService.php
@@ -63,7 +63,7 @@ class LanguageCoverageService {
   /**
    * {@inheritdoc}
    */
-  static public function getInstance() {
+  public static function getInstance() {
     if (!self::$instance) {
       self::$instance = new static();
     }
@@ -73,7 +73,7 @@ class LanguageCoverageService {
   /**
    * {@inheritdoc}
    */
-  static public function isServiceRequest() {
+  public static  function isServiceRequest() {
     $header = self::getHeaderKey(self::HTTP_HEADER_SERVICE_NAME);
     $result = isset($_SERVER['REQUEST_METHOD']) && ($_SERVER['REQUEST_METHOD'] == self::HTTP_METHOD);
     $result = $result && isset($_SERVER[$header]) && ($_SERVER[$header] == self::HTTP_HEADER_SERVICE_VALUE);
@@ -357,7 +357,7 @@ class LanguageCoverageService {
    * @return string
    *    Header name as a $_SERVER array key.
    */
-  static protected function getHeaderKey($header) {
+  protected static function getHeaderKey($header) {
     $header = 'HTTP_' . strtoupper($header);
     return str_replace('-', '_', $header);
   }


### PR DESCRIPTION
  ## [NEPT-1383](https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1383)

### Description

### Changed log:
   - Removed: The rule (The static declaration must come after the visibility declaration)
```sh
     <rule ref="Drupal.Methods.MethodDeclaration.StaticBeforeVisibility">
        <exclude-pattern>*</exclude-pattern>
    </rule>
```

   - Fixed: The errors reported by phpcs
