### PR TITLE
NEPT-1038,NEPT-1107 update patch to not show the bean h2 when empty, Quicktab prevent logging missing cont:

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -580,6 +580,7 @@ projects[print][version] = "2.0"
 projects[quicktabs][subdir] = "contrib"
 projects[quicktabs][version] = "3.8"
 projects[quicktabs][patch][] = patches/quicktabs-MULTISITE-3880.patch
+projects[quicktabs][patch][2222805] = https://www.drupal.org/files/issues/quicktabs-log_empty-2222805-14.patch
 
 projects[rate][subdir] = "contrib"
 projects[rate][version] = "1.7"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -79,7 +79,7 @@ projects[bean][version] = 1.11
 ; Issue #2084823 : Contextual links for entity view
 ; https://www.drupal.org/node/2084823
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-12156
-projects[bean][patch][] = https://www.drupal.org/files/issues/2084823.patch
+projects[bean][patch][] = https://www.drupal.org/files/issues/bean-contextual_links_for_entity_view-2084823-18.patch
 
 projects[better_exposed_filters][subdir] = "contrib"
 projects[better_exposed_filters][version] = "3.4"


### PR DESCRIPTION
## NEPT-1038 ; NEPT-1107

### Description

Update patch to not show the bean h2 when empty.
Quicktab prevent logging missing content

### Change log

- Changed: Patch on drupal org to hide h2 when title is empty, and patch to not log empty tabs.

### Commands

```sh
drush cc all
```

