### PR TITLE
NEPT-1402 Use LANGUAGE_NONE instead of 'und'

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -254,22 +254,6 @@
         <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.install</exclude-pattern>
     </rule>
 
-    <!-- Use the LANGUAGE_NONE constant. -->
-    <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-821 -->
-    <rule ref="DrupalPractice.General.LanguageNone.Und">
-        <exclude-pattern>profiles/common/themes/ec_resp/template.php</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/custom/multisite_block_carousel/multisite_block_carousel.module</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/custom/subscriptions_og/subscriptions_og.module</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.module</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/multisite_forum_community/multisite_forum_community.module</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.module</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/events/events_core/events_core.module</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/cce_basic_config/cce_basic_config.install</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/news/news_core/news_core.module</exclude-pattern>
-        <exclude-pattern>profiles/common/modules/features/news/news_og/news_og.module</exclude-pattern>
-    </rule>
-
     <!-- Remove these functions from hook_init(). -->
     <!-- https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-822 -->
     <rule ref="DrupalPractice.FunctionDefinitions.HookInitCss.AddFunctionFound">
@@ -665,11 +649,6 @@
 
     <!-- Do not use the raw $form_state['input'], use $form_state['values'] instead where possible. -->
     <rule ref="DrupalPractice.General.FormStateInput.Input">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
-    <!-- Are you accessing field values here? Then you should use LANGUAGE_NONE instead of 'und'. -->
-    <rule ref="DrupalPractice.General.LanguageNone.Und">
         <exclude-pattern>*</exclude-pattern>
     </rule>
 

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -39,6 +39,11 @@
          remove it from this list so it can be tested. -->
     <exclude-pattern>profiles/multisite_drupal_communities/inject_data.php</exclude-pattern>
 
+    <!-- This module is not supported by Core team, so to progress with the cleanup for QA AUTOMATION ticket NEPT-884
+         (NEPT-1387, NEPT-1389, NEPT-1390, NEPT-1391, NEPT-1393, NEPT-1396, NEPT-1397, NEPT-1398, NEPT-1400, NEPT-1402),
+         this exception must exist to allow the removing rule and get OK from phpcs logs (all green).  -->
+    <exclude-pattern>profiles/*/modules/custom/nexteuropa_newsroom/</exclude-pattern>
+
     <!-- Views handlers/plugins not strictly follow Drupal class name conventions. -->
     <rule ref="Drupal.NamingConventions.ValidClassName">
         <exclude-pattern>profiles/common/modules/custom/ecas/ecas_extra/includes/views/handlers/*.inc</exclude-pattern>

--- a/profiles/common/modules/custom/multisite_block_carousel/multisite_block_carousel.module
+++ b/profiles/common/modules/custom/multisite_block_carousel/multisite_block_carousel.module
@@ -297,14 +297,14 @@ function multisite_block_carousel_contents($delta) {
     $first = TRUE;
 
     // Merge photos and videos.
-    if (isset($gall->field_picture_upload['und']) && isset($gall->field_video_upload['und'])) {
-      $media_items = array_merge($gall->field_picture_upload['und'], $gall->field_video_upload['und']);
+    if (isset($gall->field_picture_upload[LANGUAGE_NONE]) && isset($gall->field_video_upload[LANGUAGE_NONE])) {
+      $media_items = array_merge($gall->field_picture_upload[LANGUAGE_NONE], $gall->field_video_upload[LANGUAGE_NONE]);
     }
-    elseif (isset($gall->field_picture_upload['und'])) {
-      $media_items = $gall->field_picture_upload['und'];
+    elseif (isset($gall->field_picture_upload[LANGUAGE_NONE])) {
+      $media_items = $gall->field_picture_upload[LANGUAGE_NONE];
     }
-    elseif (isset($gall->field_video_upload['und'])) {
-      $media_items = $gall->field_video_upload['und'];
+    elseif (isset($gall->field_video_upload[LANGUAGE_NONE])) {
+      $media_items = $gall->field_video_upload[LANGUAGE_NONE];
     }
     // @todo This is unneeded, $media_items is already instantiated to an empty
     //   array.
@@ -339,7 +339,7 @@ function multisite_block_carousel_contents($delta) {
           $thumb = image_style_url('landscape', $item['uri']);
           $return .= '<a href="' . $path . '">';
           $return .= '<img src="' . $thumb . '" alt="' . check_plain($item['filename']) . '" />';
-          $return .= '<p class="carousel-caption">' . (isset($item['field_picture_description']['und'][0]['safe_value']) ? filter_xss($item['field_picture_description']['und'][0]['safe_value']) : check_plain($item['filename'])) . '</p>';
+          $return .= '<p class="carousel-caption">' . (isset($item['field_picture_description'][LANGUAGE_NONE][0]['safe_value']) ? filter_xss($item['field_picture_description'][LANGUAGE_NONE][0]['safe_value']) : check_plain($item['filename'])) . '</p>';
           $return .= '</a>';
           break;
 

--- a/profiles/common/modules/custom/subscriptions_og/subscriptions_og.module
+++ b/profiles/common/modules/custom/subscriptions_og/subscriptions_og.module
@@ -99,7 +99,7 @@ function subscriptions_og_subscriptions($op, $arg0 = NULL, $arg1 = NULL, $arg2 =
       $options = array();
       if (og_is_group('node', $arg1)) {
         // Check if user is a member for private group.
-        if (og_is_member('node', $arg1->nid) || $arg1->group_access['und'][0]['value'] == 1) {
+        if (og_is_member('node', $arg1->nid) || $arg1->group_access[LANGUAGE_NONE][0]['value'] == 1) {
           $options['group_audience'][] = array(
             'name' => t('To content posted in %name', array('%name' => $arg1->title)),
             'link' => 'node/' . $arg1->nid,

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -892,8 +892,8 @@ function _cce_basic_config_post_install_users() {
   $account->init = $account->mail;
   $role = user_role_load_by_name('administrator');
   $account->roles[$role->rid] = $role->name;
-  $account->field_firstname['und'][0]['value'] = 'John';
-  $account->field_lastname['und'][0]['value'] = 'Smith';
+  $account->field_firstname[LANGUAGE_NONE][0]['value'] = 'John';
+  $account->field_lastname[LANGUAGE_NONE][0]['value'] = 'Smith';
   user_save($account);
 
   $account1 = new stdClass();
@@ -905,8 +905,8 @@ function _cce_basic_config_post_install_users() {
   $account1->init = $account1->mail;
   $role1 = user_role_load_by_name('contributor');
   $account1->roles[$role1->rid] = $role1->name;
-  $account1->field_firstname['und'][0]['value'] = 'John';
-  $account1->field_lastname['und'][0]['value'] = 'Doe';
+  $account1->field_firstname[LANGUAGE_NONE][0]['value'] = 'John';
+  $account1->field_lastname[LANGUAGE_NONE][0]['value'] = 'Doe';
   user_save($account1);
 
   $account2 = new stdClass();
@@ -918,8 +918,8 @@ function _cce_basic_config_post_install_users() {
   $account2->init = $account2->mail;
   $role2 = user_role_load_by_name('editor');
   $account2->roles[$role2->rid] = $role2->name;
-  $account2->field_firstname['und'][0]['value'] = 'John';
-  $account2->field_lastname['und'][0]['value'] = 'Blake';
+  $account2->field_firstname[LANGUAGE_NONE][0]['value'] = 'John';
+  $account2->field_lastname[LANGUAGE_NONE][0]['value'] = 'Blake';
   user_save($account2);
 
   // Assign dummy content to the 'administrator' user.

--- a/profiles/common/modules/features/events/events_core/events_core.module
+++ b/profiles/common/modules/features/events/events_core/events_core.module
@@ -53,7 +53,7 @@ function events_core_form_event_node_form_alter(&$form, &$form_state, $form_id) 
  * Validation function : scan urls.
  */
 function custom_valid_events_link(&$form, &$form_state) {
-  if (isset($form['field_location']['und'][0]['url']['#value']) && (bool) $form['field_location']['und'][0]['url']['#value']) {
-    $result_scan = multisite_drupal_toolbox_linkit_scan_url($form['field_location']['und'][0]['url']['#value'], 'field_location');
+  if (isset($form['field_location'][LANGUAGE_NONE][0]['url']['#value']) && (bool) $form['field_location'][LANGUAGE_NONE][0]['url']['#value']) {
+    $result_scan = multisite_drupal_toolbox_linkit_scan_url($form['field_location'][LANGUAGE_NONE][0]['url']['#value'], 'field_location');
   }
 }

--- a/profiles/common/modules/features/multisite_forum_community/multisite_forum_community.module
+++ b/profiles/common/modules/features/multisite_forum_community/multisite_forum_community.module
@@ -200,7 +200,7 @@ function multisite_forum_community_node_view($node, $view_mode, $langcode) {
   $field = field_info_instance('node', 'taxonomy_forums', $node->type);
   if (is_array($field)) {
     if ($view_mode == 'full' && node_is_page($node)) {
-      $forum_term = $node->taxonomy_forums['und'][0]['taxonomy_term'];
+      $forum_term = $node->taxonomy_forums[LANGUAGE_NONE][0]['taxonomy_term'];
       $gid = multisite_forum_community_get_forum_term_git($forum_term);
       if ($gid) {
         $group_node = node_load($gid);

--- a/profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.module
+++ b/profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.module
@@ -124,14 +124,14 @@ function multisite_mediagallery_core_preprocess_node(&$variables) {
             $picture_preview = image_style_url('preview', $local_data['uri']);
             $picture_original = file_stream_wrapper_get_instance_by_uri('public://')->getDirectoryPath() . str_replace('public://', '/', $local_data['uri']);
           }
-          $alt_text = (!empty($local_data['field_file_image_alt_text']['und'][0]['safe_value']) ? $local_data['field_file_image_alt_text']['und'][0]['safe_value'] : filter_xss($local_data['filename']));
-          $title_texte = (!empty($local_data['field_file_image_title_text']['und'][0]['safe_value']) ? $local_data['field_file_image_title_text']['und'][0]['safe_value'] : '');
+          $alt_text = (!empty($local_data['field_file_image_alt_text'][LANGUAGE_NONE][0]['safe_value']) ? $local_data['field_file_image_alt_text'][LANGUAGE_NONE][0]['safe_value'] : filter_xss($local_data['filename']));
+          $title_texte = (!empty($local_data['field_file_image_title_text'][LANGUAGE_NONE][0]['safe_value']) ? $local_data['field_file_image_title_text'][LANGUAGE_NONE][0]['safe_value'] : '');
 
           $output .= '<div id="lightbox' . $key . '" class="lightbox" style="display: none;">';
           $output .= '<img src="' . $picture_preview . '" alt="' . $alt_text . '" title="' . $title_texte . '"/>';
 
-          if (isset($local_data['field_picture_description']['und'][0]['value'])) {
-            $output .= '<p>' . filter_xss($local_data['field_picture_description']['und'][0]['value']) . '</p>';
+          if (isset($local_data['field_picture_description'][LANGUAGE_NONE][0]['value'])) {
+            $output .= '<p>' . filter_xss($local_data['field_picture_description'][LANGUAGE_NONE][0]['value']) . '</p>';
           }
 
           if (!empty($tags)) {

--- a/profiles/common/modules/features/news/news_core/news_core.module
+++ b/profiles/common/modules/features/news/news_core/news_core.module
@@ -51,7 +51,7 @@ function news_core_form_news_node_form_alter(&$form, &$form_state, $form_id) {
  * Validation function.
  */
 function news_core_custom_valid_news_link(&$form, &$form_state) {
-  if (isset($form['field_link']['und'][0]['url']['#value']) && (bool) $form['field_link']['und'][0]['url']['#value']) {
-    $result_scan = multisite_drupal_toolbox_linkit_scan_url($form['field_link']['und'][0]['url']['#value'], 'field_link');
+  if (isset($form['field_link'][LANGUAGE_NONE][0]['url']['#value']) && (bool) $form['field_link'][LANGUAGE_NONE][0]['url']['#value']) {
+    $result_scan = multisite_drupal_toolbox_linkit_scan_url($form['field_link'][LANGUAGE_NONE][0]['url']['#value'], 'field_link');
   }
 }

--- a/profiles/common/modules/features/news/news_og/news_og.module
+++ b/profiles/common/modules/features/news/news_og/news_og.module
@@ -31,6 +31,6 @@ function news_og_menu() {
  * Implements hook_form_FORM_ID_alter().
  */
 function news_og_form_news_node_form_alter(&$form, &$form_state, $form_id) {
-  $desc = $form['field_top_news']['und']['#description'];
-  $form['field_top_news']['und']['#description'] = $desc . " " . t('(The visibility of the news must be set to public to appear on the site homepage)');
+  $desc = $form['field_top_news'][LANGUAGE_NONE]['#description'];
+  $form['field_top_news'][LANGUAGE_NONE]['#description'] = $desc . " " . t('(The visibility of the news must be set to public to appear on the site homepage)');
 }

--- a/profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module
+++ b/profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module
@@ -434,7 +434,7 @@ function nexteuropa_geofield_node_validate($node, $form, &$form_state) {
       // Add the javascript files if there is a geofield_geojson field.
       if ($type == 'geofield_geojson') {
         $field_instance = $form_state['field'][$field_name][LANGUAGE_NONE];
-        drupal_add_js(array('nexteuropa_geojson' => array('map' => $node->{$field_name}['und'][0]['geofield_geojson'])), 'setting');
+        drupal_add_js(array('nexteuropa_geojson' => array('map' => $node->{$field_name}[LANGUAGE_NONE][0]['geofield_geojson'])), 'setting');
         drupal_add_js(array('nexteuropa_geojson' => array('settings' => $field_instance['instance']['widget']['settings'])), 'setting');
         drupal_add_js(array('nexteuropa_geojson' => array('cardinality' => $field_instance['field']['cardinality'])), 'setting');
       }

--- a/profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.module
+++ b/profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.module
@@ -67,7 +67,7 @@ function nexteuropa_metatags_metatag_info() {
     $terms = taxonomy_get_tree($vocabulary->vid);
     foreach ($terms as $term) {
       $term_full = taxonomy_term_load($term->tid);
-      $options[$term_full->field_meta_value['und'][0]['value']] = str_repeat('-', $term->depth) . $term->name;
+      $options[$term_full->field_meta_value[LANGUAGE_NONE][0]['value']] = str_repeat('-', $term->depth) . $term->name;
     }
   }
 


### PR DESCRIPTION
## [NEPT-1402](https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1402)

### Description
Fix QA automation rules,  use LANGUAGE_NONE instead of und.

### Change log
  - Removed: The rule "DrupalPractice.General.LanguageNone.Und"

  - Added:  An exception has been set to exclude nexteuropa_newsroom module once it is not supported   by Core team, so to progress with the clean up for
     QA AUTOMATION (NEPT-884, NEPT-1387, NEPT-1389, NEPT-1390, NEPT-1391, NEPT-1396, NEPT-1400), this exception must exist while removing the rule and get OK from the phpcs (all green).

  - Changed: The 'und' key has been changed by LANGUAGE_NONE const as DRUPAL best practices recommended.

### Commands

No commands.