### PR TITLE
NEPT-1928: Point the make file to the release v3.5.2 of nexteuropa_newsroom

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -508,9 +508,9 @@ projects[nagios][subdir] = "contrib"
 ; https://www.drupal.org/node/2854854
 projects[nagios][patch][] = https://www.drupal.org/files/issues/nagios-id-support-2854854-5.patch
 
-projects[nexteuropa_newsroom][download][type] = get
-projects[nexteuropa_newsroom][download][file_type] = "zip"
-projects[nexteuropa_newsroom][download][url] = https://github.com/ec-europa/nexteuropa-newsroom-reference/archive/master.zip
+projects[nexteuropa_newsroom][download][type] = git
+projects[nexteuropa_newsroom][download][url] = https://github.com/ec-europa/nexteuropa-newsroom-reference.git
+projects[nexteuropa_newsroom][download][tag] = v3.5.2
 projects[nexteuropa_newsroom][subdir] = custom
 
 projects[node_export][subdir] = "contrib"


### PR DESCRIPTION
## NEPT-1928

### Description

Set nexteuropa_newsroom version to v3.5.2 for the platform

### Change log

- Changed: nexteuropa_newsroom reference in the multisite_drupal_standard.make

### Commands

No command

