### PR TITLE
NEPT-1379: Fix QA automation rules - Tags should not be used.

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -548,11 +548,6 @@
         <exclude-pattern>*</exclude-pattern>
     </rule>
 
-    <!-- Tags should not be used. -->
-    <rule ref="DrupalPractice.Commenting.ExpectedException.TagFound">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
     <!-- Function return type is not void, but function is returning void here. -->
     <rule ref="Drupal.Commenting.FunctionComment.InvalidReturnNotVoid">
         <exclude-pattern>*</exclude-pattern>

--- a/profiles/common/modules/custom/multisite_config/tests/ConfigBaseTest.php
+++ b/profiles/common/modules/custom/multisite_config/tests/ConfigBaseTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\multisite_config\Tests;
 
+use Drupal\Driver\Exception\Exception;
+
 /**
  * Class ConfigAbstractTest.
  *
@@ -28,12 +30,11 @@ class ConfigBaseTest extends ConfigAbstractTest {
 
   /**
    * Test case when both service class and module do not exist.
-   *
-   * @expectedException \Exception
-   *
-   * @expectedExceptionMessage Service class "\Drupal\not_existing_module\Config" and module "not_existing_module" does not exists.
    */
   public function testNotExistingServiceClassAndModule() {
+    $this->expectException(Exception::class);
+    $exMsg = 'Service class "\Drupal\not_existing_module\Config" and module "not_existing_module" does not exists.';
+    $this->expectExceptionMessage($exMsg);
     $service = multisite_config_service('not_existing_module');
     $this->assertEquals('Drupal\multisite_config\ConfigBase', get_class($service));
   }

--- a/profiles/common/modules/custom/nexteuropa_token/tests/TokenHandlerTest.php
+++ b/profiles/common/modules/custom/nexteuropa_token/tests/TokenHandlerTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\nexteuropa_token\Tests;
 
+use Drupal\Driver\Exception\Exception;
+
 /**
  * Class TokenHandlerTest.
  *
@@ -11,11 +13,11 @@ class TokenHandlerTest extends TokenHandlerAbstractTest {
 
   /**
    * Test faulty service container call.
-   *
-   * @expectedException \Exception
    */
   public function testFaultyServiceContainerCall() {
     nexteuropa_token_get_handler('foo');
+
+    $this->expectException(Exception::class);
 
     $reflection = new \ReflectionClass('\stdClass');
     if (!$reflection->implementsInterface('\Drupal\nexteuropa_token\TokenHandlerInterface')) {


### PR DESCRIPTION
## NEPT-1379

### Description

Fix QA automation rules - Tags should not be used.

### Change log

- Changed:
    Exception removed in phpcs-qa-roadmap.xml
    Changes in : profiles/common/modules/custom/nexteuropa_token/tests/TokenHandlerTest.php
                         profiles/common/modules/custom/multisite_config/tests/ConfigBaseTest.php

### Commands
1- git fetch --all
2- git checkout nept-884-v2
3- git checkout -b nept-1379


