### PR TITLE
Nept 1584: Force variable xmlsitemap_prefetch_aliases to 0.

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -2467,8 +2467,8 @@ function cce_basic_config_update_7221() {
  * We cannot do this in sitemap feature because some users only enabled the
  * xmlsitemap module. Ticket NEPT-1584.
  */
-function cce_basic_config_update_7222(){
-  if(module_exists('xmlsitemap')) {
+function cce_basic_config_update_7222() {
+  if (module_exists('xmlsitemap')) {
     variable_set('xmlsitemap_prefetch_aliases', 0);
   }
 }

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -2460,3 +2460,15 @@ function cce_basic_config_update_7220() {
 function cce_basic_config_update_7221() {
   multisite_config_service('wysiwyg')->addPreferenceToProfile('full_html', 'version', '4.4.8.ccd0038');
 }
+
+/**
+ * Force xmlsitemap xmlsitemap_prefetch_aliases to 0.
+ *
+ * We cannot do this in sitemap feature because some users only enabled the
+ * xmlsitemap module. Ticket NEPT-1584.
+ */
+function cce_basic_config_update_7222(){
+  if(module_exists('xmlsitemap')) {
+    variable_set('xmlsitemap_prefetch_aliases', 0);
+  }
+}

--- a/profiles/common/modules/features/sitemap/sitemap.strongarm.inc
+++ b/profiles/common/modules/features/sitemap/sitemap.strongarm.inc
@@ -57,7 +57,7 @@ function sitemap_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'xmlsitemap_prefetch_aliases';
-  $strongarm->value = 1;
+  $strongarm->value = 0;
   $export['xmlsitemap_prefetch_aliases'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/tests/features/sitemap.feature
+++ b/tests/features/sitemap.feature
@@ -10,14 +10,14 @@ Feature: Check the Sitemap
       | sitemap     |
     Given I am logged in as a user with the "administrator" role
     When I go to "/admin/config/search/xmlsitemap/settings"
-    Then "Prefetch URL aliases during sitemap generation." checkbox should not be checked
+    Then the "Prefetch URL aliases during sitemap generation." checkbox should not be checked
 
   @api
   Scenario: Administrator user can check the sitemap
     Given the module is enabled
       | modules     |
       | sitemap     |
-    Given I am logged in as a user with the "anonymous" role
+    Given I am logged in as a user with the "anonymous user" role
     When I go to "/sitemap.xml"
     Then the response should not contain "Page not found"
     And the response should contain "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:xhtml=\"http://www.w3.org/1999/xhtml\">"

--- a/tests/features/sitemap.feature
+++ b/tests/features/sitemap.feature
@@ -8,7 +8,7 @@ Feature: Check the Sitemap
     Given the module is enabled
       | modules     |
       | sitemap     |
-    Given I am an administrator user
+    Given I am logged in as a user with the "administrator" role
     When I go to "/admin/config/search/xmlsitemap/settings"
     Then "Prefetch URL aliases during sitemap generation." checkbox should not be checked
 
@@ -17,7 +17,7 @@ Feature: Check the Sitemap
     Given the module is enabled
       | modules     |
       | sitemap     |
-    Given I am an anonymous user
+    Given I am logged in as a user with the "anonymous" role
     When I go to "/sitemap.xml"
     Then the response should not contain "Page not found"
     And the response should contain "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:xhtml=\"http://www.w3.org/1999/xhtml\">"

--- a/tests/features/sitemap.feature
+++ b/tests/features/sitemap.feature
@@ -4,11 +4,20 @@ Feature: Check the Sitemap
   I can publish a sitemap
 
   @api
+  Scenario: Value of the variable xmlsitemap_prefetch_aliases is zero
+    Given the module is enabled
+      | modules     |
+      | sitemap     |
+    Given I am an administrator user
+    When I go to "/admin/config/search/xmlsitemap/settings"
+    Then "Prefetch URL aliases during sitemap generation." checkbox should not be checked
+
+  @api
   Scenario: Administrator user can check the sitemap
     Given the module is enabled
       | modules     |
       | sitemap     |
     Given I am an anonymous user
     When I go to "/sitemap.xml"
-    And the response should not contain "Page not found"
+    Then the response should not contain "Page not found"
     And the response should contain "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:xhtml=\"http://www.w3.org/1999/xhtml\">"


### PR DESCRIPTION
## NEPT-1584

### Description

Force variable xmlsitemap_prefetch_aliases to 0. This functionality has a very negative impact on performances.

### Change log

- Changed: value of variable xmlsitemap_prefetch_aliases set to 0.

### Commands

```sh
drush updb
```

