### PR TITLE
NEPT-1860 - [Small jobs] Ensure beans can be send to DGT

### DIFF
--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.inc
@@ -126,7 +126,9 @@ function _tmgmt_dgt_connector_get_entity_data($entity_type, $entity_id) {
     throw new TMGMTException(t('Unable to load entity %type with id %id', array('%type' => $entity_type, $entity_id)));
   }
 
-  return tmgmt_field_get_source_data($entity_type, $entity, $entity->language, TRUE);
+  $langcode = isset($entity->language)? $entity->language : NULL;
+
+  return tmgmt_field_get_source_data($entity_type, $entity, $langcode, TRUE);
 }
 
 /**

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.inc
@@ -126,7 +126,7 @@ function _tmgmt_dgt_connector_get_entity_data($entity_type, $entity_id) {
     throw new TMGMTException(t('Unable to load entity %type with id %id', array('%type' => $entity_type, $entity_id)));
   }
 
-  $langcode = isset($entity->language)? $entity->language : NULL;
+  $langcode = isset($entity->language) ? $entity->language : NULL;
 
   return tmgmt_field_get_source_data($entity_type, $entity, $langcode, TRUE);
 }

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.install
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.install
@@ -47,6 +47,15 @@ function tmgmt_dgt_connector_install() {
     "rdf_mapping" : []
   }');
   $translator->save();
+
+  // Enable entity translation for Beans.
+  $translatable_entities = variable_get('entity_translation_entity_types', array());
+  if (!in_array('bean', $translatable_entities)) {
+    $translatable_entities['bean'] = 'bean';
+    variable_set('entity_translation_entity_types', $translatable_entities);
+  }
+
+
 }
 
 /**

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.install
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.install
@@ -50,10 +50,8 @@ function tmgmt_dgt_connector_install() {
 
   // Enable entity translation for Beans.
   $translatable_entities = variable_get('entity_translation_entity_types', array());
-  if (!in_array('bean', $translatable_entities)) {
-    $translatable_entities['bean'] = 'bean';
-    variable_set('entity_translation_entity_types', $translatable_entities);
-  }
+  $translatable_entities['bean'] = 'bean';
+  variable_set('entity_translation_entity_types', $translatable_entities);
 
 }
 

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.install
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.install
@@ -47,12 +47,6 @@ function tmgmt_dgt_connector_install() {
     "rdf_mapping" : []
   }');
   $translator->save();
-
-  // Enable entity translation for Beans.
-  $translatable_entities = variable_get('entity_translation_entity_types', array());
-  $translatable_entities['bean'] = 'bean';
-  variable_set('entity_translation_entity_types', $translatable_entities);
-
 }
 
 /**

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.install
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.install
@@ -55,7 +55,6 @@ function tmgmt_dgt_connector_install() {
     variable_set('entity_translation_entity_types', $translatable_entities);
   }
 
-
 }
 
 /**

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.module
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.module
@@ -83,7 +83,7 @@ function tmgmt_dgt_connector_nexteuropa_poetry_notification_status_updated($mess
  * nexteuropa_dgt_connector module functionalities.
  */
 function tmgmt_dgt_connector_form_tmgmt_entity_ui_translate_form_alter(&$form, &$form_state) {
-  if (!isset($form_state['tmgmt_cart'])) {
+  if (!isset($form_state['tmgmt_cart']) || 'node' !== $form_state['tmgmt_cart']['item_type']) {
     return;
   }
   $cart_info = $form_state['tmgmt_cart'];

--- a/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
+++ b/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
@@ -154,7 +154,7 @@ Feature: TMGMT Poetry Cart features
     Then I should see the message "Job has been successfully sent for translation."
     And I should see text matching "Vocab \(taxonomy\:vocabulary\:\d\) and 1 more"
 
-  @javascript
+  @javascript @wip
   Scenario: I can add blocks and beans to cart.
     Given I go to "admin/config/regional/entity_translation"
     And I click "Translatable entity types"

--- a/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
+++ b/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
@@ -121,7 +121,7 @@ Feature: TMGMT Poetry Cart features
     And I should see text matching "Test menu \(menu\:menu\:test\) and 1 more"
 
   @javascript
-  Scenario: I can add vocabolaries to cart.
+  Scenario: I can add vocabularies to cart.
     Given the vocabulary "Vocab" is created
     And the term "Term" in the vocabulary "Vocab" exists
     When I go to "admin/structure/taxonomy/vocab/edit"
@@ -153,3 +153,59 @@ Feature: TMGMT Poetry Cart features
     And I press "Submit to translator"
     Then I should see the message "Job has been successfully sent for translation."
     And I should see text matching "Vocab \(taxonomy\:vocabulary\:\d\) and 1 more"
+
+  @javascript
+  Scenario: I can add blocks and beans to cart.
+    Given I create the new block type "New bean"
+    And I go to "admin/structure/block-types"
+    # It does not work without cc
+    And the cache has been cleared
+    And I click "manage fields" in the "New bean" row
+    And I click "replace"
+    And I check the box "Replace title with a field instance"
+    And I press "Save settings"
+    And I wait for the end of the batch job
+    And I go to "/block/add"
+    # When there is only one bean it goes directly to that bean's creation page
+    # And I click "New bean"
+    And I fill in "Label" with "Label for New bean Block"
+    And I fill in "Title" with "Title for New bean Block"
+    And I press "Save"
+    Then I should see "New bean Title for New bean Block has been created."
+
+    When I click "Translate" in the "primary_tabs" region
+    And I check the box on the "French" row
+    And I check the box on the "Portuguese, Portugal" row
+    And I press "Send to cart"
+    Then I should see "The content has been added to the cart."
+
+    When I go to "/admin/structure/block/add"
+    And I fill in "Block title" with "Title for New block"
+    And I fill in "Block description" with "Description for New block"
+    And I fill in the rich text editor "Block body" with "Body for New block."
+    And I click "Not translatable, Not restricted"
+    And I check the box "Make this block translatable"
+    And I press the "Save and translate" button
+    And I check the box on the "French" row
+    And I check the box on the "Portuguese, Portugal" row
+    And I press "Send to cart"
+    Then I should see "The content has been added to the cart."
+
+    When I click "cart" in the "front_messages" region
+    And I click "Send" in the "Target languages: FR, PT" row
+    And I click "Change translator"
+    And I select "tmgmt_dgt_connector" from "Translator"
+    And I wait for AJAX to finish
+    And I fill in "Date" with a relative date of "+20" days
+    And I press "Submit to translator"
+    Then I should see the message "Job has been successfully sent for translation."
+    And I should see text matching "Title for New bean Block and 1 more"
+
+    # Delete created bean and blocks
+    When I go to "admin/structure/block-types"
+    And I click "Delete" in the "New bean" row
+    And I press the "Delete" button
+    And I go to "admin/structure/block"
+    And I click "delete" in the "Description for New block" row
+    And I press "Delete"
+    Then I should see the message "The block Description for New block has been removed."

--- a/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
+++ b/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
@@ -156,7 +156,11 @@ Feature: TMGMT Poetry Cart features
 
   @javascript
   Scenario: I can add blocks and beans to cart.
-    Given I create the new block type "New bean"
+    Given I go to "admin/config/regional/entity_translation"
+    And I click "Translatable entity types"
+    Then the "Block" checkbox should be checked
+
+    When I create the new block type "New bean"
     And I go to "admin/structure/block-types"
     # It does not work without cc
     And the cache has been cleared

--- a/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
+++ b/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
@@ -154,16 +154,18 @@ Feature: TMGMT Poetry Cart features
     Then I should see the message "Job has been successfully sent for translation."
     And I should see text matching "Vocab \(taxonomy\:vocabulary\:\d\) and 1 more"
 
-  @javascript @wip
+  @javascript
   Scenario: I can add blocks and beans to cart.
     Given I go to "admin/config/regional/entity_translation"
     And I click "Translatable entity types"
-    Then the "Block" checkbox should be checked
+    And I check the box "Block"
+    And I press "Save configuration"
+    Then I should see the message "The configuration options have been saved."
 
     When I create the new block type "New bean"
     And I go to "admin/structure/block-types"
-    # It does not work without cc
-    And the cache has been cleared
+    # It does not work without drush cc all
+    And I run drush "cc" "all"
     And I click "manage fields" in the "New bean" row
     And I click "replace"
     And I check the box "Replace title with a field instance"


### PR DESCRIPTION
## NEPT-1860

### Description

Ensure beans can be send to DGT using Smalljobs.

### Change log

- Added: Test for blocks translation
- Added: Blocks activation in entity translation configuration, when enabling module "TMGMT DGT connector"
- Changed: Blocks translation form to use default plugin

### Commands

No commands are needed.

