### PR TITLE
NEPT-1879: Improve the control on the pop-up display limitations.

### DIFF
--- a/profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.info
+++ b/profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.info
@@ -1,5 +1,6 @@
 name = Nexteuropa geofield
 description = Manage geojson data field
+php = 5.6
 core = 7.x
 package = NextEuropa
 features[features_api][] = api:2

--- a/profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module
+++ b/profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module
@@ -6,6 +6,33 @@
  */
 
 /**
+ * Defines the list of HTML tags authorized in the map pop-ups (bubbles).
+ */
+const ALLOWED_HTML_TAGS = array(
+  'a',
+  'abbr',
+  'b',
+  'bdo',
+  'br',
+  'cite',
+  'code',
+  'dfn',
+  'em',
+  'i',
+  'img',
+  'kbd',
+  'q',
+  'samp',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'sup',
+  'time',
+  'var',
+);
+
+/**
  * Implements hook_field_schema().
  */
 function nexteuropa_geofield_field_schema($field) {
@@ -266,6 +293,9 @@ function nexteuropa_geofield_field_formatter_view($entity_type, $entity, $field,
   $element = array();
   $settings = $instance['widget']['settings'];
 
+  // Filter the item value against XSS vulnerabilities.
+  $value = isset($items[0]['geofield_geojson']) ? _nexteuropa_geofield_field_filter_xss_values($items[0]['geofield_geojson']) : '';
+
   switch ($display['type']) {
     case 'geofield_geojson_raw':
       $element[0] = array(
@@ -274,12 +304,11 @@ function nexteuropa_geofield_field_formatter_view($entity_type, $entity, $field,
         '#attributes' => array(
           'id' => 'geofield_geojson_raw',
         ),
-        '#value' => isset($items[0]['geofield_geojson']) ? $items[0]['geofield_geojson'] : '',
+        '#value' => $value,
       );
       break;
 
     case 'geofield_geojson_map_format':
-      $value = isset($items[0]['geofield_geojson']) ? $items[0]['geofield_geojson'] : '';
       $element[0] = array(
         '#type' => 'markup',
         '#markup' => '<div id="geofield_geojson_map"></div><div id="geofield_geojson_map_wrapper"></div>',
@@ -302,6 +331,49 @@ function nexteuropa_geofield_field_formatter_view($entity_type, $entity, $field,
       break;
   }
   return $element;
+}
+
+/**
+ * Filters the JSON "properties" elements against XSS vulnerabilities.
+ *
+ * @param string $geojson
+ *   The JSON definition to filter.
+ *
+ * @return string
+ *   The JSON with the filtered properties "label", "name" and "description".
+ *   These properties are the only vulnerable ones; the others prevent the
+ *   map to work.
+ */
+function _nexteuropa_geofield_field_filter_xss_values($geojson) {
+  if (empty($geojson)) {
+    return '';
+  }
+
+  $array = drupal_json_decode($geojson);
+
+  if (empty($array['features'])) {
+    return $geojson;
+  }
+  $features = &$array['features'];
+  foreach ($array['features'] as $key => $feature) {
+    if (empty($feature['properties'])) {
+      continue;
+    }
+
+    if (!empty($feature['properties']['label'])) {
+      $features[$key]['properties']['label'] = filter_xss($feature['properties']['label'], ALLOWED_HTML_TAGS);
+    }
+
+    if (!empty($feature['properties']['name'])) {
+      $features[$key]['properties']['name'] = filter_xss($feature['properties']['name'], ALLOWED_HTML_TAGS);
+    }
+
+    if (!empty($feature['properties']['description'])) {
+      $features[$key]['properties']['description'] = filter_xss($feature['properties']['description'], ALLOWED_HTML_TAGS);
+    }
+  }
+
+  return drupal_json_encode($array);
 }
 
 /**


### PR DESCRIPTION
## NEPT-1879

### Description

Limit the use of HTML tags to inline one in the nexteuropa_geofield fields.

### Change log

- Changed: Add filter to limit the HTML tags uses in nexteuropa_geofield fields.

### Commands

drush cc all

