### PR TITLE
NEPT-478: Add news behat feature and the News README.md

### DIFF
--- a/profiles/common/modules/features/news/README.md
+++ b/profiles/common/modules/features/news/README.md
@@ -1,0 +1,49 @@
+The "News" feature provides a link in the main menu to the list of news, and allows filtering news according to the community in "multisite_drupal_communities" configuration.
+
+Table of content:
+=================
+- [Important](#important)
+- [Installation](#installation)
+- [Usage](#usage)
+
+# Important
+
+News uses 3 modules to work. "news_core" is not designed to work alone, but with one of the 2 other sub-modules depending on the profile configuration used in the site.
+
+ [Go to top](#table-of-content)
+
+
+# Installation
+
+For "multisite_drupal_standard" configuration enable the modules "news_core" and "news_standard".
+For "multisite_drupal_communities" configuration enable the modules "news_core" and "news_og".
+
+[Go to top](#table-of-content)
+
+# Usage
+
+## Standard configuration
+### News list
+- News feature adds a "News" link in the main menu with the News list.
+
+## Communities configuration:
+
+### Propose News for publication
+- A Member can create a news as any other content. When the news is saved, it will remain ad "Draft" or "Needs Review".<br />
+To request approval from community manager the news must be saved with the moderation state of "Needs Review".
+
+### Community News
+- A Member can see private news according to his membership by going to the community page.<br />
+The community page will filter the news of this community for its members.
+
+### Public News
+- A User can see featured public news on the homepage
+- A User can go to the public news section thanks to the "News" item in the main menu and see the list of public news but not the private, that are only for the community members.
+
+### Flag News
+- A Community manager can flag news within his community as "highlighted" while creating or editing a news:
+  - Check "Promoted to front page" to make the news appear at community's homepage.
+  - Check "Sticky at top of lists" to keep it always at top.
+- A Community manager can manage News within his community thanks to my workbench.
+
+[Go to top](#table-of-content)

--- a/tests/features/news/news_communities.feature
+++ b/tests/features/news/news_communities.feature
@@ -1,0 +1,195 @@
+@api @javascript @communities @theme_wip
+Feature: news standard and news core
+  In order to publish news
+  As different types of users
+  I want to be able to propose news
+
+  Background:
+    Given I use device with "1920" px and "1080" px resolution
+    Given the module is enabled
+      | modules       |
+      | news_core     |
+      | news_og       |
+    Given I am viewing a "community" content:
+      | title                          | Public community 1  |
+      | workbench_moderation_state     | published           |
+      | workbench_moderation_state_new | published           |
+    And I am viewing a "news" content:
+      | title                          | News test 1 public |
+      | author                         | admin              |
+      | body                           | news test 1 body   |
+      | field_news_publication_date    | 1510226280         |
+      | group_content_access           | 1                  |
+      | og_group_ref                   | Public community 1 |
+      | status                         | 1                  |
+      | workbench_moderation_state     | published          |
+      | workbench_moderation_state_new | published          |
+    And I am viewing a "news" content:
+      | title                          | News test 2 public highlighted |
+      | author                         | admin              |
+      | body                           | news test 2 body   |
+      | field_news_publication_date    | 1510226280         |
+      | og_group_ref                   | Public community 1 |
+      | group_content_access           | 1                  |
+      | field_highlighted              | highlight          |
+      | workbench_moderation_state     | published          |
+      | workbench_moderation_state_new | published          |
+      | status                         | 1                  |
+    And I am viewing a "news" content:
+      | title                          | News test 3 private higlighted|
+      | author                         | admin                         |
+      | body                           | news test 2 body              |
+      | field_news_publication_date    | 1510226280                    |
+      | og_group_ref                   | Public community 1            |
+      | group_content_access           | 2                             |
+      | field_highlighted              | highlight                     |
+      | workbench_moderation_state     | published                     |
+      | workbench_moderation_state_new | published                     |
+      | status                         | 1                             |
+    Given users:
+      | username      | name          | password | mail                   | roles         |
+      | administrator | administrator | pass     | administrator@test.com | administrator |
+      | contributor   | contributor   | pass     | contributor@test.com   | contributor   |
+    Given I am logged in as "administrator"
+    And   I have the "administrator member" role in the "Public community 1" group
+    When  I go to "/community/public-community-1"
+    And   I click "News" in the "sidebar_left" region
+    And   I wait
+    And   I click "News test 2 public highlighted"
+    And   I click "New draft"
+    And   I follow "Publishing options"
+    And   I select "Published" from "Moderation state"
+    And   I press "Save"
+    When  I go to "/community/public-community-1"
+    And   I click "News" in the "sidebar_left" region
+    And   I wait
+    And   I click "News test 3 private higlighted"
+    And   I click "New draft"
+    And   I follow "Publishing options"
+    And   I select "Published" from "Moderation state"
+    And   I press "Save"
+    When  I go to "/community/public-community-1"
+    And   I click "News" in the "sidebar_left" region
+    And   I wait
+    And   I click "News test 1 public"
+    And   I click "New draft"
+    And   I follow "Publishing options"
+    And   I select "Published" from "Moderation state"
+    And   I press "Save"
+
+
+  Scenario: as User, I can go to the public news section thanks to the "News" item in the main menu
+    Given I am on "/"
+    Then  I should see the link "Communities"
+    Then  I should see the link "News"
+    When  I click "News"
+    Then  I should be on "/news_public"
+    And   I should see the text "News"
+
+  Scenario: as Member I can propose news for publication to the community manager
+    Given I am logged in as "contributor"
+    And   I have the "member" role in the "Public community 1" group
+    When  I go to "communities_directory/my"
+    Then  I should see "Public community 1"
+    And   I click "Public community 1"
+    And   I click "Create content"
+    And   I click on the element with xpath "//*[@id='block-multisite-og-button-og-contextual-links']/div/ul/li[2]/a"
+    And   I fill in "edit-title" with "Test news behat"
+    And   I fill in the rich text editor "Body" with "Body for test news behat"
+    And   I wait
+    And   I click "Community"
+    And   I check "highlight"
+    And   I select "Public - accessible to all site users" from "Group content visibility"
+    And   I click "Revision information"
+    And   I select "Needs Review" from "Moderation state"
+    And   I press "Save"
+    And   I should see the text "News Test news behat has been created"
+    And   I should see the text "Latest content"
+    But   I should not see the link "Test news behat"
+
+  Scenario: as Community manager I can create a news and publish it
+    Given I am logged in as "administrator"
+    And   I have the "member" role in the "Public community 1" group
+    When  I go to "communities_directory/my"
+    Then  I should see "Public community 1"
+    And   I click "Public community 1"
+    And   I click "Create content"
+    And   I click on the element with xpath "//*[@id='block-multisite-og-button-og-contextual-links']/div/ul/li[2]/a"
+    And   I fill in "edit-title" with "Test news behat"
+    And   I fill in the rich text editor "Body" with "Body for test news behat"
+    And   I wait
+    And   I click on the element with xpath "//*[@id='news-node-form']/div/div[1]/ul/li[4]/a/strong"
+    And   I check "highlight"
+    And   I select "Public - accessible to all site users" from "Group content visibility"
+    And   I follow "Publishing options"
+    And   I select "Published" from "Moderation state"
+    And   I press "Save"
+    And   I should see the text "News Test news behat has been created"
+    And   I should see the text "Latest content"
+    And   I should see the link "Test news behat"
+
+  Scenario: as member I can see private news according to my membership
+    Given I am logged in as a user with the 'contributor' role and I have the following fields:
+      | username | contributor2          |
+      | name     | contributor2          |
+      | mail     | contributor2@test.com |
+      | pass     | contributor          |
+    And  I have the "administrator member" role in the "Public community 1" group
+    When I go to "communities_directory/my"
+    And  I click "Public community 1"
+    Then I should see "members list" in the "sidebar_left" region
+    And  I should see the link "contributor" in the "sidebar_left" region
+    Then I should see the text "Highlighted news" in the "content_top" region
+    Then I should see the link "News test 2 public highlighted" in the "content_top" region
+    Then I should see the link "News test 3 private higlighted" in the "content_top" region
+    But  I should not see the link "News test 1 public" in the "content_top" region
+    And  I should see "Latest Content"
+    And  I should see the link "News test 3 private higlighted" in the "sidebar_left" region
+    And  I should see the link "News test 2 public highlighted" in the "sidebar_left" region
+    And  I should see the link "News test 1 public" in the "sidebar_left" region
+    When I click "News test 2 public highlighted"
+    Then I should see the heading "News test 2 public highlighted"
+
+  Scenario: as user, I can see public news on the homepage
+    Given I am not logged in
+    When  I go to homepage
+    Then  I should see "News test 2 public highlighted"
+    And   I should see "News test 1 public"
+    But   I should not see "News test 3 private higlighted"
+    And   I click "News test 2 public highlighted"
+    Then  I should see the heading "News test 2 public highlighted"
+
+  Scenario: as Community manager, I can flag news within my community as "Top news" so that they appear at site's homepage
+    Given I am logged in as "administrator"
+    And   I have the "administrator member" role in the "Public community 1" group
+    When  I go to "/community/public-community-1"
+    And   I click "News" in the "sidebar_left" region
+    And   I wait
+    And   I click "News test 1 public"
+    And   I click "New draft"
+    And   I follow "Publishing options"
+    And   I check "Promoted to front page"
+    And   I check "Sticky at top of lists"
+    And   I select "Published" from "Moderation state"
+    And   I press "Save"
+    And   I go to homepage
+    And   I should see the link "News test 1 public"
+    And   I should see the link "Read more"
+    And   I should see the link "about News test 1 public"
+
+  Scenario: as Community manager, I can flag news within my community as "highlighted" so that they appear at community's homepage
+    Given I am logged in as "administrator"
+    And   I have the "administrator member" role in the "Public community 1" group
+    When  I go to "/community/public-community-1"
+    And   I click "News" in the "sidebar_left" region
+    And   I wait
+    And   I click "News test 1 public"
+    And   I click "New draft"
+    And   I click on the element with xpath "//*[@id='news-node-form']/div/div[1]/ul/li[4]/a/strong"
+    And   I check "highlight"
+    And   I follow "Publishing options"
+    And   I select "Published" from "Moderation state"
+    And   I press "Save"
+    When  I go to "communities_directory/my"
+    And   I click "Public community 1"
+    Then  I should see the link "News test 1 public" in the "content_top" region

--- a/tests/features/news/news_communities.feature
+++ b/tests/features/news/news_communities.feature
@@ -1,16 +1,15 @@
-@api @javascript @communities @theme_wip
+@api @communities @javascript @maximizedwindow
 Feature: news standard and news core
   In order to publish news
   As different types of users
   I want to be able to propose news
 
   Background:
-    Given I use device with "1920" px and "1080" px resolution
     Given the module is enabled
       | modules       |
       | news_core     |
       | news_og       |
-    Given I am viewing a "community" content:
+    And I am viewing a "community" content:
       | title                          | Public community 1  |
       | workbench_moderation_state     | published           |
       | workbench_moderation_state_new | published           |
@@ -46,150 +45,178 @@ Feature: news standard and news core
       | workbench_moderation_state     | published                     |
       | workbench_moderation_state_new | published                     |
       | status                         | 1                             |
-    Given users:
-      | username      | name          | password | mail                   | roles         |
-      | administrator | administrator | pass     | administrator@test.com | administrator |
-      | contributor   | contributor   | pass     | contributor@test.com   | contributor   |
-    Given I am logged in as "administrator"
-    And   I have the "administrator member" role in the "Public community 1" group
-    When  I go to "/community/public-community-1"
-    And   I click "News" in the "sidebar_left" region
-    And   I wait
-    And   I click "News test 2 public highlighted"
-    And   I click "New draft"
-    And   I follow "Publishing options"
-    And   I select "Published" from "Moderation state"
-    And   I press "Save"
-    When  I go to "/community/public-community-1"
-    And   I click "News" in the "sidebar_left" region
-    And   I wait
-    And   I click "News test 3 private higlighted"
-    And   I click "New draft"
-    And   I follow "Publishing options"
-    And   I select "Published" from "Moderation state"
-    And   I press "Save"
-    When  I go to "/community/public-community-1"
-    And   I click "News" in the "sidebar_left" region
-    And   I wait
-    And   I click "News test 1 public"
-    And   I click "New draft"
-    And   I follow "Publishing options"
-    And   I select "Published" from "Moderation state"
-    And   I press "Save"
 
-
+  @theme_wip
   Scenario: as User, I can go to the public news section thanks to the "News" item in the main menu
-    Given I am on "/"
-    Then  I should see the link "Communities"
-    Then  I should see the link "News"
-    When  I click "News"
-    Then  I should be on "/news_public"
-    And   I should see the text "News"
+    Given I am not logged in
+    When I am on "/"
+    Then I should see the link "Communities"
+    And I should see the link "News"
+    When I click "News"
+    Then I should be on "/news_public"
+    And I should see the text "News"
 
+  @theme_wip
   Scenario: as Member I can propose news for publication to the community manager
-    Given I am logged in as "contributor"
-    And   I have the "member" role in the "Public community 1" group
-    When  I go to "communities_directory/my"
-    Then  I should see "Public community 1"
-    And   I click "Public community 1"
-    And   I click "Create content"
-    And   I click on the element with xpath "//*[@id='block-multisite-og-button-og-contextual-links']/div/ul/li[2]/a"
-    And   I fill in "edit-title" with "Test news behat"
-    And   I fill in the rich text editor "Body" with "Body for test news behat"
-    And   I wait
-    And   I click "Community"
-    And   I check "highlight"
-    And   I select "Public - accessible to all site users" from "Group content visibility"
-    And   I click "Revision information"
-    And   I select "Needs Review" from "Moderation state"
-    And   I press "Save"
-    And   I should see the text "News Test news behat has been created"
-    And   I should see the text "Latest content"
-    But   I should not see the link "Test news behat"
+    Given I am logged in as a user with the 'administrator' role
+    And I have the "administrator member" role in the "Public community 1" group
+    And I go to "/community/public-community-1"
+    And I click "News" in the "sidebar_left" region
+    And I click "News test 1 public"
+    And I click "New draft"
+    And I follow "Publishing options"
+    And I select "Published" from "Moderation state"
+    And I press "Save"
+    And I am logged in as a user with the 'contributor' role
+    And I have the "member" role in the "Public community 1" group
+    When I go to "communities_directory/my"
+    Then I should see "Public community 1"
+    When I click "Public community 1"
+    And I click "Create content"
+    And I click on the element with xpath "//*[@id='block-multisite-og-button-og-contextual-links']/div/ul/li[2]/a"
+    And I fill in "edit-title" with "Test news behat"
+    And I fill in the rich text editor "Body" with "Body for test news behat"
+    And I click "Community"
+    And I check "highlight"
+    And I select "Public - accessible to all site users" from "Group content visibility"
+    And I click "Revision information"
+    And I select "Needs Review" from "Moderation state"
+    And I press "Save"
+    And I should see the text "News Test news behat has been created"
+    And I should see the text "Latest content"
+    But I should not see the link "Test news behat"
 
+  @theme_wip
   Scenario: as Community manager I can create a news and publish it
-    Given I am logged in as "administrator"
-    And   I have the "member" role in the "Public community 1" group
-    When  I go to "communities_directory/my"
-    Then  I should see "Public community 1"
-    And   I click "Public community 1"
-    And   I click "Create content"
-    And   I click on the element with xpath "//*[@id='block-multisite-og-button-og-contextual-links']/div/ul/li[2]/a"
-    And   I fill in "edit-title" with "Test news behat"
-    And   I fill in the rich text editor "Body" with "Body for test news behat"
-    And   I wait
-    And   I click on the element with xpath "//*[@id='news-node-form']/div/div[1]/ul/li[4]/a/strong"
-    And   I check "highlight"
-    And   I select "Public - accessible to all site users" from "Group content visibility"
-    And   I follow "Publishing options"
-    And   I select "Published" from "Moderation state"
-    And   I press "Save"
-    And   I should see the text "News Test news behat has been created"
-    And   I should see the text "Latest content"
-    And   I should see the link "Test news behat"
+    Given I am logged in as a user with the 'administrator' role
+    And I have the "member" role in the "Public community 1" group
+    When I go to "communities_directory/my"
+    Then I should see "Public community 1"
+    When I click "Public community 1"
+    And I click "Create content"
+    And I click on the element with xpath "//*[@id='block-multisite-og-button-og-contextual-links']/div/ul/li[2]/a"
+    And I fill in "edit-title" with "Test news behat"
+    And I fill in the rich text editor "Body" with "Body for test news behat"
+    And I click on the element with xpath "//*[@id='news-node-form']/div/div[1]/ul/li[4]/a/strong"
+    And I check "highlight"
+    And I select "Public - accessible to all site users" from "Group content visibility"
+    And I follow "Publishing options"
+    And I select "Published" from "Moderation state"
+    And I press "Save"
+    Then I should see the text "News Test news behat has been created"
+    And I should see the text "Latest content"
+    And I should see the link "Test news behat"
 
+  @theme_wip
   Scenario: as member I can see private news according to my membership
-    Given I am logged in as a user with the 'contributor' role and I have the following fields:
+    Given I am logged in as a user with the 'administrator' role
+    And I have the "administrator member" role in the "Public community 1" group
+    And I go to "/community/public-community-1"
+    And I click "News" in the "sidebar_left" region
+    And I click "News test 1 public"
+    And I click "New draft"
+    And I follow "Publishing options"
+    And I select "Published" from "Moderation state"
+    And I press "Save"
+    And I go to "/community/public-community-1"
+    And I click "News" in the "sidebar_left" region
+    And I click "News test 2 public highlighted"
+    And I click "New draft"
+    And I follow "Publishing options"
+    And I select "Published" from "Moderation state"
+    And I press "Save"
+    And I go to "/community/public-community-1"
+    And I click "News" in the "sidebar_left" region
+    And I click "News test 3 private higlighted"
+    And I click "New draft"
+    And I follow "Publishing options"
+    And I select "Published" from "Moderation state"
+    And I press "Save"
+    And I am logged in as a user with the 'contributor' role and I have the following fields:
       | username | contributor2          |
       | name     | contributor2          |
       | mail     | contributor2@test.com |
-      | pass     | contributor          |
-    And  I have the "administrator member" role in the "Public community 1" group
+      | pass     | contributor           |
+    And I have the "administrator member" role in the "Public community 1" group
     When I go to "communities_directory/my"
-    And  I click "Public community 1"
+    And I click "Public community 1"
     Then I should see "members list" in the "sidebar_left" region
-    And  I should see the link "contributor" in the "sidebar_left" region
-    Then I should see the text "Highlighted news" in the "content_top" region
-    Then I should see the link "News test 2 public highlighted" in the "content_top" region
-    Then I should see the link "News test 3 private higlighted" in the "content_top" region
-    But  I should not see the link "News test 1 public" in the "content_top" region
-    And  I should see "Latest Content"
-    And  I should see the link "News test 3 private higlighted" in the "sidebar_left" region
-    And  I should see the link "News test 2 public highlighted" in the "sidebar_left" region
-    And  I should see the link "News test 1 public" in the "sidebar_left" region
+    And I should see the link "contributor2" in the "sidebar_left" region
+    And I should see the text "Highlighted news" in the "content_top" region
+    And I should see the link "News test 2 public highlighted" in the "content_top" region
+    And I should see the link "News test 3 private higlighted" in the "content_top" region
+    But I should not see the link "News test 1 public" in the "content_top" region
+    And I should see "Latest Content"
+    And I should see the link "News test 3 private higlighted" in the "sidebar_left" region
+    And I should see the link "News test 2 public highlighted" in the "sidebar_left" region
+    And I should see the link "News test 1 public" in the "sidebar_left" region
     When I click "News test 2 public highlighted"
     Then I should see the heading "News test 2 public highlighted"
 
+  @theme_wip
   Scenario: as user, I can see public news on the homepage
-    Given I am not logged in
-    When  I go to homepage
-    Then  I should see "News test 2 public highlighted"
-    And   I should see "News test 1 public"
-    But   I should not see "News test 3 private higlighted"
-    And   I click "News test 2 public highlighted"
-    Then  I should see the heading "News test 2 public highlighted"
+    Given I am logged in as a user with the 'administrator' role
+    And I have the "administrator member" role in the "Public community 1" group
+    And I go to "/community/public-community-1"
+    And I click "News" in the "sidebar_left" region
+    And I click "News test 2 public highlighted"
+    And I click "New draft"
+    And I follow "Publishing options"
+    And I select "Published" from "Moderation state"
+    And I press "Save"
+    And I go to "/community/public-community-1"
+    And I click "News" in the "sidebar_left" region
+    And I click "News test 3 private higlighted"
+    And I click "New draft"
+    And I follow "Publishing options"
+    And I select "Published" from "Moderation state"
+    And I press "Save"
+    And I go to "/community/public-community-1"
+    And I click "News" in the "sidebar_left" region
+    And I click "News test 1 public"
+    And I click "New draft"
+    And I follow "Publishing options"
+    And I select "Published" from "Moderation state"
+    And I press "Save"
+    And I am not logged in
+    When I go to homepage
+    Then I should see "News test 1 public"
+    And I should see "News test 2 public highlighted"
+    But I should not see "News test 3 private higlighted"
+    When I click "News test 2 public highlighted"
+    Then I should see the heading "News test 2 public highlighted"
 
+  @theme_wip
   Scenario: as Community manager, I can flag news within my community as "Top news" so that they appear at site's homepage
-    Given I am logged in as "administrator"
-    And   I have the "administrator member" role in the "Public community 1" group
-    When  I go to "/community/public-community-1"
-    And   I click "News" in the "sidebar_left" region
-    And   I wait
-    And   I click "News test 1 public"
-    And   I click "New draft"
-    And   I follow "Publishing options"
-    And   I check "Promoted to front page"
-    And   I check "Sticky at top of lists"
-    And   I select "Published" from "Moderation state"
-    And   I press "Save"
-    And   I go to homepage
-    And   I should see the link "News test 1 public"
-    And   I should see the link "Read more"
-    And   I should see the link "about News test 1 public"
+    Given I am logged in as a user with the 'administrator' role
+    And I have the "administrator member" role in the "Public community 1" group
+    When I go to "/community/public-community-1"
+    And I click "News" in the "sidebar_left" region
+    And I click "News test 1 public"
+    And I click "New draft"
+    And I follow "Publishing options"
+    And I check "Promoted to front page"
+    And I check "Sticky at top of lists"
+    And I select "Published" from "Moderation state"
+    And I press "Save"
+    And I go to homepage
+    Then I should see the link "News test 1 public"
+    And I should see the link "Read more"
+    And I should see the link "about News test 1 public"
 
+  @theme_wip
   Scenario: as Community manager, I can flag news within my community as "highlighted" so that they appear at community's homepage
-    Given I am logged in as "administrator"
-    And   I have the "administrator member" role in the "Public community 1" group
-    When  I go to "/community/public-community-1"
-    And   I click "News" in the "sidebar_left" region
-    And   I wait
-    And   I click "News test 1 public"
-    And   I click "New draft"
-    And   I click on the element with xpath "//*[@id='news-node-form']/div/div[1]/ul/li[4]/a/strong"
-    And   I check "highlight"
-    And   I follow "Publishing options"
-    And   I select "Published" from "Moderation state"
-    And   I press "Save"
-    When  I go to "communities_directory/my"
-    And   I click "Public community 1"
-    Then  I should see the link "News test 1 public" in the "content_top" region
+    Given I am logged in as a user with the 'administrator' role
+    And I have the "administrator member" role in the "Public community 1" group
+    When I go to "/community/public-community-1"
+    And I click "News" in the "sidebar_left" region
+    And I click "News test 1 public"
+    And I click "New draft"
+    And I click on the element with xpath "//*[@id='news-node-form']/div/div[1]/ul/li[4]/a/strong"
+    And I check "highlight"
+    And I follow "Publishing options"
+    And I select "Published" from "Moderation state"
+    And I press "Save"
+    And I go to "communities_directory/my"
+    And I click "Public community 1"
+    Then I should see the link "News test 1 public" in the "content_top" region

--- a/tests/features/news/news_communities.feature
+++ b/tests/features/news/news_communities.feature
@@ -140,7 +140,7 @@ Feature: news standard and news core
     And I have the "administrator member" role in the "Public community 1" group
     When I go to "communities_directory/my"
     And I click "Public community 1"
-    Then I should see "members list" in the "sidebar_left" region
+    Then I should see "Members list" in the "sidebar_left" region
     And I should see the link "contributor2" in the "sidebar_left" region
     And I should see the text "Highlighted news" in the "content_top" region
     And I should see the link "News test 2 public highlighted" in the "content_top" region

--- a/tests/features/news/news_standard.feature
+++ b/tests/features/news/news_standard.feature
@@ -1,0 +1,64 @@
+@api @javascript @theme_wip
+Feature: news standard and news core
+  In order to publish news
+  As different types of users
+  I want to be able to propose news
+
+  Background:
+    Given I use device with "1920" px and "1080" px resolution
+    And the module is enabled
+      | modules       |
+      | news_core     |
+      | news_standard |
+
+    And I am viewing a "news" content:
+      | title                          | News test 1 |
+      | author                         | admin              |
+      | body                           | news test 1 body   |
+      | field_news_publication_date    | 1510226280         |
+      | group_content_access           | 1                  |
+      | status                         | 1                  |
+      | workbench_moderation_state     | published          |
+      | workbench_moderation_state_new | published          |
+
+  Scenario: as user, I can see news menu link and click on it to see the published news
+    Given I am on the homepage
+    Then  I should see "News"
+    When  I click "News"
+    And   I wait
+    Then  I should see the heading "News"
+    And   I should see "News test 1"
+    When  I click "News test 1"
+    Then  I should see "news test 1 body"
+
+
+  Scenario Outline: as a user with permissions I can propose news for publication
+    Given I am logged in as a user with the '<role>' role
+    When  I go to "node/add/news"
+    And   I fill in "edit-title" with "<title>"
+    And   I fill in the rich text editor "Body" with "body for the Test News behat"
+    Then  I should not see "Publication date"
+    And   I click "Dates"
+    And   I should see "Publication date"
+    And   I fill in "edit-field-news-publication-date-und-0-value-datepicker-popup-0" with "06/11/2017"
+    And   I fill in "edit-field-news-publication-date-und-0-value-timeEntry-popup-1" with "12:00"
+    And   I press "Save"
+    Then  I should see the text "News <title> has been created"
+    Examples:
+      | role          | title                   |
+      | administrator | Test news administrator |
+      | contributor   | Test news contributor   |
+      | editor        | Test news editor        |
+
+  Scenario: as user, I can see featured news on the homepage
+    Given I am not logged in
+    Given I am viewing an "news" content:
+      | title              | News test      |
+      | body               | news test body |
+      | status             | 1              |
+      | moderation state   | published      |
+      | revision state     | published      |
+    When  I go to homepage
+    Then  I should see "News test"
+    And   I click "News test"
+    Then  I should see "News test body"

--- a/tests/features/news/news_standard.feature
+++ b/tests/features/news/news_standard.feature
@@ -1,64 +1,49 @@
-@api @javascript @theme_wip
+@api @javascript @maximizedwindow
 Feature: news standard and news core
   In order to publish news
   As different types of users
   I want to be able to propose news
 
   Background:
-    Given I use device with "1920" px and "1080" px resolution
-    And the module is enabled
+    Given the module is enabled
       | modules       |
       | news_core     |
       | news_standard |
-
     And I am viewing a "news" content:
-      | title                          | News test 1 |
-      | author                         | admin              |
-      | body                           | news test 1 body   |
-      | field_news_publication_date    | 1510226280         |
-      | group_content_access           | 1                  |
-      | status                         | 1                  |
-      | workbench_moderation_state     | published          |
-      | workbench_moderation_state_new | published          |
+      | title                          | News test 1      |
+      | author                         | admin            |
+      | body                           | news test 1 body |
+      | field_news_publication_date    | 1510226280       |
+      | group_content_access           | 1                |
+      | status                         | 1                |
+      | workbench_moderation_state     | published        |
+      | workbench_moderation_state_new | published        |
 
   Scenario: as user, I can see news menu link and click on it to see the published news
-    Given I am on the homepage
-    Then  I should see "News"
-    When  I click "News"
-    And   I wait
-    Then  I should see the heading "News"
-    And   I should see "News test 1"
-    When  I click "News test 1"
-    Then  I should see "news test 1 body"
-
+    Given I am not logged in
+    When I am on the homepage
+    Then I should see "News"
+    When I go to "news"
+    Then I should see the heading "News"
+    And I should see "News test 1"
+    When I click "News test 1"
+    Then I should see "news test 1 body"
 
   Scenario Outline: as a user with permissions I can propose news for publication
     Given I am logged in as a user with the '<role>' role
-    When  I go to "node/add/news"
-    And   I fill in "edit-title" with "<title>"
-    And   I fill in the rich text editor "Body" with "body for the Test News behat"
-    Then  I should not see "Publication date"
-    And   I click "Dates"
-    And   I should see "Publication date"
-    And   I fill in "edit-field-news-publication-date-und-0-value-datepicker-popup-0" with "06/11/2017"
-    And   I fill in "edit-field-news-publication-date-und-0-value-timeEntry-popup-1" with "12:00"
-    And   I press "Save"
-    Then  I should see the text "News <title> has been created"
+    When I go to "node/add/news"
+    And I fill in "edit-title" with "<title>"
+    And I fill in the rich text editor "Body" with "body for the Test News behat"
+    Then I should not see "Publication date"
+    And I click "Dates"
+    And I should see "Publication date"
+    And I fill in "edit-field-news-publication-date-und-0-value-datepicker-popup-0" with "06/11/2017"
+    And I fill in "edit-field-news-publication-date-und-0-value-timeEntry-popup-1" with "12:00"
+    And I press "Save"
+    Then I should see the text "News <title> has been created"
+
     Examples:
       | role          | title                   |
       | administrator | Test news administrator |
       | contributor   | Test news contributor   |
       | editor        | Test news editor        |
-
-  Scenario: as user, I can see featured news on the homepage
-    Given I am not logged in
-    Given I am viewing an "news" content:
-      | title              | News test      |
-      | body               | news test body |
-      | status             | 1              |
-      | moderation state   | published      |
-      | revision state     | published      |
-    When  I go to homepage
-    Then  I should see "News test"
-    And   I click "News test"
-    Then  I should see "News test body"


### PR DESCRIPTION
## NEPT-478

### Description

Implement behat tests for news feature and add the News feature README.md.

### Change log

- Added: Implement behat tests for news feature and News README.md


### Commands

No commands needed