### PR TITLE
NEPT-1393: Fix QA automation rules "bool|FALSE .

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -623,11 +623,6 @@
         <exclude-pattern>*</exclude-pattern>
     </rule>
 
-    <!-- Expected "bool|false" but found "bool|FALSE" for parameter type. -->
-    <rule ref="Drupal.Commenting.FunctionComment.IncorrectParamVarName">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
     <!-- Do not concatenate strings to translatable strings, they should be part of the t() argument and you should use placeholders. -->
     <rule ref="Drupal.Semantics.FunctionT.ConcatString">
         <exclude-pattern>*</exclude-pattern>

--- a/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.helper.inc
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.helper.inc
@@ -464,9 +464,9 @@ function _nexteuropa_trackedchanges_tracking_message_for_wbm_states($entity) {
  *
  * @param object $entity
  *   Entity to check.
- * @param bool|FALSE $current_wbm_state
+ * @param bool|false $current_wbm_state
  *   Submitted entity workbench moderation state (node only).
- * @param bool|FALSE $current_status
+ * @param bool|false $current_status
  *   Submitted entity current status (node without workbench moderation only).
  *
  * @return bool


### PR DESCRIPTION
## NEPT-1393
### Description

Fix QA automation rules - Expected "bool|false" but found "bool|FALSE" for parameter type.

### Change log

- Changed:
   - Exception rule removed in phpcs-qa-roadmap.xml.
   - Comment updated.

### Commands


