### PR TITLE
NEPT-1630: Reorder hook updates sequence in cce_basic_config.

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -2455,6 +2455,16 @@ function cce_basic_config_update_7220() {
 }
 
 /**
+ * Force the deactivation of multisite_og_navigation_tree.
+ */
+function cce_basic_config_update_7221() {
+  if (module_exists('multisite_og_navigation_tree')) {
+    module_disable(array('multisite_og_navigation_tree'), FALSE);
+    drupal_uninstall_modules(array('multisite_og_navigation_tree'), FALSE);
+  }
+}
+
+/**
  * Add the ckeditor version we are expecting.
  */
 function cce_basic_config_update_7222() {
@@ -2467,7 +2477,7 @@ function cce_basic_config_update_7222() {
  * We cannot do this in sitemap feature because some users only enabled the
  * xmlsitemap module. Ticket NEPT-1584.
  */
-function cce_basic_config_update_7222() {
+function cce_basic_config_update_7223() {
   if (module_exists('xmlsitemap')) {
     variable_set('xmlsitemap_prefetch_aliases', 0);
   }
@@ -2476,14 +2486,14 @@ function cce_basic_config_update_7222() {
 /**
  * Force the first day to Monday on the platform.
  */
-function cce_basic_config_update_7223() {
+function cce_basic_config_update_7224() {
   variable_set('date_first_day', 1);
 }
 
 /**
  * Uninstall language_cookie from the platformn NEPT-163.
  */
-function cce_basic_config_update_7224() {
+function cce_basic_config_update_7225() {
   $cookie_language_usage = language_negotiation_get('language', 'language_cookie');
   $cookie_content_usage = language_negotiation_get('language_content', 'language_cookie');
   if (module_exists('language_cookie') && $cookie_language_usage === FALSE && $cookie_content_usage === FALSE) {


### PR DESCRIPTION
## NEPT-1630

### Description

After a merge ( https://github.com/ec-europa/platform-dev/pull/1714 ) the sequence of hook updates of cce_basic_config is broken.
we have :
219, 220 , 222, 222 , 223 , 224 
It has to be fixed asap.

### Change log
- Changed:
cce_basic_config.install

