### PR TITLE
NEPT-1159: Update mpdf library source in make file.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -954,7 +954,7 @@ libraries[modernizr][destination] = "../common/libraries"
 libraries[mpdf][download][type]= "file"
 libraries[mpdf][download][request_type]= "get"
 libraries[mpdf][download][file_type] = "zip"
-libraries[mpdf][download][url] = https://github.com/mpdf/mpdf/archive/v6.1.0.zip
+libraries[mpdf][download][url] = https://github.com/mpdf/mpdf/releases/download/v6.1.0/01-mPDF-v6.1.0.zip
 libraries[mpdf][destination] = "libraries"
 
 ; Leaflet


### PR DESCRIPTION
## NEPT-1159
### Description

The folder graph_cache is empty on the downloaded archive, we change the library mpdf source in make file.

### Change log

- Changed:
resources/multisite_drupal_standard.make


### Commands



