### PR TITLE
NEPT-1226 Upgrade module webform to version 7.x-4.16

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -749,8 +749,7 @@ projects[votingapi][subdir] = "contrib"
 projects[votingapi][version] = "2.12"
 
 projects[webform][subdir] = "contrib"
-projects[webform][version] = "4.12"
-projects[webform][patch][] = patches/webform-use_ecas_link-1235.patch
+projects[webform][version] = "4.16"
 
 projects[webform_rules][subdir] = "contrib"
 projects[webform_rules][version] = "1.6"


### PR DESCRIPTION
## NEPT-1226

### Description

  The module has been upgraded from 4.12 to 4.16 where it has already the previous patch applied, so the patch has been removed.

  As suggested in the ticket this branch will replace the previous nept-1226.


### Change log

- Changed:
 Version 4.12 to 4.16