### PR TITLE
NEPT-1375: Remove the "Drupal.Commenting.FileComment.NamespaceNoFileDoc" rule

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -533,11 +533,6 @@
         <exclude-pattern>*</exclude-pattern>
     </rule>
 
-    <!-- Namespaced classes, interfaces and traits should not begin with a file doc comment. -->
-    <rule ref="Drupal.Commenting.FileComment.NamespaceNoFileDoc">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
     <!-- Parameter comment indentation must be 3 spaces. -->
     <rule ref="Drupal.Commenting.FunctionComment.ParamCommentIndentation">
         <exclude-pattern>*</exclude-pattern>

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/block/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/block/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\block\\Config.
- */
-
 namespace Drupal\block;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/comment/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/comment/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\comment\\Config.
- */
-
 namespace Drupal\comment;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/context/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/context/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\context\\Config.
- */
-
 namespace Drupal\context;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/entity_translation/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/entity_translation/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\entity_translation\\Config.
- */
-
 namespace Drupal\entity_translation;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/features/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/features/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\features\\Config.
- */
-
 namespace Drupal\features;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/field/BaseField/DefaultFieldHandler.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/field/BaseField/DefaultFieldHandler.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\field\BaseField\DefaultFieldHandler.
- */
-
 namespace Drupal\field\BaseField;
 use Drupal\field\FieldHandlerInterface;
 

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/field/BaseField/TaxonomyTermReferenceFieldHandler.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/field/BaseField/TaxonomyTermReferenceFieldHandler.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\field\BaseField\TaxonomyTermReferenceFieldHandler.
- */
-
 namespace Drupal\field\BaseField;
 
 /**

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/field/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/field/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\field\\Config.
- */
-
 namespace Drupal\field;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/field/FieldHandlerInterface.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/field/FieldHandlerInterface.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\field\FieldHandlerInterface.
- */
-
 namespace Drupal\field;
 
 /**

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/field/InstanceField/DefaultFieldHandler.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/field/InstanceField/DefaultFieldHandler.php
@@ -1,11 +1,7 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\field\InstanceField\DefaultFieldHandler.
- */
-
 namespace Drupal\field\InstanceField;
+
 use Drupal\field\FieldHandlerInterface;
 
 /**

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/field_group/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/field_group/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\field_group\\Config.
- */
-
 namespace Drupal\field_group;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/field_group/FieldGroupHandler.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/field_group/FieldGroupHandler.php
@@ -1,13 +1,6 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\field\InstanceField\DefaultFieldHandler.
- */
-
 namespace Drupal\field_group;
-
-use Drupal\field_group\Config;
 
 /**
  * Class DefaultFieldHandler.

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/field_group/FieldGroupHandlerInterface.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/field_group/FieldGroupHandlerInterface.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\field_group\FieldGroupHandlerInterface.
- */
-
 namespace Drupal\field_group;
 
 /**

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/filter/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/filter/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\filter\\Config.
- */
-
 namespace Drupal\filter;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/linkchecker/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/linkchecker/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\linkchecker\\Config.
- */
-
 namespace Drupal\linkchecker;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/locale/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/locale/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\locale\\Config.
- */
-
 namespace Drupal\locale;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/menu/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/menu/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\menu\\Config.
- */
-
 namespace Drupal\menu;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/og/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/og/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\og\\Config.
- */
-
 namespace Drupal\og;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/pathauto/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/pathauto/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\pathauto\\Config.
- */
-
 namespace Drupal\pathauto;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/scheduler/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/scheduler/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\scheduler\\Config.
- */
-
 namespace Drupal\scheduler;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/system/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/system/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\system\\Config.
- */
-
 namespace Drupal\system;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/taxonomy/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/taxonomy/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\taxonomy\\Config.
- */
-
 namespace Drupal\taxonomy;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/title/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/title/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\title\\Config.
- */
-
 namespace Drupal\title;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/tmgmt/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/tmgmt/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\tmgmt\\Config.
- */
-
 namespace Drupal\tmgmt;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/user/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/user/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\user\\Config.
- */
-
 namespace Drupal\user;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/workbench_moderation/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/workbench_moderation/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\workbench_moderation\\Config.
- */
-
 namespace Drupal\workbench_moderation;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/custom/multisite_config/lib/Drupal/wysiwyg/Config.php
+++ b/profiles/common/modules/custom/multisite_config/lib/Drupal/wysiwyg/Config.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \\Drupal\\block\\Config.
- */
 
 namespace Drupal\wysiwyg;
 

--- a/profiles/common/modules/custom/multisite_config/src/ConfigBase.php
+++ b/profiles/common/modules/custom/multisite_config/src/ConfigBase.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\multisite_config\\ConfigBase.
- */
-
-// @cond DEV
 namespace Drupal\multisite_config;
 
 /**
@@ -37,4 +31,4 @@ class ConfigBase {
   }
 
 }
-// @endcond
+

--- a/profiles/common/modules/custom/multisite_config/tests/ConfigAbstractTest.php
+++ b/profiles/common/modules/custom/multisite_config/tests/ConfigAbstractTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Class \Drupal\multisite_config\Tests\NextEuropaDataExportAbstractTest.
- */
-
 namespace Drupal\multisite_config\Tests;
 
 /**

--- a/profiles/common/modules/custom/multisite_config/tests/ConfigBaseTest.php
+++ b/profiles/common/modules/custom/multisite_config/tests/ConfigBaseTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Class \Drupal\multisite_config\Tests\NextEuropaDataExportAbstractTest.
- */
-
 namespace Drupal\multisite_config\Tests;
 
 /**

--- a/profiles/common/modules/custom/multisite_config/tests/Drupal/field/BaseField/DefaultFieldHandlerTest.php
+++ b/profiles/common/modules/custom/multisite_config/tests/Drupal/field/BaseField/DefaultFieldHandlerTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains test class.
- */
-
 namespace Drupal\multisite_config\Tests\Drupal\field\BaseField;
 
 use Drupal\multisite_config\Tests\ConfigAbstractTest;

--- a/profiles/common/modules/custom/multisite_config/tests/Drupal/field/BaseField/TaxonomyTermReferenceFieldHandlerTest.php
+++ b/profiles/common/modules/custom/multisite_config/tests/Drupal/field/BaseField/TaxonomyTermReferenceFieldHandlerTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains test class.
- */
-
 namespace Drupal\multisite_config\Tests\Drupal\field\BaseField;
 
 use Drupal\multisite_config\Tests\ConfigAbstractTest;

--- a/profiles/common/modules/custom/multisite_config/tests/Drupal/field/ConfigTest.php
+++ b/profiles/common/modules/custom/multisite_config/tests/Drupal/field/ConfigTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\multisite_config\Tests\Drupal\field.
- */
-
 namespace Drupal\multisite_config\Tests\Drupal\field;
 
 use Drupal\multisite_config\Tests\ConfigAbstractTest;

--- a/profiles/common/modules/custom/multisite_config/tests/Drupal/field/InstanceField/DefaultFieldHandlerTest.php
+++ b/profiles/common/modules/custom/multisite_config/tests/Drupal/field/InstanceField/DefaultFieldHandlerTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains test class.
- */
-
 namespace Drupal\multisite_config\Tests\Drupal\field\InstanceField;
 
 use Drupal\multisite_config\Tests\ConfigAbstractTest;

--- a/profiles/common/modules/custom/multisite_config/tests/Drupal/field_group/ConfigTest.php
+++ b/profiles/common/modules/custom/multisite_config/tests/Drupal/field_group/ConfigTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\multisite_config\Tests\Drupal\field_group.
- */
-
 namespace Drupal\multisite_config\Tests\Drupal\field_group;
 
 use Drupal\multisite_config\Tests\ConfigAbstractTest;

--- a/profiles/common/modules/custom/multisite_config/tests/Drupal/taxonomy/ConfigTest.php
+++ b/profiles/common/modules/custom/multisite_config/tests/Drupal/taxonomy/ConfigTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\multisite_config\Tests\NextEuropaDataExportTest.
- */
-
 namespace Drupal\multisite_config\Tests\Drupal\taxonomy;
 
 use Drupal\multisite_config\Tests\ConfigAbstractTest;

--- a/profiles/common/modules/custom/nexteuropa_data_export/tests/NextEuropaDataExportAbstractTest.php
+++ b/profiles/common/modules/custom/nexteuropa_data_export/tests/NextEuropaDataExportAbstractTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Class \Drupal\nexteuropa_data_export\Tests\NextEuropaDataExportAbstractTest.
- */
-
 namespace Drupal\nexteuropa_data_export\Tests;
 
 use Behat\Mink\Mink;

--- a/profiles/common/modules/custom/nexteuropa_data_export/tests/NextEuropaDataExportTest.php
+++ b/profiles/common/modules/custom/nexteuropa_data_export/tests/NextEuropaDataExportTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_data_export\Tests\NextEuropaDataExportTest.
- */
-
 namespace Drupal\nexteuropa_data_export\Tests;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_laco/src/LanguageCoverageService.php
+++ b/profiles/common/modules/custom/nexteuropa_laco/src/LanguageCoverageService.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_laco\LanguageCoverageService.
- */
-
 namespace Drupal\nexteuropa_laco;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_laco/tests/LanguageCoverageServiceTest.php
+++ b/profiles/common/modules/custom/nexteuropa_laco/tests/LanguageCoverageServiceTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_laco\Tests\LanguageCoverageServiceTest.
- */
-
 namespace Drupal\nexteuropa_laco\Tests;
 
 use Drupal\nexteuropa_laco\LanguageCoverageService as Service;

--- a/profiles/common/modules/custom/nexteuropa_piwik/src/Entity/PiwikRule.php
+++ b/profiles/common/modules/custom/nexteuropa_piwik/src/Entity/PiwikRule.php
@@ -1,10 +1,7 @@
 <?php
-/**
- * @file
- * Definition of Drupal\nexteuropa_piwik\Entity\PiwikRule.
- */
 
 namespace Drupal\nexteuropa_piwik\Entity;
+
 use \Entity;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_piwik/src/EntityDefaultUIController/PiwikRuleEntityUIController.php
+++ b/profiles/common/modules/custom/nexteuropa_piwik/src/EntityDefaultUIController/PiwikRuleEntityUIController.php
@@ -1,10 +1,7 @@
 <?php
-/**
- * @file
- * Definition of PiwikRuleEntityUIController.
- */
 
 namespace Drupal\nexteuropa_piwik\EntityDefaultUIController;
+
 use \EntityDefaultUIController;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/BaseUrlTokenHandler.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/BaseUrlTokenHandler.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\BaseUrlTokenHandler.
- */
-
 namespace Drupal\nexteuropa_token;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/Entity/LinkTokenHandler.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/Entity/LinkTokenHandler.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Entity\LinkTokenHandler.
- */
-
 namespace Drupal\nexteuropa_token\Entity;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/Entity/TokenAbstractHandler.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/Entity/TokenAbstractHandler.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Entity\TokenAbstractHandler.
- */
-
 namespace Drupal\nexteuropa_token\Entity;
 
 use Drupal\nexteuropa_token\TokenAbstractHandler as BaseTokenAbstractHandler;

--- a/profiles/common/modules/custom/nexteuropa_token/src/Entity/TokenHandlerInterface.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/Entity/TokenHandlerInterface.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Entity\TokenHandlerInterface.
- */
-
 namespace Drupal\nexteuropa_token\Entity;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/Entity/UrlTokenHandler.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/Entity/UrlTokenHandler.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Entity\UrlTokenHandler.
- */
-
 namespace Drupal\nexteuropa_token\Entity;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeTokenHandler.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeTokenHandler.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Entity\ViewModeTokenHandler.
- */
-
 namespace Drupal\nexteuropa_token\Entity;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/BeanViewModeType.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/BeanViewModeType.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Entity\ViewModeType\BeanViewModeType.
- */
-
 namespace Drupal\nexteuropa_token\Entity\ViewModeType;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/NodeViewModeType.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/NodeViewModeType.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Entity\ViewModeType\NodeViewModeType.
- */
-
 namespace Drupal\nexteuropa_token\Entity\ViewModeType;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/TermViewModeType.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/TermViewModeType.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Entity\ViewModeType\TermViewModeType.
- */
-
 namespace Drupal\nexteuropa_token\Entity\ViewModeType;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/UserViewModeType.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/UserViewModeType.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Entity\ViewModeType\UserViewModeType.
- */
-
 namespace Drupal\nexteuropa_token\Entity\ViewModeType;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/ViewModeTypeBase.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/ViewModeTypeBase.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Entity\ViewModeType\ViewModeTypeBase.
- */
-
 namespace Drupal\nexteuropa_token\Entity\ViewModeType;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/ViewModeTypeInterface.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/Entity/ViewModeType/ViewModeTypeInterface.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Entity\ViewModeType\ViewModeTypeInterface.
- */
-
 namespace Drupal\nexteuropa_token\Entity\ViewModeType;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/HashTokenHandler.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/HashTokenHandler.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\HashTokenHandler.
- */
-
 namespace Drupal\nexteuropa_token;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/TokenAbstractHandler.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/TokenAbstractHandler.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\TokenAbstractHandler.
- */
-
 namespace Drupal\nexteuropa_token;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/src/TokenHandlerInterface.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/TokenHandlerInterface.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\TokenHandlerInterface.
- */
-
 namespace Drupal\nexteuropa_token;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/tests/Entity/LinkEntityTokenHandlerTest.php
+++ b/profiles/common/modules/custom/nexteuropa_token/tests/Entity/LinkEntityTokenHandlerTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Tests\LinkEntityTokenHandlerTest.
- */
-
 namespace Drupal\nexteuropa_token\Tests\Entity;
 
 use Drupal\nexteuropa_token\Entity\LinkTokenHandler;

--- a/profiles/common/modules/custom/nexteuropa_token/tests/Entity/UrlEntityTokenHandlerTest.php
+++ b/profiles/common/modules/custom/nexteuropa_token/tests/Entity/UrlEntityTokenHandlerTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Tests\UrlEntityTokenHandlerTest.
- */
-
 namespace Drupal\nexteuropa_token\Tests\Entity;
 
 use Drupal\nexteuropa_token\Entity\UrlTokenHandler;

--- a/profiles/common/modules/custom/nexteuropa_token/tests/Entity/ViewModeEntityTokenHandlerTest.php
+++ b/profiles/common/modules/custom/nexteuropa_token/tests/Entity/ViewModeEntityTokenHandlerTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Tests\ViewModeEntityTokenHandlerTest.
- */
-
 namespace Drupal\nexteuropa_token\Tests\Entity;
 
 use Drupal\nexteuropa_token\Entity\ViewModeTokenHandler;

--- a/profiles/common/modules/custom/nexteuropa_token/tests/HashTokenHandlerTest.php
+++ b/profiles/common/modules/custom/nexteuropa_token/tests/HashTokenHandlerTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Tests\HashTokenHandlerTest.
- */
-
 namespace Drupal\nexteuropa_token\Tests;
 
 use Drupal\nexteuropa_token\HashTokenHandler;

--- a/profiles/common/modules/custom/nexteuropa_token/tests/PoetryTokenProcessorsTest.php
+++ b/profiles/common/modules/custom/nexteuropa_token/tests/PoetryTokenProcessorsTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Tests\PoetryTokenProcessorsTest.
- */
-
 namespace Drupal\nexteuropa_token\Tests;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/tests/TokenHandlerAbstractTest.php
+++ b/profiles/common/modules/custom/nexteuropa_token/tests/TokenHandlerAbstractTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Tests\TokenHandlerAbstractTest.
- */
-
 namespace Drupal\nexteuropa_token\Tests;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/tests/TokenHandlerTest.php
+++ b/profiles/common/modules/custom/nexteuropa_token/tests/TokenHandlerTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token\Tests\TokenHandlerTest.
- */
-
 namespace Drupal\nexteuropa_token\Tests;
 
 /**

--- a/profiles/common/modules/custom/nexteuropa_token/tests/nexteuropa_token_test/src/TestTokenHandler.php
+++ b/profiles/common/modules/custom/nexteuropa_token/tests/nexteuropa_token_test/src/TestTokenHandler.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_token_test\TestTokenHandler.
- */
-
 namespace Drupal\nexteuropa_token_test;
 
 use Drupal\nexteuropa_token\Entity\UrlTokenHandler;

--- a/profiles/common/modules/custom/nexteuropa_varnish/src/Entity/PurgeRule.php
+++ b/profiles/common/modules/custom/nexteuropa_varnish/src/Entity/PurgeRule.php
@@ -1,10 +1,7 @@
 <?php
-/**
- * @file
- * Definition of Drupal\nexteuropa_varnish\Entity\PurgeRule.
- */
 
 namespace Drupal\nexteuropa_varnish\Entity;
+
 use Drupal\nexteuropa_varnish\PurgeRuleType;
 use \Entity;
 

--- a/profiles/common/modules/custom/nexteuropa_varnish/src/PurgeRuleController.php
+++ b/profiles/common/modules/custom/nexteuropa_varnish/src/PurgeRuleController.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains Drupal\nexteuropa_varnish\PurgeRuleController.
- */
 
 namespace Drupal\nexteuropa_varnish;
 

--- a/profiles/common/modules/custom/nexteuropa_varnish/src/PurgeRuleType.php
+++ b/profiles/common/modules/custom/nexteuropa_varnish/src/PurgeRuleType.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Definition of Drupal\nexteuropa_varnish\PurgeRuleType.
- */
 
 namespace Drupal\nexteuropa_varnish;
 

--- a/profiles/common/modules/custom/version_management/src/Config.php
+++ b/profiles/common/modules/custom/version_management/src/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \\Drupal\\version_management\\Config.
- */
-
 namespace Drupal\version_management;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/features/nexteuropa_core/src/Config.php
+++ b/profiles/common/modules/features/nexteuropa_core/src/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_core\Config.
- */
-
 namespace Drupal\nexteuropa_core;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/features/nexteuropa_core/src/Tests/HookAlterTest.php
+++ b/profiles/common/modules/features/nexteuropa_core/src/Tests/HookAlterTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa_core\Tests\HookAlterTest.
- */
-
 namespace Drupal\nexteuropa_core\Tests;
 
 use Drupal\nexteuropa\Unit\AbstractUnitTest;

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/src/Mock/PoetryMock.php
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/src/Mock/PoetryMock.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains Drupal\tmgmt_poetry_mock\Mock\PoetryMock.
- */
-
 namespace Drupal\tmgmt_poetry_mock\Mock;
 
 /**

--- a/profiles/common/modules/features/nexteuropa_editorial/src/Config.php
+++ b/profiles/common/modules/features/nexteuropa_editorial/src/Config.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Multisite\Config\Features\nexteuropa_editorial\Config.
- */
-
 namespace Drupal\nexteuropa_editorial;
 
 use Drupal\multisite_config\ConfigBase;

--- a/profiles/common/modules/features/nexteuropa_integration/src/ClosureDecoratedMigrateSourceBackend.php
+++ b/profiles/common/modules/features/nexteuropa_integration/src/ClosureDecoratedMigrateSourceBackend.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa_integration\ClosureDecoratedMigrateSourceBackend.
- */
 
 namespace Drupal\nexteuropa_integration;
 

--- a/profiles/common/modules/features/nexteuropa_trackedchanges/src/Entity/NETCInfo.php
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/src/Entity/NETCInfo.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa_trackedchanges\Entity\NETCInfo.
- */
 
 namespace Drupal\nexteuropa_trackedchanges\Entity;
 

--- a/profiles/common/modules/features/nexteuropa_trackedchanges/src/NETCInfoController.php
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/src/NETCInfoController.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains Drupal\nexteuropa_trackedchanges\NETCInfoController.
- */
 
 namespace Drupal\nexteuropa_trackedchanges;
 

--- a/src/Phing/PhpCodeSnifferConfigurationTask.php
+++ b/src/Phing/PhpCodeSnifferConfigurationTask.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \NextEuropa\build\Phing\PhpCodeSnifferConfigurationTask.
- */
-
 namespace NextEuropa\Phing;
 
 require_once 'phing/Task.php';

--- a/tests/src/Component/PyStringYamlParser.php
+++ b/tests/src/Component/PyStringYamlParser.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa\Component\PyStringYamlParser.
- */
-
 namespace Drupal\nexteuropa\Component;
 
 use Behat\Gherkin\Node\PyStringNode;

--- a/tests/src/Component/Utility/Transliterate.php
+++ b/tests/src/Component/Utility/Transliterate.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa\Component\Utility\Transliterate.
- */
-
 namespace Drupal\nexteuropa\Component\Utility;
 
 /**

--- a/tests/src/Context/AgnosticBatchContext.php
+++ b/tests/src/Context/AgnosticBatchContext.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\AgnosticBatchContext.
- */
-
 namespace Drupal\nexteuropa\Context;
 
 use Behat\MinkExtension\Context\RawMinkContext;

--- a/tests/src/Context/ApacheSolrContext.php
+++ b/tests/src/Context/ApacheSolrContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\FrontendCacheContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/BeanContext.php
+++ b/tests/src/Context/BeanContext.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\BeanContext.
- */
-
 namespace Drupal\nexteuropa\Context;
 
 use Behat\Behat\Context\Context;

--- a/tests/src/Context/BlockContext.php
+++ b/tests/src/Context/BlockContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\BlockContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/CKEditorContext.php
+++ b/tests/src/Context/CKEditorContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\CKEditorContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/ContentTypeContext.php
+++ b/tests/src/Context/ContentTypeContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\FieldContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/ContextUtil.php
+++ b/tests/src/Context/ContextUtil.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\ContextUtil.
- */
-
 namespace Drupal\nexteuropa\Context;
 
 /**

--- a/tests/src/Context/DatabaseLogContext.php
+++ b/tests/src/Context/DatabaseLogContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\DatabaseLogContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/DrupalContext.php
+++ b/tests/src/Context/DrupalContext.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\DrupalContext.
- */
-
 namespace Drupal\nexteuropa\Context;
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;

--- a/tests/src/Context/DrupalMailContext.php
+++ b/tests/src/Context/DrupalMailContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains DrupalMailContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/DrushContext.php
+++ b/tests/src/Context/DrushContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\DrushContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/EcasContext.php
+++ b/tests/src/Context/EcasContext.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\DrupalContext.
- */
-
 namespace Drupal\nexteuropa\Context;
 
 use Drupal\DrupalExtension\Context\RawDrupalContext;

--- a/tests/src/Context/FieldContext.php
+++ b/tests/src/Context/FieldContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\FieldContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/FlickrContext.php
+++ b/tests/src/Context/FlickrContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\FlickrContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/FormContext.php
+++ b/tests/src/Context/FormContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\FormContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/FrontendCacheContext.php
+++ b/tests/src/Context/FrontendCacheContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\FrontendCacheContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/IntegrationLayerContext.php
+++ b/tests/src/Context/IntegrationLayerContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\IntegrationLayerContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/MediaContext.php
+++ b/tests/src/Context/MediaContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\MediaContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/MessageContext.php
+++ b/tests/src/Context/MessageContext.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\MessageContext.
- */
-
 namespace Drupal\nexteuropa\Context;
 
 use Behat\Gherkin\Node\PyStringNode;

--- a/tests/src/Context/MinkContext.php
+++ b/tests/src/Context/MinkContext.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\MinkContext.
- */
-
 namespace Drupal\nexteuropa\Context;
 
 use Behat\Gherkin\Node\PyStringNode;

--- a/tests/src/Context/ModuleContext.php
+++ b/tests/src/Context/ModuleContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\ModuleContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/MultilingualContext.php
+++ b/tests/src/Context/MultilingualContext.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\MultilingualContext.
- */
-
 namespace Drupal\nexteuropa\Context;
 
 use Drupal\DrupalDriverManager;

--- a/tests/src/Context/PathautoContext.php
+++ b/tests/src/Context/PathautoContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\PathautoContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/PiwikRulesContext.php
+++ b/tests/src/Context/PiwikRulesContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\FrontendCacheContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/SchedulerContext.php
+++ b/tests/src/Context/SchedulerContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\SchedulerContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/TaxonomyContext.php
+++ b/tests/src/Context/TaxonomyContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\TaxonomyContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/VariableContext.php
+++ b/tests/src/Context/VariableContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\VariableContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Context/ViewsContext.php
+++ b/tests/src/Context/ViewsContext.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\ViewsContext.
- */
-
 namespace Drupal\nexteuropa\Context;
 
 use Drupal\DrupalExtension\Context\RawDrupalContext;

--- a/tests/src/Context/WebtoolsContext.php
+++ b/tests/src/Context/WebtoolsContext.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains \Drupal\nexteuropa\Context\WebtoolsContext.
- */
 
 namespace Drupal\nexteuropa\Context;
 

--- a/tests/src/Extensions/DrupalExtension.php
+++ b/tests/src/Extensions/DrupalExtension.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains Drupal\nexteuropa\DrupalExtension\ServiceContainer.
- */
-
 namespace Drupal\nexteuropa\Extensions;
 
 use Drupal\DrupalExtension\ServiceContainer\DrupalExtension as OriginalDrupalExtension;

--- a/tests/src/Extensions/TransformExtension.php
+++ b/tests/src/Extensions/TransformExtension.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains Drupal\nexteuropa\Extensions\TransformExtension.
- */
-
 namespace Drupal\nexteuropa\Extensions;
 
 use Behat\Testwork\ServiceContainer\Extension as ExtensionInterface;

--- a/tests/src/Transformation/Transformer/ArgumentTransformer.php
+++ b/tests/src/Transformation/Transformer/ArgumentTransformer.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * @file
- * Contains Drupal\nexteuropa\Transformation\Transformer\ArgumentTransformer.
- */
 
 namespace Drupal\nexteuropa\Transformation\Transformer;
 

--- a/tests/src/Unit/AbstractUnitTest.php
+++ b/tests/src/Unit/AbstractUnitTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\nexteuropa\Unit\AbstractUnitTest.
- */
-
 namespace Drupal\nexteuropa\Unit;
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
## NEPT-1375

### Description

Namespaced classes, interfaces and traits should not begin with a file doc comment.

### Change log

- Removed: "Drupal.Commenting.FileComment.NamespaceNoFileDoc" rule from phpcs-qa-roadmap.xml
- Removed: "@file" comment on the existing namespaced classes, interfaces and traits


### Commands

```sh
No required command.

```

