### PR TITLE
NEPT-1756: Hide the label of the europasearch form by default

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1011,7 +1011,7 @@ libraries[respond][download][url] = https://raw.githubusercontent.com/scottjehl/
 projects[ec_resp][type] = theme
 projects[ec_resp][download][type] = git
 projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
-projects[ec_resp][download][tag] = 2.3.3
+projects[ec_resp][download][tag] = 2.3.4
 
 projects[atomium][type] = theme
 projects[atomium][download][type] = git


### PR DESCRIPTION
## NEPT-1756

### Description

Hide the label of the europasearch form by default

### Change log

- Changed: ec_resp version



