### PR TITLE
Release 2.5 merge into Release 2.6

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -454,6 +454,32 @@ function cce_basic_config_install() {
 
   multisite_config_service('wysiwyg')->addPreferenceToProfile('full_html', 'version', '4.4.8.ccd0038');
 
+  // Create WYSIWYG profile for Filtered  HTML text format.
+  multisite_config_service('wysiwyg')->createProfile('filtered_html', 'ckeditor');
+
+  $plugin_settings = array(
+    'default' => array(
+      'Bold',
+      'Italic',
+      'Underline',
+      'BulletedList',
+      'NumberedList',
+      'Undo',
+      'Link',
+      'Unlink',
+      'Anchor',
+      'TextColor',
+      'BGColor',
+      'Blockquote',
+      'Font',
+      'FontSize',
+      'Maximize',
+    ),
+  );
+  foreach ($plugin_settings as $group => $buttons) {
+    multisite_config_service('wysiwyg')->addButtonsToProfile('filtered_html', $group, $buttons);
+  }
+
   // Dynamically set the 'print_pdf_pdf_tool' variable. It cannot be exported
   // in a regular feature since it includes the path to where the Print PDF
   // module is installed, which is different depending on the installation

--- a/profiles/common/modules/features/nexteuropa_mediagallery/nexteuropa_mediagallery.info
+++ b/profiles/common/modules/features/nexteuropa_mediagallery/nexteuropa_mediagallery.info
@@ -1,7 +1,7 @@
 name = Nexteuropa Media Gallery
 description = Add Gallery content type for display in a galleries page and block
 core = 7.x
-package = Nexteuropa
+package = NextEuropa
 dependencies[] = cce_basic_config
 dependencies[] = ds
 dependencies[] = ec_embedded_video

--- a/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.module
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.module
@@ -632,6 +632,11 @@ function nexteuropa_trackedchanges_wysiwyg_editor_settings_alter(&$settings, $co
     $settings['lite']['isTracking'] = (bool) variable_get('ckeditor_lite_istracking', FALSE);
   }
 
+  if (empty($settings['extraPlugins']) || (strpos($settings['extraPlugins'], 'lite') === FALSE)) {
+    // Ckeditor lite is an extra plugin. If it is not set, no need to continue.
+    return;
+  }
+
   if ($state == 'create') {
     $is_btn_disabled = variable_get('nexteuropa_trackedchanges_disable_track_on_create');
     if ($is_btn_disabled) {

--- a/profiles/multisite_drupal_communities/modules/custom/multisite_dynamic_basetheme
+++ b/profiles/multisite_drupal_communities/modules/custom/multisite_dynamic_basetheme
@@ -1,1 +1,0 @@
-../../../common/modules/custom/multisite_dynamic_basetheme

--- a/profiles/multisite_drupal_standard/modules/custom/multisite_dynamic_basetheme
+++ b/profiles/multisite_drupal_standard/modules/custom/multisite_dynamic_basetheme
@@ -1,1 +1,0 @@
-../../../common/modules/custom/multisite_dynamic_basetheme

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -192,7 +192,7 @@ projects[diff][download][revision] = b1b09189d52380a008c9cb29b879e3aa140ec2e0
 projects[diff][download][type] = git
 
 projects[ds][subdir] = "contrib"
-projects[ds][version] = "2.14"
+projects[ds][version] = "2.15"
 
 projects[easy_breadcrumb][subdir] = "contrib"
 projects[easy_breadcrumb][version] = "2.12"
@@ -1031,7 +1031,7 @@ projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
 projects[ec_resp][download][tag] = 2.3.7
 
 projects[atomium][type] = theme
-projects[atomium][version] = 2.7
+projects[atomium][version] = 2.8
 
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git


### PR DESCRIPTION
## NEPT-1828 - NEPT-1441 - NEPT-1923 - NEPT-1593 - NEPT-1931 - NEPT-1909

### Description

NEPT-1828: Upgrade the ec_resp release version (#1978)
NEPT-1441: Use correct package name NextEuropa (#1975)
NEPT-1923: Upgrade ds to 2.15. (#2008)
NEPT-1593: Add ckeditor to filtered format. (#1992)
NEPT-1931: Remove useless symlinks. (#2016)
NEPT-1909: Update Atomium version from 2.7 to 2.8. (#1988)

### Commands

drush cc all

