### PR TITLE
NEPT-1640: Feedback from QA, update file_entity to version + patch.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -285,10 +285,11 @@ projects[field_group][version] = "1.5"
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-6603
 projects[field_group][patch][] = https://www.drupal.org/files/issues/field_group_label_translation_patch.patch
 
-projects[file_entity][download][revision] = "f9b172177f340204fbed3ad0ac2fdcfef0d42271"
-projects[file_entity][download][type] = "git"
-projects[file_entity][download][url] = http://git.drupal.org/project/file_entity.git
 projects[file_entity][subdir] = "contrib"
+projects[file_entity][version] = "2.4"
+; https://www.drupal.org/node/2893132
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-672
+projects[file_entity][patch][] = https://www.drupal.org/files/issues/D7-file_entity-file_description_missing-2893132-2.patch
 
 projects[filefield_sources][subdir] = "contrib"
 projects[filefield_sources][version] = "1.10"


### PR DESCRIPTION
## NEPT-1640
### Description
Change the way we retrieve file_entity module, to be aligned with QA

### Change log

- Changed: multisite_drupal_standard.make file, changed to module version + patch instead of commit number

