### PR TITLE
 NEPT-1923: Merge from release-2.5

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -454,6 +454,32 @@ function cce_basic_config_install() {
 
   multisite_config_service('wysiwyg')->addPreferenceToProfile('full_html', 'version', '4.4.8.ccd0038');
 
+  // Create WYSIWYG profile for Filtered  HTML text format.
+  multisite_config_service('wysiwyg')->createProfile('filtered_html', 'ckeditor');
+
+  $plugin_settings = array(
+    'default' => array(
+      'Bold',
+      'Italic',
+      'Underline',
+      'BulletedList',
+      'NumberedList',
+      'Undo',
+      'Link',
+      'Unlink',
+      'Anchor',
+      'TextColor',
+      'BGColor',
+      'Blockquote',
+      'Font',
+      'FontSize',
+      'Maximize',
+    ),
+  );
+  foreach ($plugin_settings as $group => $buttons) {
+    multisite_config_service('wysiwyg')->addButtonsToProfile('filtered_html', $group, $buttons);
+  }
+
   // Dynamically set the 'print_pdf_pdf_tool' variable. It cannot be exported
   // in a regular feature since it includes the path to where the Print PDF
   // module is installed, which is different depending on the installation

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector.inc
@@ -141,6 +141,7 @@ function _tmgmt_dgt_connector_get_entity_data($entity_type, $entity_id) {
  *   Returns an array with data of the string.
  */
 function _tmgmt_dgt_connector_get_i18n_string_data($item_type, $item_id) {
+
   // Get i18n object from id.
   list(, $type, $object_id) = explode(':', $item_id, 3);
   $i18n_object = tmgmt_i18n_string_get_wrapper($item_type, (object) array('type' => $type, 'objectid' => $object_id));

--- a/profiles/common/modules/features/nexteuropa_mediagallery/nexteuropa_mediagallery.info
+++ b/profiles/common/modules/features/nexteuropa_mediagallery/nexteuropa_mediagallery.info
@@ -1,7 +1,7 @@
 name = Nexteuropa Media Gallery
 description = Add Gallery content type for display in a galleries page and block
 core = 7.x
-package = Nexteuropa
+package = NextEuropa
 dependencies[] = cce_basic_config
 dependencies[] = ds
 dependencies[] = ec_embedded_video

--- a/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.module
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.module
@@ -632,6 +632,11 @@ function nexteuropa_trackedchanges_wysiwyg_editor_settings_alter(&$settings, $co
     $settings['lite']['isTracking'] = (bool) variable_get('ckeditor_lite_istracking', FALSE);
   }
 
+  if (empty($settings['extraPlugins']) || (strpos($settings['extraPlugins'], 'lite') === FALSE)) {
+    // Ckeditor lite is an extra plugin. If it is not set, no need to continue.
+    return;
+  }
+
   if ($state == 'create') {
     $is_btn_disabled = variable_get('nexteuropa_trackedchanges_disable_track_on_create');
     if ($is_btn_disabled) {

--- a/profiles/multisite_drupal_communities/modules/custom/multisite_dynamic_basetheme
+++ b/profiles/multisite_drupal_communities/modules/custom/multisite_dynamic_basetheme
@@ -1,1 +1,0 @@
-../../../common/modules/custom/multisite_dynamic_basetheme

--- a/profiles/multisite_drupal_standard/modules/custom/multisite_dynamic_basetheme
+++ b/profiles/multisite_drupal_standard/modules/custom/multisite_dynamic_basetheme
@@ -1,1 +1,0 @@
-../../../common/modules/custom/multisite_dynamic_basetheme

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -679,6 +679,10 @@ projects[tmgmt][patch][] = https://www.drupal.org/files/issues/tmgmt-test_transl
 ; https://www.drupal.org/node/2812863
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-60
 projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2812863.patch
+; #2955245 : i18nviews strings are not shown on sources view
+; https://www.drupal.org/node/2955245
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1878
+projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2018-04-17/2955245-5.patch
 
 projects[token][subdir] = "contrib"
 projects[token][version] = "1.7"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1031,7 +1031,7 @@ projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
 projects[ec_resp][download][tag] = 2.3.7
 
 projects[atomium][type] = theme
-projects[atomium][version] = 2.7
+projects[atomium][version] = 2.8
 
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1028,7 +1028,7 @@ libraries[respond][download][url] = https://raw.githubusercontent.com/scottjehl/
 projects[ec_resp][type] = theme
 projects[ec_resp][download][type] = git
 projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
-projects[ec_resp][download][tag] = 2.3.6
+projects[ec_resp][download][tag] = 2.3.7
 
 projects[atomium][type] = theme
 projects[atomium][version] = 2.7

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -192,7 +192,7 @@ projects[diff][download][revision] = b1b09189d52380a008c9cb29b879e3aa140ec2e0
 projects[diff][download][type] = git
 
 projects[ds][subdir] = "contrib"
-projects[ds][version] = "2.14"
+projects[ds][version] = "2.15"
 
 projects[easy_breadcrumb][subdir] = "contrib"
 projects[easy_breadcrumb][version] = "2.12"

--- a/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
+++ b/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
@@ -121,7 +121,7 @@ Feature: TMGMT Poetry Cart features
     And I should see text matching "Test menu \(menu\:menu\:test\) and 1 more"
 
   @javascript
-  Scenario: I can add vocabolaries to cart.
+  Scenario: I can add vocabularies to cart.
     Given the vocabulary "Vocab" is created
     And the term "Term" in the vocabulary "Vocab" exists
     When I go to "admin/structure/taxonomy/vocab/edit"
@@ -153,3 +153,11 @@ Feature: TMGMT Poetry Cart features
     And I press "Submit to translator"
     Then I should see the message "Job has been successfully sent for translation."
     And I should see text matching "Vocab \(taxonomy\:vocabulary\:\d\) and 1 more"
+
+  @javascript
+  Scenario: I can add views to cart.
+    #TODO: Replace the test with a custom cart check
+    When I go to "admin/tmgmt/sources/i18n_string_views"
+    And I check the box on the "Archive (views:views:archive)" row
+    And I press "Add to cart"
+    Then I should see the success message "1 content source was added into the cart."


### PR DESCRIPTION
## NEPT-1923, NEPT-1828, NEPT-1441

### Description

Merge from release-2.5 that includes:
- NEPT-1441: Use correct package name NextEuropa for nexteuropa_mediagallery;
- NEPT-1828: Upgrade the ec_resp release version;
- NEPT-1923: Upgrade ds to 2.15.

### Change log

- Changed:
  * Use correct package name NextEuropa for nexteuropa_mediagallery
  * make file: Upgrade ec_resp and ds


### Commands

None

