### PR TITLE
NEPCB-59: Access right issue on unpublished community resolved

### DIFF
--- a/profiles/multisite_drupal_communities/modules/custom/multisite_drupal_access/multisite_drupal_access.module
+++ b/profiles/multisite_drupal_communities/modules/custom/multisite_drupal_access/multisite_drupal_access.module
@@ -12,7 +12,7 @@ function multisite_drupal_access_node_access_records($node) {
   $grants = array();
 
   // Give the right for any users to view community type.
-  if ($node->type == 'community') {
+  if (($node->type == 'community') && $node->status) {
     $grants[] = array(
       'realm' => 'all',
       'gid' => 0,


### PR DESCRIPTION
## NEPCB-59

### Description

Security issue concerning the accessibility of unpublished “community” contents by anonymous users.

### Change log

- Added:
- Changed: Condition updated into hook_node_access_records()
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

drush php-eval if(variable_get("install_profile") == multisite_drupal_communities){node_access_rebuild();}


