### PR TITLE
  NEPT-1323 Upgrade metatag module version 1.21 to 1.22

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -488,11 +488,7 @@ projects[message][subdir] = "contrib"
 projects[message][version] = "1.10"
 
 projects[metatag][subdir] = "contrib"
-projects[metatag][version] = "1.21"
-; Notice : Undefined index: group in metatag_views_i18n_object_info()
-; https://www.drupal.org/node/2882048
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1039
-projects[metatag][patch][] = https://www.drupal.org/files/issues/undefined_group_in_i18n-2882048-5.patch 
+projects[metatag][version] = "1.22"
 
 ; A recent version of the Migrate module is pinned that contains a fix for
 ; https://www.drupal.org/node/2504517


### PR DESCRIPTION
## NEPT-1323

### Description

Upgrade metatag module version 1.21 to 1.22

### Change log

- Changed:
    Version 1.21 to 1.22
- Removed:
  Patch that is not needed [anymore](https://www.drupal.org/files/issues/undefined_group_in_i18n-2882048-5.patch)

### Commands

```sh
drush updb

```

