### PR TITLE
NEPT-1405  Content missing for @var tag 

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -678,11 +678,6 @@
         <exclude-pattern>*</exclude-pattern>
     </rule>
 
-    <!-- Content missing for @var tag in member variable comment. -->
-    <rule ref="Drupal.Commenting.VariableComment.EmptyVar">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
     <!-- Expected 1 blank line after function. -->
     <rule ref="Squiz.WhiteSpace.FunctionSpacing.After">
         <exclude-pattern>*</exclude-pattern>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -39,6 +39,11 @@
          remove it from this list so it can be tested. -->
     <exclude-pattern>profiles/multisite_drupal_communities/inject_data.php</exclude-pattern>
 
+    <!-- This module is not supported by Core team, so to progress with the cleanup for QA AUTOMATION ticket NEPT-884
+         (NEPT-1387, NEPT-1389, NEPT-1390, NEPT-1391, NEPT-1393, NEPT-1396, NEPT-1397, NEPT-1398, NEPT-1400, NEPT-1402, NEPT-1405),
+         this exception must exist to allow the removing rule and get OK from phpcs logs (all green).  -->
+    <exclude-pattern>profiles/*/modules/custom/nexteuropa_newsroom/</exclude-pattern>
+
     <!-- Views handlers/plugins not strictly follow Drupal class name conventions. -->
     <rule ref="Drupal.NamingConventions.ValidClassName">
         <exclude-pattern>profiles/common/modules/custom/ecas/ecas_extra/includes/views/handlers/*.inc</exclude-pattern>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -39,11 +39,6 @@
          remove it from this list so it can be tested. -->
     <exclude-pattern>profiles/multisite_drupal_communities/inject_data.php</exclude-pattern>
 
-    <!-- This module is not supported by Core team, so to progress with the cleanup for QA AUTOMATION ticket NEPT-884
-         (NEPT-1387, NEPT-1389, NEPT-1390, NEPT-1391, NEPT-1393, NEPT-1396, NEPT-1397, NEPT-1398, NEPT-1400, NEPT-1402, NEPT-1405),
-         this exception must exist to allow the removing rule and get OK from phpcs logs (all green).  -->
-    <exclude-pattern>profiles/*/modules/custom/nexteuropa_newsroom/</exclude-pattern>
-
     <!-- Views handlers/plugins not strictly follow Drupal class name conventions. -->
     <rule ref="Drupal.NamingConventions.ValidClassName">
         <exclude-pattern>profiles/common/modules/custom/ecas/ecas_extra/includes/views/handlers/*.inc</exclude-pattern>

--- a/tests/src/Transformation/Transformer/ArgumentTransformer.php
+++ b/tests/src/Transformation/Transformer/ArgumentTransformer.php
@@ -18,7 +18,7 @@ class ArgumentTransformer implements ArgumentTransformerInterface {
   /**
    * Extension configuration.
    *
-   * @var
+   * @var array
    */
   private $config;
 


### PR DESCRIPTION
## [NEPT-1405](https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1405)

### Description
Fix QA automation rules - Content missing for @var tag in member variable comment.

### Change log
  - Removed: The rule ref="DrupalPractice.General.LanguageNone.Und"
  
  - Added: 
            1- An exception has been set to exclude nexteuropa_newsroom module once it is not 
                supported   by Core team, so to progress with the clean up for
                QA AUTOMATION (NEPT-884, NEPT-1387, NEPT-1389, NEPT-1390, NEPT-1391, NEPT-
                1396, NEPT-1400, NEPT-1402, NEPT-1405), this exception must exist while removing the 
                rule and get OK from the phpcs (all green).
             2- The variable type for heredoc.

### Commands

NA.

