### PR TITLE
NEPT-1824: Upgrade filefield_sources to 11.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -273,11 +273,7 @@ projects[file_entity][version] = "2.0-beta2"
 projects[file_entity][patch][] = https://www.drupal.org/files/issues/2537982-fix-changing-file-scheme.patch
 
 projects[filefield_sources][subdir] = "contrib"
-projects[filefield_sources][version] = "1.10"
-; Update custom version of file_save_upload() to match Drupal 7.56
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1185
-; https://www.drupal.org/node/2888308
-projects[filefield_sources][patch][] = https://www.drupal.org/files/issues/filefield-sources-2888308-2.patch
+projects[filefield_sources][version] = "1.11"
 
 projects[filefield_sources_plupload][subdir] = "contrib"
 projects[filefield_sources_plupload][version] = "1.1"


### PR DESCRIPTION
## NEPT-NEPT-1824

### Description

Upgrade FileField source to the latest version

### Change log

- Changed: multisite_drupal_standard.make

### Commands

drush cc all