### PR TITLE
NEPT-1727: Upgrade Taxonomy Term Reference Tree Widget to 1.11.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -643,7 +643,7 @@ projects[tagclouds][subdir] = "contrib"
 projects[tagclouds][version] = "1.11"
 
 projects[term_reference_tree][subdir] = "contrib"
-projects[term_reference_tree][version] = "1.10"
+projects[term_reference_tree][version] = "1.11"
 projects[term_reference_tree][patch][] = patches/term_reference_tree-i18n-2000.patch
 projects[term_reference_tree][patch][] = patches/term_reference_tree-ie8-2000.patch
 


### PR DESCRIPTION
## NEPT-1727

### Description

 Upgrade the contrib module "Taxonomy Term Reference Tree Widget"

### Change log

Added:
- Changed: Upgrading the module to the version 1.11


### Commands

drush cc all

