### PR TITLE
NEPT-1176: Drupal logout malfunction

### DIFF
--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -234,8 +234,7 @@ function ecas_logout($full_logout = TRUE) {
   if ($full_logout) {
     _ecas_init_phpcas_client();
     $params = array(
-      'service' => variable_get('site_name', 'ecas'),
-      'url' => url('front', array('absolute' => TRUE)),
+      'url' => url('<front>', array('absolute' => TRUE)),
     );
     drupal_alter('ecas_full_logout_parameters', $params);
     phpCAS::logout($params);


### PR DESCRIPTION
## NEPT-1176

### Description

Fix the redirection process that stopped directly after the EU Login process.

### Change log

- Fixed: Fixed: the redirection definition in the logout call in the ECAS module.

### Commands

```sh
No command required

```

