### PR TITLE
Add newsroom to phpcs exclusion

### DIFF
--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -37,7 +37,7 @@
     <!-- This module is not supported by Core team so we exclude it from QA -->
     <exclude-pattern>profiles/*/modules/custom/nexteuropa_newsroom/</exclude-pattern>
 
-    Views handlers/plugins not strictly follow Drupal class name conventions. -->
+    <!-- Views handlers/plugins not strictly follow Drupal class name conventions. -->
     <rule ref="Drupal.NamingConventions.ValidClassName">
         <exclude-pattern>profiles/common/modules/custom/ecas/ecas_extra/includes/views/handlers/*.inc</exclude-pattern>
         <exclude-pattern>profiles/common/modules/features/multisite_business_indicators/multisite_business_indicators_standard/includes/views_handler_*.inc</exclude-pattern>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -34,7 +34,10 @@
     <exclude-pattern>profiles/common/modules/features/multisite_wysiwyg/ckeditor/skins</exclude-pattern>
     <exclude-pattern>profiles/common/modules/custom/multisite_drupal_toolbox/icons</exclude-pattern>
 
-    <!-- Views handlers/plugins not strictly follow Drupal class name conventions. -->
+    <!-- This module is not supported by Core team so we exclude it from QA -->
+    <exclude-pattern>profiles/*/modules/custom/nexteuropa_newsroom/</exclude-pattern>
+
+    Views handlers/plugins not strictly follow Drupal class name conventions. -->
     <rule ref="Drupal.NamingConventions.ValidClassName">
         <exclude-pattern>profiles/common/modules/custom/ecas/ecas_extra/includes/views/handlers/*.inc</exclude-pattern>
         <exclude-pattern>profiles/common/modules/features/multisite_business_indicators/multisite_business_indicators_standard/includes/views_handler_*.inc</exclude-pattern>


### PR DESCRIPTION
## NEPT-1827

### Description

In some cases, it is impossible to push commit to github because the phpcs step raises errors on the "nexteuropa_newsroom" module.

That should never happen because "nexteuropa_newsroom" module is en external module that is not maintained by the platform team and does not belong to the project github repository.

The phpcs rules must be updated to exclude the module from the CS process.

### Change log

- Changed: /phpcs-ruleset.xml



