### PR TITLE
NEPT-308: Remove dependencies to dblog from profiles.

### DIFF
--- a/profiles/multisite_drupal_communities/multisite_drupal_communities.info
+++ b/profiles/multisite_drupal_communities/multisite_drupal_communities.info
@@ -20,7 +20,6 @@ dependencies[] = ctools
 dependencies[] = current_search
 dependencies[] = dashboard
 dependencies[] = date
-dependencies[] = dblog
 dependencies[] = diff
 dependencies[] = easy_breadcrumb
 dependencies[] = email

--- a/profiles/multisite_drupal_standard/multisite_drupal_standard.info
+++ b/profiles/multisite_drupal_standard/multisite_drupal_standard.info
@@ -15,7 +15,6 @@ dependencies[] = number
 dependencies[] = options
 dependencies[] = path
 dependencies[] = taxonomy
-dependencies[] = dblog
 dependencies[] = search
 dependencies[] = field_ui
 dependencies[] = file

--- a/tests/features/subscriptions.feature
+++ b/tests/features/subscriptions.feature
@@ -9,6 +9,7 @@ Feature: Subscription
     And the module is enabled
       |modules                      |
       |multisite_notifications_core |
+      |dblog                        |
 
   @javascript @theme_wip
   # It is in wip for the europa theme because it implies a step referring a


### PR DESCRIPTION
## NEPT-308

### Description

Remove dependencies to dblog from profiles.

### Change log

- Removed: Dependencies to dblog

### Commands

```sh
no command
```

