### PR TITLE
Assign CEM role to ECAS user of a defined group

### DIFF
--- a/profiles/common/modules/custom/ecas/ecas.api.php
+++ b/profiles/common/modules/custom/ecas/ecas.api.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @file
+ * Documentation file for the module API.
+ */
+
+/**
+ * Act on the list of user data value to save of the Ecas user.
+ *
+ * @param array $edit
+ *   The list array of user data values. it is the same "$edit" parameter as
+ *   in user_save().
+ * @param object $user
+ *   A user object.
+ * @param array $user_info
+ *   An associative array with the following interesting keys:
+ *   - mail: mail address.
+ *   - givenname: first name.
+ *   - sn: last name.
+ *   These values will be used to fill fields/profiles/...
+ * @param array $args
+ *   Extra parameters, not used directly in this function but passed to the
+ *   info_ecas_update() hook.
+ */
+function hook_ecas_sync_user_info(array &$edit, $user, array $user_info, array $args) {
+  $role = user_role_load_by_name('role_name');
+  $user_roles = (isset($user->roles)) ? $user->roles : array();
+  $user_roles[$role->rid] = $role->name;
+
+  $edit['roles'] = $user_roles;
+}
+
+/**
+ * Responds to the synchronisation of the ECAS user.
+ *
+ * This hook is invoked from ecas_sync_user_info() after the user object has
+ * been defined saved.
+ *
+ * @param object $user
+ *   A user object.
+ * @param array $user_info
+ *   An associative array with the following interesting keys:
+ *   - mail: mail address.
+ *   - givenname: first name.
+ *   - sn: last name.
+ *   These values will be used to fill fields/profiles/...
+ * @param array $args
+ *   Extra parameters, not used directly in this function but passed to the
+ *   info_ecas_update() hook.
+ */
+function ecas_group_sync_info_ecas_update($user, array $user_info, array $args) {
+  $group_query = db_select('node', 'n')
+    ->condition('title', 'group delta')
+    ->fields('n', array('nid'));
+
+  $nid = $group_query->execute()->fetchField();
+  og_group('node', $nid, array(
+    "entity type" => "user",
+    "entity" => $user,
+    "field_name" => 'og_user_node',
+  ));
+}

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -296,29 +296,30 @@ function ecas_save_page() {
  *   - cas:lastName: last name.
  *   - cas:domain: the domain, e.g. eu.europa.ec or external.
  *   - cas:departmentNumber: the department, e.g. DIGIT.A.3.
+ * @param array $edit
+ *   The array containing user properties and field values to edit at saving
+ *   time.
+ *   It is the same array structure as in the user_save().
  *
  * @see ecas_sync_user_info()
  */
-function ecas_sync_profile_core(&$user, array $user_info) {
+function ecas_sync_profile_core(&$user, array $user_info, array &$edit = array()) {
   $field_firstname = trim(variable_get('ecas_profile_core_firstname_field', 'field_firstname'));
   $field_lastname = trim(variable_get('ecas_profile_core_lastname_field', 'field_lastname'));
   $field_ecasmail = trim(variable_get('ecas_profile_core_ecas_email_field', 'field_ecas_mail'));
   $field_ecascreator = trim(variable_get('ecas_profile_core_ecas_creator_field', 'field_creator'));
 
-  // Can be used for all entity types.
-  $edit = (array) $user;
-
   // You can now access the fields without knowing the language.
-  if (!empty($field_firstname) && isset($edit[$field_firstname])) {
+  if (!empty($field_firstname) && isset($user->{$field_firstname})) {
     $edit[$field_firstname][LANGUAGE_NONE][0]['value'] = $user_info['cas:firstName'];
   }
-  if (!empty($field_lastname) && isset($edit[$field_lastname])) {
+  if (!empty($field_lastname) && isset($user->{$field_lastname})) {
     $edit[$field_lastname][LANGUAGE_NONE][0]['value'] = $user_info['cas:lastName'];
   }
-  if (!empty($field_ecasmail) && isset($edit[$field_ecasmail])) {
+  if (!empty($field_ecasmail) && isset($user->{$field_ecasmail})) {
     $edit[$field_ecasmail][LANGUAGE_NONE][0]['value'] = $user_info['cas:email'];
   }
-  if (!empty($field_ecascreator) && isset($edit[$field_ecascreator])) {
+  if (!empty($field_ecascreator) && isset($user->{$field_ecascreator})) {
     if ($user_info['cas:domain'] == 'external') {
       $edit[$field_ecascreator][LANGUAGE_NONE][0]['value'] = $user_info['cas:domain'];
     }
@@ -326,9 +327,6 @@ function ecas_sync_profile_core(&$user, array $user_info) {
       $edit[$field_ecascreator][LANGUAGE_NONE][0]['value'] = $user_info['cas:domain'] . '/' . $user_info['cas:departmentNumber'];
     }
   }
-
-  // Save changes.
-  user_save($user, $edit);
 }
 
 /**
@@ -351,21 +349,61 @@ function ecas_sync_profile_core(&$user, array $user_info) {
  *   info_ecas_update() hook.
  */
 function ecas_sync_user_info(&$user, array $user_info, array $args) {
+  $edit = array();
   // Update the user mail in the users table.
   if (variable_get('ecas_update_mail_address', TRUE)) {
-    $picture = $user->picture;
-    // Fix : save file object replaced by fid by user_save function.
-    user_save($user, array('mail' => $user_info['cas:email']));
-    $user->mail = $user_info['cas:email'];
-    $user->picture = $picture;
+    $edit['mail'] = $user_info['cas:email'];
   }
 
   // Update extra core user fields.
   if (variable_get('ecas_profile_core_enabled', FALSE)) {
-    ecas_sync_profile_core($user, $user_info);
+    ecas_sync_profile_core($user, $user_info, $edit);
   }
 
+  // Call "hook_ecas_sync_user_info" implementation with $edit passed by
+  // reference as parameter.
+  foreach (module_implements('ecas_sync_user_info') as $module) {
+    $function = $module . '_ecas_sync_user_info';
+    $function($edit, $user, $user_info, $args);
+  }
+
+  // Fix : save file object replaced by fid by user_save function.
+  $picture = $user->picture;
+  user_save($user, $edit);
+  $user->mail = $user_info['cas:email'];
+  $user->picture = $picture;
+
+  // Old hook implementation. we keep it for backward compatibility.
   module_invoke_all('info_ecas_update', $user, $user_info, $args);
+}
+
+/**
+ * Implements hook_ecas_sync_user_info().
+ *
+ * Assign the "CEM" role assigned to the user if they belong to the COMM_CEM.
+ */
+function ecas_ecas_sync_user_info(array &$edit, $user, array $user_info, array $args) {
+  $cem_group = 'COMM_CEM';
+  $cem_role_name = 'cem';
+
+  $user_cas_groups = array();
+  if (!empty($user_info['cas:groups']) && !empty($user_info['cas:groups']['cas:group'])) {
+    $user_cas_groups = $user_info['cas:groups']['cas:group'];
+  }
+
+  $cem_role = user_role_load_by_name($cem_role_name);
+  $user_roles = (isset($user->roles)) ? $user->roles : array();
+  // By default, the role is not set for any user automatically.
+  // Then, unset it by default and reassign it later if the user has the
+  // EU login group.
+  unset($user_roles[$cem_role->rid]);
+  if (in_array($cem_group, $user_cas_groups)) {
+    $role_name = $cem_role->name;
+    $user_roles[$cem_role->rid] = $role_name;
+    watchdog('ecas', 'User %name has received the %role role.)', array('%name' => $user->name, '%role' => $role_name), WATCHDOG_INFO, l(t('edit user'), sprintf('admin/user/edit/%d', $user->uid)));
+  }
+
+  $edit['roles'] = $user_roles;
 }
 
 /**

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -57,6 +57,7 @@ function cce_basic_config_install() {
   // Create contributor editor roles.
   multisite_config_service('user')->createRole('contributor', 3);
   multisite_config_service('user')->createRole('editor', 4);
+  multisite_config_service('user')->createRole('cem', 5);
 
   // Body field base creation.
   _cce_basic_config_body_field_base_add();

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install.inc
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install.inc
@@ -304,7 +304,9 @@ function _cce_basic_config_post_install_user_roles_perms() {
   $admin_role->name = 'administrator';
   $admin_role->weight = 2;
   user_role_save($admin_role);
-  user_role_grant_permissions($admin_role->rid, array_keys(module_invoke_all('permission')));
+
+  $all_permissions = array_keys(module_invoke_all('permission'));
+  user_role_grant_permissions($admin_role->rid, $all_permissions);
 
   // Set this as the administrator role.
   variable_set('user_admin_role', $admin_role->rid);
@@ -421,6 +423,89 @@ function _cce_basic_config_post_install_user_roles_perms() {
     'use text format filtered_html',
   );
   user_role_grant_permissions(DRUPAL_ANONYMOUS_RID, $anonymous_permissions);
+
+  // Grant permissions for cem.
+  $cem_permissions = array(
+    'access broken links report',
+    'access contextual links',
+    'access dashboard',
+    'access ecas import users function',
+    'access media browser',
+    'access own broken links report',
+    'add media from remote sources',
+    'administer content translations',
+    'change own username',
+    'create article content',
+    'create editorial_team content',
+    'delete own article content',
+    'delete own audio files',
+    'delete own document files',
+    'delete own editorial_team content',
+    'delete own image files',
+    'delete own video files',
+    'download any audio files',
+    'download any document files',
+    'download any image files',
+    'download any video files',
+    'download own audio files',
+    'download own document files',
+    'download own image files',
+    'download own video files',
+    'edit any article content',
+    'edit any audio files',
+    'edit any document files',
+    'edit any editorial_team content',
+    'edit any image files',
+    'edit any video files',
+    'edit own article content',
+    'edit own audio files',
+    'edit own comments',
+    'edit own document files',
+    'edit own editorial_team content',
+    'edit own image files',
+    'edit own video files',
+    'moderate content from draft to needs_review',
+    'moderate content from needs_review to draft',
+    'moderate content from needs_review to published',
+    'moderate content from needs_review to validated',
+    'moderate content from published to archived',
+    'moderate content from published to draft',
+    'moderate content from published to expired',
+    'moderate content from published to needs_review',
+    'moderate content from validated to published',
+    'multisite_workbench_moderation_view_bulk_update',
+    'node-specific print configuration',
+    're convert video',
+    'send unlimited emails',
+    'show format selection for bean',
+    'show format selection for comment',
+    'show format selection for file',
+    'show format selection for flagging',
+    'show format selection for og_membership',
+    'show format selection for og_membership_type',
+    'show format selection for rules_config',
+    'show format selection for taxonomy_term',
+    'show format selection for tmgmt_job',
+    'show format selection for user',
+    'show format tips',
+    'show more format tips link',
+    'translate content',
+    'translate file entities',
+    'translate node entities',
+    'use default thumb',
+    'use text format full_html',
+    'view advanced help index',
+    'view advanced help popup',
+    'view advanced help topic',
+    'view alert message',
+    'view private files',
+    'view rate results page',
+    'view the administration theme',
+  );
+  // Depending on the platform profile, some default platform modules are not
+  // enabled.
+  // We need to only keep the enabled permissions of the array above.
+  multisite_config_service('user')->grantPermission('cem', array_intersect($all_permissions, $cem_permissions));
 }
 
 /**

--- a/profiles/common/modules/features/events/events_core/events_core.features.user_permission.inc
+++ b/profiles/common/modules/features/events/events_core/events_core.features.user_permission.inc
@@ -18,6 +18,7 @@ function events_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -29,6 +30,7 @@ function events_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -40,6 +42,7 @@ function events_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -51,6 +54,7 @@ function events_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -62,6 +66,7 @@ function events_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );

--- a/profiles/common/modules/features/links/links_core/links_core.features.user_permission.inc
+++ b/profiles/common/modules/features/links/links_core/links_core.features.user_permission.inc
@@ -18,6 +18,7 @@ function links_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -29,6 +30,7 @@ function links_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -40,6 +42,7 @@ function links_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -51,6 +54,7 @@ function links_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -62,6 +66,7 @@ function links_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );

--- a/profiles/common/modules/features/multi_user_blog/multi_user_blog.features.user_permission.inc
+++ b/profiles/common/modules/features/multi_user_blog/multi_user_blog.features.user_permission.inc
@@ -18,6 +18,7 @@ function multi_user_blog_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -39,6 +40,7 @@ function multi_user_blog_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -60,6 +62,7 @@ function multi_user_blog_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );

--- a/profiles/common/modules/features/multisite_charts/multisite_charts.features.user_permission.inc
+++ b/profiles/common/modules/features/multisite_charts/multisite_charts.features.user_permission.inc
@@ -17,6 +17,7 @@ function multisite_charts_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'contributor' => 'contributor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -36,6 +37,7 @@ function multisite_charts_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'contributor' => 'contributor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -55,6 +57,7 @@ function multisite_charts_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'contributor' => 'contributor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );

--- a/profiles/common/modules/features/multisite_maps/multisite_maps.features.user_permission.inc
+++ b/profiles/common/modules/features/multisite_maps/multisite_maps.features.user_permission.inc
@@ -17,6 +17,7 @@ function multisite_maps_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'contributor' => 'contributor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -36,6 +37,7 @@ function multisite_maps_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'contributor' => 'contributor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -55,6 +57,7 @@ function multisite_maps_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'contributor' => 'contributor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );

--- a/profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.features.user_permission.inc
+++ b/profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.features.user_permission.inc
@@ -18,6 +18,7 @@ function multisite_mediagallery_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -39,6 +40,7 @@ function multisite_mediagallery_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -60,6 +62,7 @@ function multisite_mediagallery_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );

--- a/profiles/common/modules/features/news/news_core/news_core.features.user_permission.inc
+++ b/profiles/common/modules/features/news/news_core/news_core.features.user_permission.inc
@@ -18,6 +18,7 @@ function news_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -29,6 +30,7 @@ function news_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -40,6 +42,7 @@ function news_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -51,6 +54,7 @@ function news_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -62,6 +66,7 @@ function news_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );

--- a/profiles/common/modules/features/newsletters/newsletters.features.user_permission.inc
+++ b/profiles/common/modules/features/newsletters/newsletters.features.user_permission.inc
@@ -36,6 +36,7 @@ function newsletters_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'simplenews',
   );
@@ -47,6 +48,7 @@ function newsletters_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'simplenews',
   );
@@ -57,6 +59,7 @@ function newsletters_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'contributor' => 'contributor',
+      'cem' => 'cem',
     ),
     'module' => 'simplenews',
   );
@@ -68,6 +71,7 @@ function newsletters_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -79,6 +83,7 @@ function newsletters_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -90,6 +95,7 @@ function newsletters_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -101,6 +107,7 @@ function newsletters_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'simplenews',
   );
@@ -113,6 +120,7 @@ function newsletters_user_default_permissions() {
       'anonymous user' => 'anonymous user',
       'authenticated user' => 'authenticated user',
       'contributor' => 'contributor',
+      'cem' => 'cem',
     ),
     'module' => 'simplenews',
   );

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.install
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.install
@@ -63,6 +63,40 @@ function nexteuropa_core_install() {
   );
   multisite_config_service('user')->grantPermission('administrator', $permissions);
 
+  // Set permissions for "cem" role.
+  $permissions = array(
+
+    // Admin menu.
+    'access administration menu',
+    'display drupal links',
+
+    // Bean.
+    'access bean overview',
+    'view bean page',
+    'view bean revisions',
+
+    // Coffee.
+    'access coffee',
+
+    // Menu.
+    'administer menu',
+
+    // Node.
+    'access content overview',
+
+    'access administration pages',
+
+    // Path.
+    'create url aliases',
+
+    // User.
+    'cancel account',
+
+    // Version Management.
+    'version management edits',
+  );
+  multisite_config_service('user')->grantPermission('cem', $permissions);
+
   // Set permissions for "contributor" role.
   $permissions = array(
     // Version Management.

--- a/profiles/common/modules/features/nexteuropa_editorial/nexteuropa_editorial.install
+++ b/profiles/common/modules/features/nexteuropa_editorial/nexteuropa_editorial.install
@@ -90,6 +90,63 @@ function nexteuropa_editorial_install() {
   // Set "administrator" permissions.
   multisite_config_service('user')->grantPermission('administrator', $permissions);
 
+  // Set "cem" permissions.
+  $cem_permissions = array(
+
+    // Admin menu.
+    'access administration menu',
+
+    // Bean.
+    'access bean overview',
+    'view bean page',
+    'view bean revisions',
+
+    // Contextual.
+    'access contextual links',
+
+    // Entity Translation.
+    'translate any entity',
+
+    // File entity.
+    'create files',
+    'view own private files',
+    'view own files',
+
+    // Menu.
+    'administer menu',
+
+    // Node.
+    'view own unpublished content',
+    'access content overview',
+
+    // Path.
+    'create url aliases',
+
+    // Scheduler.
+    'schedule (un)publishing of nodes',
+
+    // Scheduler Workbench Integration.
+    'override default scheduler time',
+
+    // Translation Management.
+    'submit translation jobs',
+    'create translation jobs',
+
+    // Workbench.
+    'access workbench',
+
+    // Workbench Moderation.
+    'use workbench_moderation my drafts tab',
+    'use workbench_moderation needs review tab',
+
+    // WYSIWYG Editor.
+    'use media wysiwyg',
+
+    // System.
+    'access administration pages',
+  );
+  multisite_config_service('user')->grantPermission('cem', $cem_permissions, 'nexteuropa_editorial');
+
   // Rebuilds the node access database.
   node_access_rebuild();
 

--- a/profiles/common/modules/features/nexteuropa_feature_set/nexteuropa_feature_set.install
+++ b/profiles/common/modules/features/nexteuropa_feature_set/nexteuropa_feature_set.install
@@ -11,11 +11,8 @@
  * Grant access to features set and admin menu to user role.
  */
 function nexteuropa_feature_set_install() {
-  multisite_config_service('user')->createRole('cem', 5);
   // Grant permissions for cem.
   $permissions = array(
-    'access administration menu',
-    'access administration pages',
     'administer feature sets',
   );
   multisite_config_service('user')->grantPermission('cem', $permissions);

--- a/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.install
+++ b/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.install
@@ -53,6 +53,22 @@ function nexteuropa_multilingual_install() {
   );
   multisite_config_service('user')->grantPermission('administrator', $permissions);
 
+  // Set "cem" permissions.
+  $cem_permissions = array(
+
+    // Entity Translation.
+    'translate any entity',
+
+    // Locale.
+    'translate interface',
+
+    // Translation Management Core.
+    'create translation jobs',
+    'submit translation jobs',
+    'accept translation jobs',
+  );
+  multisite_config_service('user')->grantPermission('cem', $cem_permissions);
+
   // Suffix is not compatible with prefix. Remove that negotiation mechanism.
   multisite_config_service('locale')->disableLanguageNegotiation(LOCALE_LANGUAGE_NEGOTIATION_URL);
 

--- a/profiles/common/modules/features/nexteuropa_pages/nexteuropa_pages.install
+++ b/profiles/common/modules/features/nexteuropa_pages/nexteuropa_pages.install
@@ -89,6 +89,15 @@ function nexteuropa_pages_install() {
     'edit own page content',
   );
   multisite_config_service('user')->grantPermission('editor', $editor_permissions, 'node');
+
+  // Grant permissions for cem.
+  $editor_permissions = array(
+    'create page content',
+    'delete own page content',
+    'edit any page content',
+    'edit own page content',
+  );
+  multisite_config_service('user')->grantPermission('cem', $editor_permissions, 'node');
 }
 
 /**

--- a/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.install
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.install
@@ -107,6 +107,7 @@ function nexteuropa_trackedchanges_install() {
     'ckeditor_lite highlight changes',
   );
   multisite_config_service('user')->grantPermission('administrator', $permissions);
+  multisite_config_service('user')->grantPermission('cem', $permissions);
   multisite_config_service('user')->grantPermission('contributor', $permissions);
   multisite_config_service('user')->grantPermission('editor', $permissions);
 
@@ -114,6 +115,7 @@ function nexteuropa_trackedchanges_install() {
     'use text format full_html_track',
   );
   multisite_config_service('user')->grantPermission('administrator', $wsw_permissions, 'filter');
+  multisite_config_service('user')->grantPermission('cem', $wsw_permissions, 'filter');
   multisite_config_service('user')->grantPermission('contributor', $wsw_permissions, 'filter');
   multisite_config_service('user')->grantPermission('editor', $wsw_permissions, 'filter');
 

--- a/profiles/common/modules/features/survey/survey_core/survey_core.features.user_permission.inc
+++ b/profiles/common/modules/features/survey/survey_core/survey_core.features.user_permission.inc
@@ -28,6 +28,7 @@ function survey_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'webform',
   );
@@ -39,6 +40,7 @@ function survey_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'webform',
   );
@@ -50,6 +52,7 @@ function survey_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -61,6 +64,7 @@ function survey_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -82,6 +86,7 @@ function survey_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );

--- a/profiles/common/modules/features/wiki/wiki_core/wiki_core.features.user_permission.inc
+++ b/profiles/common/modules/features/wiki/wiki_core/wiki_core.features.user_permission.inc
@@ -18,6 +18,7 @@ function wiki_core_user_default_permissions() {
       'administrator' => 'administrator',
       'authenticated user' => 'authenticated user',
       'contributor' => 'contributor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -29,6 +30,7 @@ function wiki_core_user_default_permissions() {
       'administrator' => 'administrator',
       'contributor' => 'contributor',
       'editor' => 'editor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -40,6 +42,7 @@ function wiki_core_user_default_permissions() {
       'administrator' => 'administrator',
       'authenticated user' => 'authenticated user',
       'contributor' => 'contributor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -51,6 +54,7 @@ function wiki_core_user_default_permissions() {
       'administrator' => 'administrator',
       'authenticated user' => 'authenticated user',
       'contributor' => 'contributor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );
@@ -62,6 +66,7 @@ function wiki_core_user_default_permissions() {
       'administrator' => 'administrator',
       'authenticated user' => 'authenticated user',
       'contributor' => 'contributor',
+      'cem' => 'cem',
     ),
     'module' => 'node',
   );


### PR DESCRIPTION
## NEPT-1432

### Description

Assign automatically the CEM role to ECAS user of a defined group.
Add more permissions to the cem role
Align the cam permissions on contributor ones in the feature definitions.

### Change log

- Added: hook_ecas_sync_user_info() in the ecas module with documentation.
- Changed: The default cem role permissions and move the code to cce_basic_config module.

### Commands

None