### PR TITLE
Upgrade entitycache to 7.x-1.5

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.helpers.inc
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.helpers.inc
@@ -41,7 +41,6 @@ function _cce_basic_config_import_images($images) {
   }
 }
 
-
 /**
  * Field widget form alter callback.
  *

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.module
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.module
@@ -359,3 +359,22 @@ function cce_basic_config_preprocess_container(&$variables) {
     $variables['theme_hook_suggestions'][] = $prefix . $suffix;
   }
 }
+
+/**
+ * Implements hook_entitycache_node_load().
+ *
+ * See https://www.drupal.org/project/entitycache/issues/2877280
+ * Nept-352.
+ */
+function cce_basic_config_entitycache_node_load(&$entities) {
+  $arg = arg();
+  if (count($arg) == 3 && $arg[0] == 'node' && $arg[2] == 'edit') {
+    $nid = $arg[1];
+    if (isset($entities[$nid])) {
+      $last_changed = node_last_changed($nid);
+      $entity = $entities[$nid];
+      $entity->changed = $last_changed;
+      $entities[$nid] = $entity;
+    }
+  }
+}

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.module
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.module
@@ -387,7 +387,9 @@ function cce_basic_config_entitycache_node_load(&$entities) {
       $entities[$nid] = $entity;
     }
   }
+}
 
+/**
  * Implements hook_field_widget_WIDGET_TYPE_form_alter().
  *
  * It implements it for "Text area" widget.

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -235,7 +235,7 @@ projects[entity_translation][patch][] = https://www.drupal.org/files/issues/enti
 projects[entity_translation][patch][] = https://www.drupal.org/files/issues/entity_translation-fix_content_translation_test-2877074-4.patch
 
 projects[entitycache][subdir] = "contrib"
-projects[entitycache][version] = 1.2
+projects[entitycache][version] = 1.5
 
 projects[entityreference][subdir] = "contrib"
 projects[entityreference][version] = "1.5"


### PR DESCRIPTION
## NEPT-352

### Description

Updated entitycache module to 1.5. Additional hook_entitycache_node_load to mitigate https://www.drupal.org/project/entitycache/issues/2877280

#### Command

drush updb entitycache
drush registry-rebuild ( https://www.drupal.org/project/entitycache/releases/7.x-1.5)
