### PR TITLE
NEPT-1496: Remove ec_resp files in platform_dev

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -679,6 +679,10 @@ projects[tmgmt][patch][] = https://www.drupal.org/files/issues/tmgmt-test_transl
 ; https://www.drupal.org/node/2812863
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-60
 projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2812863.patch
+; #2362321 : Check source length limits
+; https://www.drupal.org/node/2362321
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1802
+projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2018-04-12/check_source_length-d7-2362321-37.patch
 ; #2955245 : i18nviews strings are not shown on sources view
 ; https://www.drupal.org/node/2955245
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1878

--- a/tests/features/tmgmt/tmgmt_dgt_connector.feature
+++ b/tests/features/tmgmt/tmgmt_dgt_connector.feature
@@ -33,8 +33,8 @@ Feature: TMGMT Poetry features
   @javascript
   Scenario: I can translate contents with TMGMT Cart.
     When I am viewing a multilingual "page" content:
-      | language | title     | field_ne_body | status |
-      | en       | My page 1 | Short body    | 1      |
+      | language | title     | field_ne_body |
+      | en       | My page 1 | Short body    |
     And I click "Translate" in the "primary_tabs" region
     Then I should see "There are 0 items in the translation cart."
 
@@ -43,8 +43,8 @@ Feature: TMGMT Poetry features
     And I should see "There is 1 item in the translation cart."
 
     When I am viewing a multilingual "page" content:
-      | language | title     | field_ne_body | status |
-      | en       | My page 2 | Short body 2  | 1      |
+      | language | title     | field_ne_body |
+      | en       | My page 2 | Short body 2  |
     And I click "Translate" in the "primary_tabs" region
     Then I should see "There is 1 item in the translation cart."
 
@@ -87,6 +87,9 @@ Feature: TMGMT Poetry features
     And I click "In progress" in the "French" row
     And I press "Save"
     And I click "Needs review" in the "French" row
+    When I fill in the following:
+      | edit-title-field0value-translation   | FR My Page 2    |
+      | edit-field-ne-body0value-translation | FR Short body 2 |
     And I press "Save as completed"
     Then I should see "None" in the "French" row
 

--- a/tests/features/tmgmt/tmgmt_poetry_translations.feature
+++ b/tests/features/tmgmt/tmgmt_poetry_translations.feature
@@ -11,7 +11,6 @@ Feature: TMGMT Poetry features
     And tmgmt_poetry is configured to use tmgmt_poetry_mock
     And the following languages are available:
       | languages |
-      | en        |
       | pt-pt     |
       | fr        |
       | de        |
@@ -731,7 +730,7 @@ Feature: TMGMT Poetry features
     And the translation request has version to 1
 
   @theme_wip
-  Scenario: Check the limit 'version' of the request
+  Scenario: Check the limit 'version' and 'partie' of the request
     Given I am logged in as a user with the 'editor' role
     And I have the 'contributor' role in the 'Global editorial team' group
     When I create the following multilingual "page" content:
@@ -749,6 +748,9 @@ Feature: TMGMT Poetry features
     And I click "In progress" in the "French" row
     And I press "Save"
     And I click "Needs review" in the "French" row
+    When I fill in the following:
+      | edit-title-field0value-translation   | FR Title |
+      | edit-field-ne-body0value-translation | FR Body  |
     And I press "Save as completed"
     Then I should see "None" in the "French" row
 
@@ -760,23 +762,7 @@ Feature: TMGMT Poetry features
     Then I check the job reference of the translation request page
     And the poetry translation service received the translation request
     And the translation request has version to 0
-
-  @theme_wip
-  Scenario: Check the limit 'partie' of the request
-    Given I am logged in as a user with the 'editor' role
-    And I have the 'contributor' role in the 'Global editorial team' group
-    When I create the following multilingual "page" content:
-      | language | title                | field_ne_body |
-      | en       | Title last version 1 | Body test 1   |
-    And I visit the "page" content with title "Title last version 1"
-    And I click "Translate" in the "primary_tabs" region
-    And I check the box on the "French" row
-    And I press "Request translation"
-    And I fill in "Date" with a relative date of "+10" days
-    And I press "Submit to translator"
-    And I store the job reference of the translation request page
-    And the poetry translation service received the translation request
-    And set the translation request partie to 99
+    When set the translation request partie to 99
     And I create the following multilingual "page" content:
       | language | title                | field_ne_body |
       | en       | Title last version 2 | Body test 2   |

--- a/tests/features/tmgmt/tmgmt_workbench.feature
+++ b/tests/features/tmgmt/tmgmt_workbench.feature
@@ -127,6 +127,7 @@ Feature: TMGMT Workbench features
     Then I click "In progress" in the "French" row
     And I press "Save"
     And I click "Needs review" in the "French" row
+    And I fill in "edit-title-field0value-translation" with "FR Original version"
     And I press "Save as completed"
     And I visit the "page" content with title "Original version"
     Then the url should match "(.)*content/original-version_en"


### PR DESCRIPTION
## NEPT-1496

### Description

Templates of EC_RESP are on the platform and should be in the theme

### Change log

- Removed: profiles/common/themes/ec_resp

### Commands

No commands

