### PR TITLE
NEPT-1259: mpdf library: reduce its weight

### DIFF
--- a/build.package.xml
+++ b/build.package.xml
@@ -62,6 +62,18 @@
             <!-- Install all contributed projects inside the chosen profile. -->
             <option name="contrib-destination">profiles/${platform.profile.name}</option>
         </drush>
+        <!-- Delete fonts from mpdf -->
+        <delete>
+          <fileset dir="${platform.build.dir}/profiles/multisite_drupal_standard/libraries/mpdf/ttfonts" >
+            <include name="*.*" />
+          </fileset>
+        </delete>
+        <!-- Download fonts from mpdf 5.7.4. and add them to mpdf-->
+        <exec
+            command="curl -L https://github.com/mpdf/mpdf/archive/v5.7.4.zip -o ${project.basedir}/mpdf-5.7.4.zip"/>
+        <exec
+            command="unzip -j ${project.basedir}/mpdf-5.7.4.zip 'mpdf-5.7.4/ttfonts/*' -d ${platform.build.dir}/profiles/multisite_drupal_standard/libraries/mpdf/ttfonts"/>
+        <delete file="${project.basedir}/mpdf-5.7.4.zip" includeemptydirs="true" verbose="true" failonerror="true" />
     </target>
 
     <!-- Make one of the profiles in order to build a multisite platform. -->


### PR DESCRIPTION
## NEPT-1259

### Description

Reduce the size of the mpdf library by using the fonts from the 2.2 release

### Change log

- Added: Added to the build process the fonts from https://github.com/mpdf/mpdf/archive/v5.7.4.zip

### Commands

Requires building the platform 
