### PR TITLE
Nept 1495 update typo

### DIFF
--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -34,6 +34,9 @@
     <exclude-pattern>profiles/common/modules/features/multisite_wysiwyg/ckeditor/skins</exclude-pattern>
     <exclude-pattern>profiles/common/modules/custom/multisite_drupal_toolbox/icons</exclude-pattern>
 
+    <!-- This module is not supported by Core team so we exclude it from QA -->
+    <exclude-pattern>profiles/*/modules/custom/nexteuropa_newsroom/</exclude-pattern>
+
     <!-- Views handlers/plugins not strictly follow Drupal class name conventions. -->
     <rule ref="Drupal.NamingConventions.ValidClassName">
         <exclude-pattern>profiles/common/modules/custom/ecas/ecas_extra/includes/views/handlers/*.inc</exclude-pattern>

--- a/profiles/common/modules/features/events/events_og/events_og.install
+++ b/profiles/common/modules/features/events/events_og/events_og.install
@@ -67,7 +67,7 @@ function events_og_modules_enabled($modules) {
 /**
  * Add events options on "communities_menu_item" context.
  */
-function events_og_udpate_7101() {
+function events_og_update_7101() {
   multisite_drupal_toolbox_add_path_context('communities_menu_item', 'community/*/event/*');
   multisite_drupal_toolbox_add_views_context('communities_menu_item', 'calendar:month');
 }


### PR DESCRIPTION
## NEPT-1495

### Fix typo in update function

A typo exists in events_og_udpate_7101(). Also, Newsroom was excluded from the phpcs-ruleset.xml so I have added it back in.
