### PR TITLE
nept-1849 Upgrade Drupal Core to 7.57

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = "core"
-projects[drupal][version] = "7.56"
+projects[drupal][version] = "7.57"
 
 ; AJAX callbacks not properly working with the language url suffix.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-4268


### PR DESCRIPTION
## NEPT-1849

### Description

Upgrade Drupal Core to 7.57