### PR TITLE
NEPT-1400 Fix QA automation rules - Unused private method.

### DIFF
--- a/phpcs-qa-roadmap.xml
+++ b/phpcs-qa-roadmap.xml
@@ -658,11 +658,6 @@
         <exclude-pattern>*</exclude-pattern>
     </rule>
 
-    <!-- Unused private method. -->
-    <rule ref="DrupalPractice.Objects.UnusedPrivateMethod.UnusedMethod">
-        <exclude-pattern>*</exclude-pattern>
-    </rule>
-
     <!-- Do not use the raw $form_state['input'], use $form_state['values'] instead where possible. -->
     <rule ref="DrupalPractice.General.FormStateInput.Input">
         <exclude-pattern>*</exclude-pattern>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -39,6 +39,11 @@
          remove it from this list so it can be tested. -->
     <exclude-pattern>profiles/multisite_drupal_communities/inject_data.php</exclude-pattern>
 
+    <!-- This module is not supported by Core team, so to progress with the cleanup for QA AUTOMATION ticket NEPT-884
+         (NEPT-1387, NEPT-1389, NEPT-1390, NEPT-1391, NEPT-1393, NEPT-1396, NEPT-1397, NEPT-1398, NEPT-1400),
+         this exception must exist to allow the removing rule and get OK from phpcs logs (all green).  -->
+    <exclude-pattern>profiles/*/modules/custom/nexteuropa_newsroom/</exclude-pattern>
+
     <!-- Views handlers/plugins not strictly follow Drupal class name conventions. -->
     <rule ref="Drupal.NamingConventions.ValidClassName">
         <exclude-pattern>profiles/common/modules/custom/ecas/ecas_extra/includes/views/handlers/*.inc</exclude-pattern>

--- a/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/views/nexteuropa_token_ckeditor_bean_handler_field_selection.inc
+++ b/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/views/nexteuropa_token_ckeditor_bean_handler_field_selection.inc
@@ -93,19 +93,4 @@ class nexteuropa_token_ckeditor_bean_handler_field_selection extends views_handl
     return $view_modes;
   }
 
-  /**
-   * Get view mode label.
-   *
-   * @param string $view_mode
-   *    View mode machine name.
-   *
-   * @return mixed
-   *    View mode options array.
-   */
-  private function get_view_mode_label($view_mode) {
-    $view_modes = $this->get_view_modes_options();
-
-    return $view_modes[$view_mode];
-  }
-
 }

--- a/profiles/common/modules/custom/tmgmt_workbench/includes/tmgmt_workbench.plugin.inc
+++ b/profiles/common/modules/custom/tmgmt_workbench/includes/tmgmt_workbench.plugin.inc
@@ -72,25 +72,6 @@ class TMGMTWorkbenchSourcePluginController extends TMGMTEntitySourcePluginContro
   }
 
   /**
-   * Get moderation state.
-   *
-   * @param object $node
-   *    Node object.
-   * @param string $type
-   *    Moderation type.
-   *
-   * @return string|FALSE
-   *    Moderation state or FALSE.
-   */
-  private function getModerationState($node, $type = 'current') {
-    if (is_object($node) && property_exists($node, 'workbench_moderation') && isset($node->workbench_moderation[$type])) {
-      $state = $node->workbench_moderation[$type];
-      return $state->state;
-    }
-    return FALSE;
-  }
-
-  /**
    * Get moderation revision.
    *
    * @param object $node


### PR DESCRIPTION
## NEPT-1400

### Description

Fix QA automation rules, nused private method.

### Change log

  - Removed: The rule
     1- "DrupalPractice.Objects.UnusedPrivateMethod.UnusedMethod"
     2- The private methods that are not being used.

  - Added: An exception has been set to exclude nexteuropa_newsroom module once it is not 
                supported   by Core team, so to progress with the clean up for
               QA AUTOMATION (NEPT-884, NEPT-1387, NEPT-1389, NEPT-1390, NEPT-1391, NEPT-1396, 
               NEPT-1400), this exception must exist while removing the rule and get OK from the phpcs (all 
               green).

### Commands

NA.
