### PR TITLE
NEPT-1951: Prepare the ec_resp release with the views table fix for the caption

### DIFF
--- a/profiles/common/modules/custom/tmgmt_og/README.txt
+++ b/profiles/common/modules/custom/tmgmt_og/README.txt
@@ -1,6 +1,0 @@
-
-Installation 
-============
-
-In order for the module to work TMGMT module needs to be patched as described on
-the following issue: https://www.drupal.org/node/2307531

--- a/profiles/common/modules/custom/tmgmt_workbench/tmgmt_workbench.info
+++ b/profiles/common/modules/custom/tmgmt_workbench/tmgmt_workbench.info
@@ -6,6 +6,7 @@ configure = admin/config/regional/tmgmt_workbench_settings
 
 dependencies[] = date_popup
 dependencies[] = tmgmt_entity
+dependencies[] = tmgmt_entity_ui
 dependencies[] = workbench
 dependencies[] = workbench_moderation
 

--- a/profiles/common/modules/features/nexteuropa_editorial/nexteuropa_editorial.install
+++ b/profiles/common/modules/features/nexteuropa_editorial/nexteuropa_editorial.install
@@ -9,6 +9,7 @@
  * Implements hook_install().
  */
 function nexteuropa_editorial_install() {
+  $t = get_t();
 
   // Create "editorial team member" site-wide role, automatically assigned
   // when a user is a member of an editorial team group.
@@ -144,6 +145,19 @@ function nexteuropa_editorial_install() {
 
   // Linkchecker: checks for both internal and external links.
   multisite_config_service('system')->setVariable('linkchecker_check_links_types', 0);
+
+  // NEPT-1880: Add base menu link for admin/tmgmt, because when tmgmt is
+  // enabled as a dependency from another module, the menu links for cart and
+  // source will appear in top level of admin menu.
+  $item = array(
+    'link_title' => $t('Translation'),
+    'link_path' => 'admin/tmgmt',
+    'router_path' => 'admin/tmgmt',
+    'menu_name' => 'management',
+    'module' => 'system',
+    'depth' => 2,
+  );
+  menu_link_save($item);
 }
 
 /**

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1040,7 +1040,7 @@ libraries[respond][download][url] = https://raw.githubusercontent.com/scottjehl/
 projects[ec_resp][type] = theme
 projects[ec_resp][download][type] = git
 projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
-projects[ec_resp][download][tag] = 2.3.8
+projects[ec_resp][download][branch] = 2.3.9
 
 projects[atomium][type] = theme
 projects[atomium][version] = 2.8


### PR DESCRIPTION
## NEPT-1951

### Description

Upgrade ec_resp to the version containing the fix for the caption display of views table template.

### Change log

- Changed: Modify the ec_resp version into multisite_drupal_standard.make

### Commands

drush cc all

