### PR TITLE
NEPT-1909: Update versions of atomium (2.6) and ec_europa (0.0.8).

### DIFF
--- a/build.properties.dist
+++ b/build.properties.dist
@@ -14,7 +14,7 @@ platform.site.theme_default = ec_resp
 ecl.version = 0.18.0
 
 # The default EC Europa theme release
-ec_europa.version = 0.0.6
+ec_europa.version = 0.0.8
 
 # The default Atomium and Europa theme build properties.
 # Used only if default theme is set to "ec_europa".

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1016,9 +1016,9 @@ projects[ec_resp][download][tag] = 2.3.4
 projects[atomium][type] = theme
 projects[atomium][download][type] = git
 projects[atomium][download][url] = https://github.com/ec-europa/atomium.git
-projects[atomium][download][branch] = 7.x-2.x
+projects[atomium][download][tag] = 7.x-2.6
 
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
-projects[ec_europa][download][branch] = master
+projects[ec_europa][download][tag] = 0.0.8


### PR DESCRIPTION
## NEPT-1909

### Description

Update versions of atomium (2.6) and ec_europa (0.0.8).

### Change log

- Changed: make file and build.properties.dist

### Commands

drush cc all

