### PR TITLE
NEPT-1828: Upgrade the ec_resp release version

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1033,7 +1033,7 @@ libraries[respond][download][url] = https://raw.githubusercontent.com/scottjehl/
 projects[ec_resp][type] = theme
 projects[ec_resp][download][type] = git
 projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
-projects[ec_resp][download][tag] = 2.3.6
+projects[ec_resp][download][branch] = nept-1828
 
 projects[atomium][type] = theme
 projects[atomium][version] = 2.7

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1033,7 +1033,7 @@ libraries[respond][download][url] = https://raw.githubusercontent.com/scottjehl/
 projects[ec_resp][type] = theme
 projects[ec_resp][download][type] = git
 projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
-projects[ec_resp][download][branch] = nept-1828
+projects[ec_resp][download][tag] = 2.3.7
 
 projects[atomium][type] = theme
 projects[atomium][version] = 2.7


### PR DESCRIPTION
## NEPT-1828

### Description

Upgrade ec_resp to latest release.

### Change log

- Changed: resources/multisite_drupal_standard.make to change the ec_resp release number

### Commands

drush cc all

