### PR TITLE
NEPT-1432: Add cce_basic_config_update_7226() to set cem permissions.

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -2057,10 +2057,10 @@ function cce_basic_config_update_7226() {
   }
 
   if (module_exists('survey_core')) {
-    $components_to_revert[''] = array('user_permission');
+    $components_to_revert['survey_core'] = array('user_permission');
   }
 
-  if (module_exists('survey_core')) {
+  if (module_exists('wiki_core')) {
     $components_to_revert['wiki_core'] = array('user_permission');
   }
 


### PR DESCRIPTION
## NEPT-1432

### Description

Set the cem permissions through all platform features

### Change log

- Added: cce_basic_config_update_7226() that sets the gem permissions by:
  - soft configuring these defined in cce_basic_config and nexteuropa_trackedchanges feature
  - Reverting the following features in order to take into account of the hard configured cem permissions

### Commands

drush updatedb