### PR TITLE
NEPT-1902: Use the release 0.1.0 of nexteuropa_poetry

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1045,8 +1045,8 @@ projects[ec_europa][download][tag] = 0.0.10
 ; Custom modules
 ; ==============
 
-projects[nexteuropa_poetry][subdir] = "contrib"
-projects[nexteuropa_poetry][type] = module
-projects[nexteuropa_poetry][download][type] = git
-projects[nexteuropa_poetry][download][url] = https://github.com/ec-europa/nexteuropa_poetry.git
-projects[nexteuropa_poetry][download][branch] = master
+projects[nexteuropa_poetry][download][type] = get
+projects[nexteuropa_poetry][download][file_type] = "zip"
+projects[nexteuropa_poetry][download][url] = https://github.com/ec-europa/nexteuropa_poetry/archive/0.1.0.zip
+projects[nexteuropa_poetry][subdir] = contrib
+

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1050,4 +1050,3 @@ projects[nexteuropa_poetry][type] = module
 projects[nexteuropa_poetry][download][type] = git
 projects[nexteuropa_poetry][download][url] = https://github.com/ec-europa/nexteuropa_poetry.git
 projects[nexteuropa_poetry][download][tag] = 0.1.0
-

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1045,8 +1045,9 @@ projects[ec_europa][download][tag] = 0.0.10
 ; Custom modules
 ; ==============
 
-projects[nexteuropa_poetry][download][type] = get
-projects[nexteuropa_poetry][download][file_type] = "zip"
-projects[nexteuropa_poetry][download][url] = https://github.com/ec-europa/nexteuropa_poetry/archive/0.1.0.zip
-projects[nexteuropa_poetry][subdir] = contrib
+projects[nexteuropa_poetry][subdir] = "contrib"
+projects[nexteuropa_poetry][type] = module
+projects[nexteuropa_poetry][download][type] = git
+projects[nexteuropa_poetry][download][url] = https://github.com/ec-europa/nexteuropa_poetry.git
+projects[nexteuropa_poetry][download][tag] = 0.1.0
 


### PR DESCRIPTION
## NEPT-1902

### Description

Use the release 0.1.0 of nexteuropa_poetry instead of the master branch.

### Change log

- Changed: nexteuropa_poetry declaration in the resources/multisite_drupal_standard.make

### Commands

No command

