### PR TITLE
NEPT-1386 When importing a class with "use", do not include

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -588,11 +588,6 @@
         <exclude-pattern>*</exclude-pattern>
     </rule>
 
-    <!-- When importing a class with "use", do not include a leading. -->
-    <rule ref="Drupal.Classes.UseLeadingBackslash.SeparatorStart">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
     <!-- Parameter $entity_id is not described in comment. -->
     <rule ref="Drupal.Commenting.FunctionComment.ParamMissingDefinition">
         <exclude-pattern>*</exclude-pattern>

--- a/profiles/common/modules/custom/nexteuropa_piwik/src/Entity/PiwikRule.php
+++ b/profiles/common/modules/custom/nexteuropa_piwik/src/Entity/PiwikRule.php
@@ -5,7 +5,8 @@
  */
 
 namespace Drupal\nexteuropa_piwik\Entity;
-use \Entity;
+
+use Entity;
 
 /**
  * PIWIK rule entity.

--- a/profiles/common/modules/custom/nexteuropa_piwik/src/EntityDefaultUIController/PiwikRuleEntityUIController.php
+++ b/profiles/common/modules/custom/nexteuropa_piwik/src/EntityDefaultUIController/PiwikRuleEntityUIController.php
@@ -5,7 +5,8 @@
  */
 
 namespace Drupal\nexteuropa_piwik\EntityDefaultUIController;
-use \EntityDefaultUIController;
+
+use EntityDefaultUIController;
 
 /**
  * Entity UI controller for the Next Europa PIWIK rules.

--- a/profiles/common/modules/custom/nexteuropa_varnish/src/Entity/PurgeRule.php
+++ b/profiles/common/modules/custom/nexteuropa_varnish/src/Entity/PurgeRule.php
@@ -6,7 +6,7 @@
 
 namespace Drupal\nexteuropa_varnish\Entity;
 use Drupal\nexteuropa_varnish\PurgeRuleType;
-use \Entity;
+use Entity;
 
 /**
  * Purge rule entity.

--- a/profiles/common/modules/custom/nexteuropa_varnish/src/PurgeRuleController.php
+++ b/profiles/common/modules/custom/nexteuropa_varnish/src/PurgeRuleController.php
@@ -6,7 +6,7 @@
 
 namespace Drupal\nexteuropa_varnish;
 
-use \EntityAPIController;
+use EntityAPIController;
 
 /**
  * Class PurgeRuleController.

--- a/profiles/common/modules/features/ec_embedded_image/ec_embedded_image.behat.inc
+++ b/profiles/common/modules/features/ec_embedded_image/ec_embedded_image.behat.inc
@@ -4,7 +4,7 @@
  * Contains ECEmbeddedImageSubContext.
  */
 
-use \Drupal\DrupalExtension\Context\DrupalSubContextBase;
+use Drupal\DrupalExtension\Context\DrupalSubContextBase;
 
 /**
  * Behat context for test setup related to the Embedded Image feature.

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.behat.inc
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.behat.inc
@@ -4,7 +4,7 @@
  * Contains NexteuropaCoreSubContext.
  */
 
-use \Drupal\DrupalExtension\Context\DrupalSubContextBase;
+use Drupal\DrupalExtension\Context\DrupalSubContextBase;
 
 /**
  * Behat context for the test setup related to Nexteuropa core tokens.


### PR DESCRIPTION
## [NEPT-1386](https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1386)

   ### Description

Fix QA automation rules - When importing a class with "use", do not include a leading backslash

   ### Change log
- Removed: The rule ref="Drupal.Classes.UseLeadingBackslash.SeparatorStart"
- Removed: All back slash fire up by phpcs

### Commands

NA.