### PR TITLE
NEPT-1753: Concatatenate the LANGUAGE_NONE instead of put between doubble quotes

### DIFF
--- a/profiles/common/modules/custom/multisite_drupal_language_negociation/multisite_drupal_language_negociation.module
+++ b/profiles/common/modules/custom/multisite_drupal_language_negociation/multisite_drupal_language_negociation.module
@@ -159,7 +159,7 @@ function multisite_drupal_language_negociation_views_query_alter(&$view, &$query
 
       // Conditions for the language selection and fallbacks.
       $query->add_where(0, "
-        (node.language IN (LANGUAGE_NONE, '$language->language'))
+        (node.language IN ('" . LANGUAGE_NONE . "', '$language->language'))
         OR (node.tnid = node.nid AND node_node.status = '0')
         OR (node.tnid = node.nid AND node_node.language IS NULL)
         OR (node.language = '$language_default->language' AND node.tnid = 0)


### PR DESCRIPTION
## NEPT-1753

### Description

Fix issue with the misuse of LANGUAGE_NONE in the multisite_drupal_language_negociation_views_query_alter

### Change log

- Fixed: misuse of LANGUAGE_NONE in the multisite_drupal_language_negociation_views_query_alter


### Commands


