### PR TITLE
NEPT-1080: Add link to DGT cart

### DIFF
--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/includes/forms/tmgmt_dgt_connector_form_cart_bundle_items.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/includes/forms/tmgmt_dgt_connector_form_cart_bundle_items.inc
@@ -200,9 +200,9 @@ function _tmgmt_dgt_connector_cart_update_cart_bundle(array &$form_state) {
 
   // Discard the CartBundle entity if needed and close the popup.
   if (_tmgmt_dgt_connector_cart_discard_cart_bundle($form_state, $cart_bundle)) {
-    $form_state['redirect'] = TMGMT_DGT_CONNECTOR_CART_VIEW_PATH;
+    $form_state['redirect'] = TMGMT_DGT_CART_VIEW_PATH;
     $form_state['ajax_commands'][] = ctools_modal_command_dismiss();
-    $form_state['ajax_commands'][] = ctools_ajax_command_redirect(TMGMT_DGT_CONNECTOR_CART_VIEW_PATH);
+    $form_state['ajax_commands'][] = ctools_ajax_command_redirect(TMGMT_DGT_CART_VIEW_PATH);
   }
 }
 

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/includes/forms/tmgmt_dgt_connector_form_cart_bundle_items.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/includes/forms/tmgmt_dgt_connector_form_cart_bundle_items.inc
@@ -200,9 +200,9 @@ function _tmgmt_dgt_connector_cart_update_cart_bundle(array &$form_state) {
 
   // Discard the CartBundle entity if needed and close the popup.
   if (_tmgmt_dgt_connector_cart_discard_cart_bundle($form_state, $cart_bundle)) {
-    $form_state['redirect'] = TMGMT_DGT_CART_VIEW_PATH;
+    $form_state['redirect'] = TMGMT_DGT_CONNECTOR_CART_VIEW_PATH;
     $form_state['ajax_commands'][] = ctools_modal_command_dismiss();
-    $form_state['ajax_commands'][] = ctools_ajax_command_redirect(TMGMT_DGT_CART_VIEW_PATH);
+    $form_state['ajax_commands'][] = ctools_ajax_command_redirect(TMGMT_DGT_CONNECTOR_CART_VIEW_PATH);
   }
 }
 

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/includes/views/tmgmt_dgt_connector_cart.views_default.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/includes/views/tmgmt_dgt_connector_cart.views_default.inc
@@ -274,7 +274,7 @@ function tmgmt_dgt_connector_cart_views_default_views() {
   $handler->display->display_options['display_description'] = 'Page view for the Cart Bundle entities';
   $handler->display->display_options['path'] = 'admin/tmgmt/dgt_cart';
   $handler->display->display_options['menu']['type'] = 'tab';
-  $handler->display->display_options['menu']['title'] = 'Small Jobs';
+  $handler->display->display_options['menu']['title'] = 'Small Jobs Cart';
   $handler->display->display_options['menu']['weight'] = '21';
   $handler->display->display_options['menu']['name'] = 'management';
   $handler->display->display_options['menu']['context'] = 0;

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/includes/views/tmgmt_dgt_connector_cart.views_default.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/includes/views/tmgmt_dgt_connector_cart.views_default.inc
@@ -272,7 +272,13 @@ function tmgmt_dgt_connector_cart_views_default_views() {
   /* Display: Cart Bundle | Page */
   $handler = $view->new_display('page', 'Cart Bundle | Page', 'cart_page_view');
   $handler->display->display_options['display_description'] = 'Page view for the Cart Bundle entities';
-  $handler->display->display_options['path'] = 'admin/dgt_connector/cart';
+  $handler->display->display_options['path'] = 'admin/tmgmt/dgt_cart';
+  $handler->display->display_options['menu']['type'] = 'tab';
+  $handler->display->display_options['menu']['title'] = 'Small Jobs';
+  $handler->display->display_options['menu']['weight'] = '21';
+  $handler->display->display_options['menu']['name'] = 'management';
+  $handler->display->display_options['menu']['context'] = 0;
+  $handler->display->display_options['menu']['context_only_inline'] = 0;
 
   $views[$view->name] = $view;
 

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/src/ViewsHandler/CartBundleActionsField.php
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/src/ViewsHandler/CartBundleActionsField.php
@@ -19,13 +19,13 @@ class CartBundleActionsField extends views_handler_field {
 
     $send_link = l(
       t('Send'),
-      "admin/dgt_connector/cart-items-send/$cbid",
+      "admin/tmgmt/dgt_cart/items-send/$cbid",
       array()
     );
 
     $edit_link = l(
       t('Edit'),
-      "admin/dgt_connector/cart-items-edit/$cbid/nojs",
+      "admin/tmgmt/dgt_cart/items-edit/$cbid/nojs",
       array(
         'attributes' => array(
           'class' => 'ctools-use-modal',
@@ -35,7 +35,7 @@ class CartBundleActionsField extends views_handler_field {
 
     $discard_link = l(
       t('Discard'),
-      "admin/dgt_connector/cart-items-discard/$cbid/nojs",
+      "admin/tmgmt/dgt_cart/items-discard/$cbid/nojs",
       array('query' => drupal_get_destination())
     );
 

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
@@ -42,27 +42,8 @@ function tmgmt_dgt_connector_cart_menu() {
     'access arguments' => array('access to the dgt connector cart'),
     'type' => MENU_CALLBACK,
   );
-  $items['admin/dgt_connector/cart222'] = array(
-    'title' => 'Small Jobs',
-    'title callback' => '_tmgmt_dgt_connector_cart_menu_title',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('tmgmt_ui_cart_content'),
-    'access arguments' => array('create translation jobs'),
-    'type' => MENU_NORMAL_ITEM,
-    'menu_name' => 'management',
-    'weight' => 21,
-  );
 
   return $items;
-}
-
-/**
- * Cart page title callback.
- *
- * @return string
- */
-function _tmgmt_dgt_connector_cart_menu_title() {
-  return t('Small Jobs (@count)', array('@count' => tmgmt_ui_cart_get()->count()));
 }
 
 /**

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
@@ -466,7 +466,7 @@ function _tmgmt_dgt_connector_cart_form_submit($form, &$form_state) {
   }
 
   drupal_set_message(t('The content has been added to the <a href="@url">cart</a>.', array(
-    '@url' => url('admin/dgt_connector/cart'),
+    '@url' => url('admin/tmgmt/dgt_cart'),
   )));
 }
 

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
@@ -42,8 +42,27 @@ function tmgmt_dgt_connector_cart_menu() {
     'access arguments' => array('access to the dgt connector cart'),
     'type' => MENU_CALLBACK,
   );
+  $items['admin/dgt_connector/cart222'] = array(
+    'title' => 'Small Jobs',
+    'title callback' => '_tmgmt_dgt_connector_cart_menu_title',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('tmgmt_ui_cart_content'),
+    'access arguments' => array('create translation jobs'),
+    'type' => MENU_NORMAL_ITEM,
+    'menu_name' => 'management',
+    'weight' => 21,
+  );
 
   return $items;
+}
+
+/**
+ * Cart page title callback.
+ *
+ * @return string
+ */
+function _tmgmt_dgt_connector_cart_menu_title() {
+  return t('Small Jobs (@count)', array('@count' => tmgmt_ui_cart_get()->count()));
 }
 
 /**
@@ -465,7 +484,9 @@ function _tmgmt_dgt_connector_cart_form_submit($form, &$form_state) {
     return;
   }
 
-  drupal_set_message(t('The content has been added to the cart.'));
+  drupal_set_message(t('The content has been added to the <a href="@url">cart</a>.', array(
+    '@url' => url('admin/dgt_connector/cart'),
+  )));
 }
 
 /**

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
@@ -8,7 +8,7 @@
 use Drupal\tmgmt_dgt_connector_cart\Entity\CartBundle;
 use Drupal\tmgmt_dgt_connector_cart\Entity\CartItem;
 
-define('TMGMT_DGT_CART_VIEW_PATH', 'admin/tmgmt/dgt_cart');
+define('TMGMT_DGT_CONNECTOR_CART_VIEW_PATH', 'admin/tmgmt/dgt_cart');
 
 // Including the custom form callback.
 module_load_include('inc', 'tmgmt_dgt_connector_cart', 'includes/tmgmt_dgt_connector_cart');
@@ -44,6 +44,16 @@ function tmgmt_dgt_connector_cart_menu() {
   );
 
   return $items;
+}
+
+/**
+ * Implements hook_menu_alter().
+ *
+ * Update menu link's title to distinguish from Small Jobs Cart.
+ */
+function tmgmt_dgt_connector_cart_menu_alter(&$items) {
+  $items['admin/tmgmt/cart']['title'] = 'TMGMT Cart';
+  unset($items['admin/tmgmt/cart']['title callback']);
 }
 
 /**

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
@@ -8,7 +8,7 @@
 use Drupal\tmgmt_dgt_connector_cart\Entity\CartBundle;
 use Drupal\tmgmt_dgt_connector_cart\Entity\CartItem;
 
-define('TMGMT_DGT_CONNECTOR_CART_VIEW_PATH', 'admin/dgt_connector/cart');
+define('TMGMT_DGT_CART_VIEW_PATH', 'admin/tmgmt/dgt_cart');
 
 // Including the custom form callback.
 module_load_include('inc', 'tmgmt_dgt_connector_cart', 'includes/tmgmt_dgt_connector_cart');
@@ -21,23 +21,23 @@ module_load_include('inc', 'tmgmt_dgt_connector_cart', 'includes/forms/tmgmt_dgt
 function tmgmt_dgt_connector_cart_menu() {
   $items = array();
 
-  $items['admin/dgt_connector/cart-items-edit/%/%ctools_js'] = array(
+  $items['admin/tmgmt/dgt_cart/items-edit/%/%ctools_js'] = array(
     'page callback' => '_tmgmt_dgt_connector_cart_cart_bundle_edit_wrapper',
-    'page arguments' => array(3, 4),
+    'page arguments' => array(4, 5),
     'access callback' => 'user_access',
     'access arguments' => array('access to the dgt connector cart'),
     'type' => MENU_CALLBACK,
   );
-  $items['admin/dgt_connector/cart-items-send/%'] = array(
+  $items['admin/tmgmt/dgt_cart/items-send/%'] = array(
     'page callback' => '_tmgmt_dgt_connector_cart_cart_bundle_send_wrapper',
-    'page arguments' => array(3, 4),
+    'page arguments' => array(4, 5),
     'access callback' => 'user_access',
     'access arguments' => array('access to the dgt connector cart'),
     'type' => MENU_CALLBACK,
   );
-  $items['admin/dgt_connector/cart-items-discard/%/%ctools_js'] = array(
+  $items['admin/tmgmt/dgt_cart/items-discard/%/%ctools_js'] = array(
     'page callback' => '_tmgmt_dgt_connector_cart_form_cart_bundle_discard_wrapper',
-    'page arguments' => array(3, 4),
+    'page arguments' => array(4, 5),
     'access callback' => 'user_access',
     'access arguments' => array('access to the dgt connector cart'),
     'type' => MENU_CALLBACK,

--- a/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.views_default.inc
+++ b/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.views_default.inc
@@ -23,7 +23,7 @@ function nexteuropa_multilingual_views_default_views() {
 
   /* Display: Master */
   $handler = $view->new_display('default', 'Master', 'default');
-  $handler->display->display_options['title'] = 'Recent translation jobs';
+  $handler->display->display_options['title'] = 'Recent jobs';
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'tmgmt_views_job_access';
   $handler->display->display_options['cache']['type'] = 'none';
@@ -363,7 +363,7 @@ function nexteuropa_multilingual_views_default_views() {
   $handler = $view->new_display('page', 'Page', 'page');
   $handler->display->display_options['path'] = 'admin/tmgmt/recent-changes';
   $handler->display->display_options['menu']['type'] = 'tab';
-  $handler->display->display_options['menu']['title'] = 'Recent translation jobs';
+  $handler->display->display_options['menu']['title'] = 'Recent jobs';
   $handler->display->display_options['menu']['weight'] = '1';
   $handler->display->display_options['menu']['context'] = 0;
   $handler->display->display_options['menu']['context_only_inline'] = 0;

--- a/tests/behat.yml.dist
+++ b/tests/behat.yml.dist
@@ -96,6 +96,7 @@ default:
         header_top: ".region-header-top"
         header: "#layout-header"
         primary_tabs: ".ecl-navigation-list--tabs"
+        back_primary_tabs: ".tabs.primary"
         content: ".page-content"
         footer: "#layout-footer"
         messages: "#console"

--- a/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
+++ b/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
@@ -48,7 +48,8 @@ Feature: TMGMT Poetry Cart features
 
     When I am not logged in
     And I am logged in as "admin_cart"
-    And I go to "admin/tmgmt/dgt_cart"
+    And I click "Translation" in the "admin_menu"
+    And I click "Small Jobs Cart" in the "back_primary_tabs"
     And I click "Edit" in the "Target languages: FR, PT" row
     And I wait for AJAX to finish
     And I should see text matching "Translation Bundle content."

--- a/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
+++ b/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
@@ -1,4 +1,4 @@
-@api @poetry_mock @i18n @poetry @theme_wip
+@api @poetry_mock @i18n @poetry
 Feature: TMGMT Poetry Cart features
   In order to request Carts translations with Poetry service.
   As an Administrator
@@ -45,6 +45,8 @@ Feature: TMGMT Poetry Cart features
     And I check the box on the "Portuguese, Portugal" row
     And I press "Send to cart"
     Then I should see the success message "The content has been added to the cart."
+    When I click "cart"
+    And I should see "Target languages: FR, PT"
 
     When I am not logged in
     And I am logged in as "admin_cart"

--- a/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
+++ b/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
@@ -48,7 +48,7 @@ Feature: TMGMT Poetry Cart features
 
     When I am not logged in
     And I am logged in as "admin_cart"
-    And I go to "admin/dgt_connector/cart"
+    And I go to "admin/tmgmt/dgt_cart"
     And I click "Edit" in the "Target languages: FR, PT" row
     And I wait for AJAX to finish
     And I should see text matching "Translation Bundle content."


### PR DESCRIPTION
## NEPT-1080

### Description

Add link Small Jobs, to DGT Cart page, in TMGMT page and menu.

### Change log

- Added: Small Jobs link to DGT cart.
- Changed: Cart Bundle URL (from admin/dgt_connector/cart to admin/tmgmt/dgt_cart).
- Changed: Message after adding to the cart as now link to cart page.

### Commands

No commands needed.

