### PR TITLE
NEPT-289: Make Mpdf library PHP 7.0 compatibility

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -934,7 +934,7 @@ libraries[modernizr][destination] = "../common/libraries"
 libraries[mpdf][download][type]= "file"
 libraries[mpdf][download][request_type]= "get"
 libraries[mpdf][download][file_type] = "zip"
-libraries[mpdf][download][url] = https://github.com/mpdf/mpdf/archive/v6.1.0.zip
+libraries[mpdf][download][url] = https://github.com/mpdf/mpdf/archive/v6.1.4.zip
 libraries[mpdf][destination] = "libraries"
 
 ; Leaflet


### PR DESCRIPTION
## NEPT-289

### Description

Upgrade mpdf to 6.1.4. in order to make the library PHP 7 compliant

### Change log

- Changed: Upgrade mpdf to 6.1.4.

### Commands

```sh
drush cc all

```

