### PR TITLE
NEPT-1325: Upgrade rules module to version 2.10

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -598,7 +598,11 @@ projects[registry_autoload][subdir] = "contrib"
 projects[registry_autoload][version] = 1.3
 
 projects[rules][subdir] = "contrib"
-projects[rules][version] = "2.9"
+projects[rules][version] = "2.10"
+; #2851567 rules_init() and cache rebuilding are broken
+; https://www.drupal.org/project/rules/issues/2851567
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1325
+projects[rules][patch][2851567] = https://www.drupal.org/files/issues/rules_init_and_cache-2851567-8.patch
 
 projects[scheduler][subdir] = "contrib"
 projects[scheduler][version] = 1.3


### PR DESCRIPTION
## NEPT-1325

### Description
Upgrade rules module to version 2.10

### Change log

- Changed: Version of rules module.

### Commands

```sh
drush updb

```

