### PR TITLE
NEPT-1441: CLONE - [nexteuropa_mediagallery] minimal typo in package name at .info file

### DIFF
--- a/profiles/common/modules/features/nexteuropa_mediagallery/nexteuropa_mediagallery.info
+++ b/profiles/common/modules/features/nexteuropa_mediagallery/nexteuropa_mediagallery.info
@@ -1,7 +1,7 @@
 name = Nexteuropa Media Gallery
 description = Add Gallery content type for display in a galleries page and block
 core = 7.x
-package = Nexteuropa
+package = NextEuropa
 dependencies[] = cce_basic_config
 dependencies[] = ds
 dependencies[] = ec_embedded_video


### PR DESCRIPTION
## NEPT-1441

### Description

Fix nexteuropa_multimedia package name

### Change log


- Changed: Change package name to NextEuropa
