### PR TITLE
NEPT-1380 Function return type is not void, but function is returning void here

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -558,11 +558,6 @@
         <exclude-pattern>*</exclude-pattern>
     </rule>
 
-    <!-- Function return type is not void, but function is returning void here. -->
-    <rule ref="Drupal.Commenting.FunctionComment.InvalidReturnNotVoid">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
     <!-- Expected 1 newline at end of file. -->
     <rule ref="Drupal.Files.EndFileNewline.NoneFound">
         <exclude-pattern>*</exclude-pattern>


### PR DESCRIPTION
## [NEPT-1380](https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1380)

### Description

Fix QA automation rules - Function return type is not void, but function is returning void here

### Change log

  - Removed: The rule ref="Drupal.Commenting.FunctionComment.InvalidReturnNotVoid"
                      The **phpcs** has not retrieve any error.

    
### Commands

NA.