### PR TITLE
NEPT-1385 Namespaced classes/interfaces/traits with "use" statements

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -583,11 +583,6 @@
         <exclude-pattern>*</exclude-pattern>
     </rule>
 
-    <!-- Namespaced classes/interfaces/traits should be referenced with use statements. -->
-    <rule ref="Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
     <!-- When importing a class with "use", do not include a leading. -->
     <rule ref="Drupal.Classes.UseLeadingBackslash.SeparatorStart">
         <exclude-pattern>*</exclude-pattern>

--- a/profiles/common/modules/custom/nexteuropa_laco/src/nexteuropa_laco.behat.inc
+++ b/profiles/common/modules/custom/nexteuropa_laco/src/nexteuropa_laco.behat.inc
@@ -10,6 +10,7 @@ use Drupal\DrupalExtension\Context\DrupalSubContextInterface;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 use Drupal\nexteuropa_laco\LanguageCoverageService as Service;
 use Behat\Gherkin\Node\TableNode;
+use GuzzleHttp\Client;
 
 /**
  * Behat step definitions for the NextEuropa Multilingual module.
@@ -55,7 +56,7 @@ class NextEuropaLacoSubContext extends RawDrupalContext implements DrupalSubCont
   public function assertLanguageCoverage($code, $language, $path, $message = '') {
     global $base_url;
 
-    $client = new \GuzzleHttp\Client([
+    $client = new Client([
       'headers' => [
         Service::HTTP_HEADER_SERVICE_NAME => Service::HTTP_HEADER_SERVICE_VALUE,
         Service::HTTP_HEADER_LANGUAGE_NAME => $language,

--- a/profiles/common/modules/custom/nexteuropa_laco/tests/LanguageCoverageServiceTest.php
+++ b/profiles/common/modules/custom/nexteuropa_laco/tests/LanguageCoverageServiceTest.php
@@ -8,7 +8,7 @@
 namespace Drupal\nexteuropa_laco\Tests;
 
 use Drupal\nexteuropa_laco\LanguageCoverageService as Service;
-
+use GuzzleHttp\Client;
 
 /**
  * Class LanguageCoverageServiceTest.
@@ -56,7 +56,7 @@ class LanguageCoverageServiceTest extends \PHPUnit_Framework_TestCase {
    *    Response object instance.
    */
   protected function request($path, $language = 'en') {
-    $client = new \GuzzleHttp\Client([
+    $client = new Client([
       'headers' => [
         Service::HTTP_HEADER_SERVICE_NAME => Service::HTTP_HEADER_SERVICE_VALUE,
         Service::HTTP_HEADER_LANGUAGE_NAME => $language,

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/inc/tmgmt_poetry.webservice.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/inc/tmgmt_poetry.webservice.inc
@@ -4,6 +4,8 @@
  * Webservice definition and behaviour.
  */
 
+use Drupal\tmgmt_poetry_mock\Mock\PoetryMock;
+
 /**
  * Log message severity -- Emergency: system is unusable.
  */
@@ -106,7 +108,7 @@ function FPFISPoetryIntegrationRequest($user, $password, $msg) {
 
   // Use the Poetry Mock translator if the tmgmt_poetry_mock is enabled.
   if (module_exists('tmgmt_poetry_mock')) {
-    $poetry_translator = tmgmt_translator_load(\Drupal\tmgmt_poetry_mock\Mock\PoetryMock::TRANSLATOR_NAME);
+    $poetry_translator = tmgmt_translator_load(PoetryMock::TRANSLATOR_NAME);
   }
 
   // Authenticate the request.

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/includes/tmgmt_poetry_mock.server.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/includes/tmgmt_poetry_mock.server.inc
@@ -4,6 +4,8 @@
  * Page callbacks for the mocked Poetry server.
  */
 
+use Drupal\tmgmt_poetry_mock\Mock\PoetryMock;
+
 /**
  * A page callback which simulate poetry webservice.
  */
@@ -11,7 +13,7 @@ function _tmgmt_poetry_mock_soap_server() {
   $poetry_wsdl = _tmgmt_poetry_mock_get_poetry_service_wsdl();
   $options = ['uri' => _tmgmt_poetry_mock_get_poetry_service_endpoint()];
   $server = new \SoapServer($poetry_wsdl, $options);
-  $server->setClass(\Drupal\tmgmt_poetry_mock\Mock\PoetryMock::class);
+  $server->setClass(PoetryMock::class);
   $server->handle();
 }
 

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/src/Mock/PoetryMock.php
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/src/Mock/PoetryMock.php
@@ -148,7 +148,7 @@ class PoetryMock {
    */
   public function sendRequestToDrupal($message) {
     $this->instantiateClient($this->settings['drupal_wsdl']);
-    $translator = tmgmt_translator_load(\Drupal\tmgmt_poetry_mock\Mock\PoetryMock::TRANSLATOR_NAME);
+    $translator = tmgmt_translator_load(self::TRANSLATOR_NAME);
     $settings = $translator->getSetting('settings');
     try {
       $response = $this->client->{self::SOAP_METHOD}(
@@ -736,21 +736,21 @@ class PoetryMock {
   public static function importMockTranslator() {
     /** @var \EntityDrupalWrapper $translator */
     $translator = entity_import('tmgmt_translator', '{
-    "name" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::TRANSLATOR_NAME . '",
-    "label" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::TRANSLATOR_LABEL . '",
+    "name" : "' . self::TRANSLATOR_NAME . '",
+    "label" : "' . self::TRANSLATOR_LABEL . '",
     "description" : "",
     "weight" : "-999",
     "plugin" : "poetry",
     "settings" : {
       "auto_accept" : 0,
       "settings" : {
-        "counter" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::COUNTER_STRING . '",
+        "counter" : "' . self::COUNTER_STRING . '",
         "code" : "WEB",
         "website_identifier" : "my-website",
-        "callback_user" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::CALLBACK_USER . '",
-        "callback_password" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::CALLBACK_PASSWORD . '",
-        "poetry_user" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::POETRY_USER . '",
-        "poetry_password" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::POETRY_PASSWORD . '"
+        "callback_user" : "' . self::CALLBACK_USER . '",
+        "callback_password" : "' . self::CALLBACK_PASSWORD . '",
+        "poetry_user" : "' . self::POETRY_USER . '",
+        "poetry_password" : "' . self::POETRY_PASSWORD . '"
       },
       "organization" : {
         "responsable" : "DIGIT",
@@ -771,6 +771,7 @@ class PoetryMock {
     },
     "rdf_mapping" : []
   }');
+
     $translator->save();
   }
 

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/tmgmt_poetry_mock.install
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/tmgmt_poetry_mock.install
@@ -4,27 +4,29 @@
  * Install file.
  */
 
+use Drupal\tmgmt_poetry_mock\Mock\PoetryMock;
+
 /**
  * Implements hook_install().
  */
 function tmgmt_poetry_mock_install() {
   /** @var EntityDrupalWrapper $translator */
   $translator = entity_import('tmgmt_translator', '{
-    "name" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::TRANSLATOR_NAME . '",
-    "label" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::TRANSLATOR_LABEL . '",
+    "name" : "' . PoetryMock::TRANSLATOR_NAME . '",
+    "label" : "' . PoetryMock::TRANSLATOR_LABEL . '",
     "description" : "",
     "weight" : "-999",
     "plugin" : "poetry",
     "settings" : {
       "auto_accept" : 0,
       "settings" : {
-        "counter" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::COUNTER_STRING . '",
+        "counter" : "' . PoetryMock::COUNTER_STRING . '",
         "code" : "WEB",
         "website_identifier" : "my-website",
-        "callback_user" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::CALLBACK_USER . '",
-        "callback_password" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::CALLBACK_PASSWORD . '",
-        "poetry_user" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::POETRY_USER . '",
-        "poetry_password" : "' . \Drupal\tmgmt_poetry_mock\Mock\PoetryMock::POETRY_PASSWORD . '"
+        "callback_user" : "' . PoetryMock::CALLBACK_USER . '",
+        "callback_password" : "' . PoetryMock::CALLBACK_PASSWORD . '",
+        "poetry_user" : "' . PoetryMock::POETRY_USER . '",
+        "poetry_password" : "' . PoetryMock::POETRY_PASSWORD . '"
       },
       "organization" : {
         "responsable" : "DIGIT",
@@ -45,6 +47,7 @@ function tmgmt_poetry_mock_install() {
     },
     "rdf_mapping" : []
   }');
+
   $translator->save();
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,8 +5,10 @@
  * PHPUnit bootstrap file.
  */
 
+use Drupal\Driver\DrupalDriver;
+
 require_once DRUPAL_ROOT . '/vendor/autoload.php';
 
-$driver = new \Drupal\Driver\DrupalDriver(DRUPAL_ROOT, BASE_URL);
+$driver = new DrupalDriver(DRUPAL_ROOT, BASE_URL);
 $driver->setCoreFromVersion();
 $driver->bootstrap();

--- a/tests/src/Context/BeanContext.php
+++ b/tests/src/Context/BeanContext.php
@@ -9,6 +9,7 @@ namespace Drupal\nexteuropa\Context;
 
 use Behat\Behat\Context\Context;
 use Drupal\nexteuropa\Component\Utility\Transliterate;
+use Rych\Random\Random;
 
 /**
  * Context for configuring the Bean.
@@ -41,7 +42,7 @@ class BeanContext implements Context {
    */
   public function __construct() {
     $this->transliterate = new Transliterate();
-    $this->random = new \Rych\Random\Random();
+    $this->random = new Random();
   }
 
   /**


### PR DESCRIPTION
## [NEPT-1385](https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1385)

   ### Description
   Fix QA automation rules - Namespaced classes/interfaces/traits should be referenced with use statements

### Change log

- Removed: The rule ref="Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing"

- Fixed: Include the classes by using USE and namespacing

### Commands

NA.
