### PR TITLE
NEPT-1390 Fix QA automation rules - Line indented incorrectly

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -608,11 +608,6 @@
         <exclude-pattern>*</exclude-pattern>
     </rule>
 
-    <!-- Line indented incorrectly. -->
-    <rule ref="Drupal.WhiteSpace.ScopeIndent.IncorrectExact">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
     <!-- You must use "/**" style comments for a member variable comment. -->
     <rule ref="Drupal.Commenting.VariableComment.WrongStyle">
         <exclude-pattern>*</exclude-pattern>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -39,6 +39,12 @@
          remove it from this list so it can be tested. -->
     <exclude-pattern>profiles/multisite_drupal_communities/inject_data.php</exclude-pattern>
 
+    <!-- This module is not supported by Core team, so to progress with the cleanup
+         for QA AUTOMATION (NEPT-884, NEPT-1387, NEPT-1389, NEPT-1390), this exception must exist
+         to allow the removing of "Drupal.Commenting.FunctionComment.ParamMissingDefinition" rule
+         and has the phpcs logs OK (all green).  -->
+    <exclude-pattern>profiles/*/modules/custom/nexteuropa_newsroom/</exclude-pattern>
+
     <!-- Views handlers/plugins not strictly follow Drupal class name conventions. -->
     <rule ref="Drupal.NamingConventions.ValidClassName">
         <exclude-pattern>profiles/common/modules/custom/ecas/ecas_extra/includes/views/handlers/*.inc</exclude-pattern>

--- a/profiles/common/modules/features/e_library/e_library_core/e_library_core.module
+++ b/profiles/common/modules/features/e_library/e_library_core/e_library_core.module
@@ -32,7 +32,7 @@ function e_library_core_tokens($type, $tokens, $data = array(), $options = array
     foreach ($tokens as $name => $original) {
       switch ($name) {
         case 'e_library_title':
-                    $replacements[$original] = t("e-library");
+          $replacements[$original] = t("e-library");
           break;
       }
     }

--- a/profiles/common/modules/features/events/events_core/events_core.module
+++ b/profiles/common/modules/features/events/events_core/events_core.module
@@ -33,7 +33,7 @@ function events_core_tokens($type, $tokens, $data = array(), $options = array())
     foreach ($tokens as $name => $original) {
       switch ($name) {
         case 'events_title':
-                    $replacements[$original] = t("events");
+          $replacements[$original] = t("events");
           break;
       }
     }

--- a/profiles/common/modules/features/idea/idea_core/idea_core.module
+++ b/profiles/common/modules/features/idea/idea_core/idea_core.module
@@ -32,7 +32,7 @@ function idea_core_tokens($type, $tokens, $data = array(), $options = array()) {
     foreach ($tokens as $name => $original) {
       switch ($name) {
         case 'idea_title':
-                    $replacements[$original] = t("idea");
+          $replacements[$original] = t("idea");
           break;
       }
     }

--- a/profiles/common/modules/features/links/links_core/links_core.module
+++ b/profiles/common/modules/features/links/links_core/links_core.module
@@ -32,7 +32,7 @@ function links_core_tokens($type, $tokens, $data = array(), $options = array()) 
     foreach ($tokens as $name => $original) {
       switch ($name) {
         case 'links_title':
-                    $replacements[$original] = t("links");
+          $replacements[$original] = t("links");
           break;
       }
     }

--- a/profiles/common/modules/features/multi_user_blog/multi_user_blog.module
+++ b/profiles/common/modules/features/multi_user_blog/multi_user_blog.module
@@ -32,7 +32,7 @@ function multi_user_blog_tokens($type, $tokens, $data = array(), $options = arra
     foreach ($tokens as $name => $original) {
       switch ($name) {
         case 'multi_user_blog_title':
-                    $replacements[$original] = t("blog");
+          $replacements[$original] = t("blog");
           break;
       }
     }

--- a/profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module
+++ b/profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module
@@ -12,11 +12,11 @@ function nexteuropa_geofield_field_schema($field) {
 
   switch ($field['type']) {
     case 'geofield_geojson':
-        $schema['columns']['geofield_geojson'] = array(
-          'type' => 'text',
-          'size' => 'big',
-          'not null' => FALSE,
-        );
+      $schema['columns']['geofield_geojson'] = array(
+        'type' => 'text',
+        'size' => 'big',
+        'not null' => FALSE,
+      );
       break;
   }
   return $schema;
@@ -269,18 +269,18 @@ function nexteuropa_geofield_field_formatter_view($entity_type, $entity, $field,
 
   switch ($display['type']) {
     case 'geofield_geojson_raw':
-        $element[0] = array(
-          '#type' => 'html_tag',
-          '#tag' => 'div',
-          '#attributes' => array(
-            'id' => 'geofield_geojson_raw',
-          ),
-          '#value' => isset($items[0]['geofield_geojson']) ? $items[0]['geofield_geojson'] : '',
-        );
+      $element[0] = array(
+        '#type' => 'html_tag',
+        '#tag' => 'div',
+        '#attributes' => array(
+          'id' => 'geofield_geojson_raw',
+        ),
+        '#value' => isset($items[0]['geofield_geojson']) ? $items[0]['geofield_geojson'] : '',
+      );
       break;
 
     case 'geofield_geojson_map_format':
-        $value = isset($items[0]['geofield_geojson']) ? $items[0]['geofield_geojson'] : '';
+      $value = isset($items[0]['geofield_geojson']) ? $items[0]['geofield_geojson'] : '';
       $element[0] = array(
         '#type' => 'markup',
         '#markup' => '<div id="geofield_geojson_map"></div><div id="geofield_geojson_map_wrapper"></div>',

--- a/profiles/common/modules/features/wiki/wiki_core/wiki_core.module
+++ b/profiles/common/modules/features/wiki/wiki_core/wiki_core.module
@@ -32,7 +32,7 @@ function wiki_core_tokens($type, $tokens, $data = array(), $options = array()) {
     foreach ($tokens as $name => $original) {
       switch ($name) {
         case 'wiki_title':
-                    $replacements[$original] = t("wiki");
+          $replacements[$original] = t("wiki");
           break;
       }
     }


### PR DESCRIPTION
## [NEPT-1390](https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1390)

### Description

Fix QA automation rules - Line indented incorrectly.

### Change log
  - Removed: The rule ref="Drupal.WhiteSpace.ScopeIndent.IncorrectExact"

  - Added: The right indentation.

  - Created:  An exception has been set to exclude nexteuropa_newsroom module once it is not 
                    supported by Core team, so to progress with the clean up for QA AUTOMATION (NEPT-
                    884, NEPT-1387 and NEPT-1389), this exception must exist so when remove the rule   
                    "Drupal.Commenting.FunctionComment.ParamMissingDefinition" the phpcs is OK (all 
                     green).

### Commands

NA.