### PR TITLE
NEPT-1388: Remove rule and update one line comment style.

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -598,11 +598,6 @@
         <exclude-pattern>*</exclude-pattern>
     </rule>
 
-    <!-- Missing @var tag in member variable comment. -->
-    <rule ref="Drupal.Commenting.VariableComment.MissingVar">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
     <!-- Return type "int | NULL" must not contain spaces. -->
     <rule ref="Drupal.Commenting.FunctionComment.ReturnTypeSpaces">
         <exclude-pattern>*</exclude-pattern>

--- a/profiles/common/modules/custom/nexteuropa_token/src/HashTokenHandler.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/HashTokenHandler.php
@@ -17,9 +17,7 @@ class HashTokenHandler extends TokenAbstractHandler {
   const DEFAULT_PREFIX = 'prefix';
   const TOKEN_NAME = 'url-hash';
 
-  /**
-   * Character sets used in encoding routine.
-   */
+  // Character sets used in encoding routine.
   protected $sliceChars   = "5zqcn9l7mg0rskjb621pwtv3xd84fh";
   protected $typeChars    = "d3gxr6zws4fb2qp8mk9n1vtcj7l5h0";
   protected $firstChars   = "6svjw1z7dmt9kqgcr405b3nxp82hlf";

--- a/profiles/common/modules/custom/nexteuropa_token/tests/TokenHandlerAbstractTest.php
+++ b/profiles/common/modules/custom/nexteuropa_token/tests/TokenHandlerAbstractTest.php
@@ -14,15 +14,11 @@ namespace Drupal\nexteuropa_token\Tests;
  */
 abstract class TokenHandlerAbstractTest extends \PHPUnit_Framework_TestCase {
 
-  /**
-   * Test fixtures.
-   */
+  // Test fixtures.
   protected static $contentType = NULL;
   protected static $vocabulary = NULL;
 
-  /**
-   * List of entities created during tests, keyed by entity type.
-   */
+  // List of entities created during tests, keyed by entity type.
   protected $entities = NULL;
 
   /**


### PR DESCRIPTION
## NEPT-1388

### Description

Fix QA automation rules - Missing @var tag in member variable comment.

### Change log

- Changed: Remove exception rule in phpcs-qa-roadmap.xml
- Changed: Update comment lines in profiles/common/modules/custom/nexteuropa_token/ module files.
