### PR TITLE
NEPT-1424: Fix geofield js not counting amount of layers correctly.

### DIFF
--- a/profiles/common/modules/features/nexteuropa_geofield/js/nexteuropa_geofield.edit.js
+++ b/profiles/common/modules/features/nexteuropa_geofield/js/nexteuropa_geofield.edit.js
@@ -70,16 +70,19 @@
       if (settings.nexteuropa_geojson.map) {
         loadedMap = jQuery.parseJSON(settings.nexteuropa_geojson.map);
         drawnItems = L.geoJson(loadedMap).addTo(map);
-        // Popups are not pre-populated.
-        if (settings.nexteuropa_geojson.settings.fs_objects.objects_amount > 1) {
-          for (key in drawnItems._layers) {
+
+        for (key in drawnItems._layers) {
+          if (settings.nexteuropa_geojson.settings.fs_objects.objects_amount > 1) {
             // Create forms elements to manage popups content.
             layer_properties = drawnItems._layers[key].feature.properties;
             createLabel(key, layer_properties.name, layer_properties.description);
-            objects_count++;
           }
-          updateGeoJsonField();
-          updatePopups();
+          objects_count++;
+        }
+        // Popups are not pre-populated.
+        if (settings.nexteuropa_geojson.settings.fs_objects.objects_amount > 1) {
+            updateGeoJsonField();
+            updatePopups();
         }
 
         // Focus on map elements.


### PR DESCRIPTION
## NEPT-1424

### Description

Fix geofield js not counting amount of layers correctly.

### Change log
- Fixed: Fix geofield js not counting amount of layers correctly.