### PR TITLE
NEPT-1828: Upgrade the ec_resp release version (#1978)

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1028,7 +1028,7 @@ libraries[respond][download][url] = https://raw.githubusercontent.com/scottjehl/
 projects[ec_resp][type] = theme
 projects[ec_resp][download][type] = git
 projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
-projects[ec_resp][download][tag] = 2.3.6
+projects[ec_resp][download][tag] = 2.3.7
 
 projects[atomium][type] = theme
 projects[atomium][version] = 2.7


### PR DESCRIPTION
* NEPT-1828: Upgrade temporarily the ec_resp release version for the nept-1828 branch.

* NEPT-1828: Upgrade ec_resp to 2.3.7.


### Description

Upgrade ec_resp to latest release.

### Change log

- Changed: resources/multisite_drupal_standard.make to change the ec_resp release number

### Commands

drush cc all

