### PR TITLE
NEPT-1823: Fix the incorrect Poetry reference numbering

### DIFF
--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/plugins/tmgmt_poetry.plugin.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/plugins/tmgmt_poetry.plugin.inc
@@ -408,13 +408,15 @@ xsi:noNamespaceSchemaLocation=\"http://intragate.ec.europa.eu/DGT/poetry_service
     }
     else {
       // If it doesn't, check the highest numero.
-      $query = db_select('poetry_map', 'pm');
+      $query = db_select('poetry_map', 'pm')
+        ->condition('annee', date("Y"));
       $query->addExpression('MAX(numero)', 'max_numero');
       $max_numero = $query->execute()
         ->fetchAssoc();
       if (!empty($max_numero['max_numero'])) {
         $query = db_select('poetry_map', 'pm')
           ->fields('pm', array('annee', 'numero', 'version', 'partie'))
+          ->condition('annee', date("Y"))
           ->condition('numero', $max_numero['max_numero'], '=');
         $query->addExpression('MAX(partie)', 'max_partie');
         $result = $query->execute()


### PR DESCRIPTION
## NEPT-1823

### Description

Add condition on the current year into the "max" queries used in the poetry ref. generation.

### Change log

- Added: The generateRequestId method of TMGMTPoetryTranslatorPluginController

### Commands



