### PR TITLE
NEPT-1932: Update drupal core version to 7.59.

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = "core"
-projects[drupal][version] = "7.58"
+projects[drupal][version] = "7.59"
 
 ; AJAX callbacks not properly working with the language url suffix.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-4268


### PR DESCRIPTION
## NEPT-1932
### Description

Update Drupal core to 7.59

### Change log

- Security: Update Drupal core to 7.59

### Commands

No command.

