### PR TITLE
NEPT-1894: Add "defer_on_js_to_load" paremeter and the "defer" attribute in nexteuropa_json_field

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_json_field/nexteuropa_json_field.module
+++ b/profiles/common/modules/custom/nexteuropa_json_field/nexteuropa_json_field.module
@@ -28,7 +28,6 @@ function nexteuropa_json_field_field_info() {
  */
 function nexteuropa_json_field_field_instance_settings_form($field, $instance) {
   $options = module_invoke_all('json_field_js_to_load');
-
   $form = array();
 
   if (!empty($options)) {
@@ -39,8 +38,21 @@ function nexteuropa_json_field_field_instance_settings_form($field, $instance) {
       '#default_value' => isset($settings['js_to_load']) ? $settings['js_to_load'] : array(),
       '#options' => $options,
       '#description' => t('Select external javascripts to load for this field'),
+      '#weight' => 1,
+    );
+
+    $form['defer_on_js_to_load'] = array(
+      '#type' => 'checkboxes',
+      '#title' => t('Add the "refer" attribute to'),
+      '#default_value' => isset($settings['defer_on_js_to_load']) ? $settings['defer_on_js_to_load'] : array(),
+      '#options' => $options,
+      '#description' => t(
+        'Add the "<a href="@url" target="_blank">refer</a>" attribute in the &lt;script&gt; HTML tag of the Javascript files selected above.',
+        array('@url' => 'https://dev.w3.org/html5/spec-preview/the-script-element.html#attr-script-defer')),
+      '#weight' => 2,
     );
   }
+
   return $form;
 }
 
@@ -80,12 +92,30 @@ function nexteuropa_json_field_field_formatter_view($entity_type, $entity, $fiel
       $settings = $instance['settings'];
       if (isset($settings['js_to_load']) && !empty($settings['js_to_load'])) {
         static $javascript_included;
-        foreach ($settings['js_to_load'] as $js_variable) {
+
+        $defer_settings = (!empty($settings['defer_on_js_to_load'])) ? $settings['defer_on_js_to_load'] : array();
+
+        foreach ($settings['js_to_load'] as $key => $js_variable) {
+          // If the field instance is saved and a listed "js to load" is not
+          // selected, $js_variable == 0 instead of the parameter name.
+          if (empty($js_variable)) {
+            continue;
+          }
+
           $js_url = variable_get($js_variable, '');
+
           if ($js_url != '' && !$javascript_included[$js_variable]) {
+            // NEPT-1894: The $defer parameter is set as below in order to
+            // ensure the backward compatibility of this evolution without
+            // implying a hook_update that was forbidden at implementation time.
+            $defer = TRUE;
+            if (isset($defer_settings[$key])) {
+              $defer = $defer_settings[$key];
+            }
+
             // Ensure to use a PR URL (compatibility for http/https).
             $js_url = preg_replace("#^https?:#", "", $js_url);
-            drupal_add_js($js_url, 'external');
+            drupal_add_js($js_url, array('type' => 'external', 'defer' => $defer));
             $javascript_included[$js_variable] = TRUE;
           }
         }

--- a/profiles/common/modules/features/nexteuropa_webtools/nexteuropa_webtools.admin.inc
+++ b/profiles/common/modules/features/nexteuropa_webtools/nexteuropa_webtools.admin.inc
@@ -13,7 +13,7 @@ function nexteuropa_webtools_settings_form() {
 
   $form['nexteuropa_webtools_smartloader_prurl'] = array(
     '#type' => 'textfield',
-    '#title' => t('Smarloader Protocol-Relative URL'),
+    '#title' => t('Smartloader Protocol-Relative URL'),
     '#default_value' => variable_get('nexteuropa_webtools_smartloader_prurl', ''),
     '#description' => t("The URL of the webtools smartloader script. e.g. '//example.com/load.js'"),
     '#required' => TRUE,

--- a/profiles/common/modules/features/nexteuropa_webtools/nexteuropa_webtools.features.field_instance.inc
+++ b/profiles/common/modules/features/nexteuropa_webtools/nexteuropa_webtools.features.field_instance.inc
@@ -215,6 +215,9 @@ function nexteuropa_webtools_field_default_field_instances() {
       'js_to_load' => array(
         'nexteuropa_webtools_smartloader_prurl' => 'nexteuropa_webtools_smartloader_prurl',
       ),
+      'defer_on_js_to_load' => array(
+        'nexteuropa_webtools_smartloader_prurl' => 'nexteuropa_webtools_smartloader_prurl',
+      ),
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),

--- a/profiles/common/modules/features/nexteuropa_webtools/nexteuropa_webtools.install
+++ b/profiles/common/modules/features/nexteuropa_webtools/nexteuropa_webtools.install
@@ -38,3 +38,15 @@ function nexteuropa_webtools_requirements($phase) {
   }
   return $requirements;
 }
+
+/**
+ * Set defer_on_js_to_load for "bean-webtools-field_json_object" field.
+ */
+function nexteuropa_webtools_update_7001() {
+  // Needs to flush the cache before the revert.
+  // The hook update meet the same issue described in
+  // https://www.drupal.org/project/i18n/issues/2082573.
+  // The cache flush was enough to fix.
+  drupal_flush_all_caches();
+  features_revert_module('nexteuropa_webtools');
+}


### PR DESCRIPTION
## NEPT-1894

### Description

Add the "defer" attribute on the script HTMl tag generated by nexteuropa_json_field

### Change log

- Added: The field setting parameter "defer_on_js_to_load" for "JSON settings" fields
- Added: hoo_update to enable the "defer" insertion for webtools blocks.
- Changed: Set the "field_json_object" field of the web tools block type to take into account of "defer_on_js_to_load"     

### Commands

drush udpatedb