### PR TITLE
NEPT-1974: Fixes required by QA about 2.5.36

### DIFF
--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
@@ -443,7 +443,7 @@ function _tmgmt_dgt_connector_cart_sources_add_cart_button(array &$form, array &
   );
   $form['actions']['cart'] = array(
     '#type' => 'submit',
-    '#value' => 'Send to cart',
+    '#value' => t('Send to cart'),
     '#submit' => array('_tmgmt_dgt_connector_cart_form_submit'),
     '#validate' => array('_tmgmt_dgt_connector_cart_form_validate'),
   );

--- a/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.callbacks.inc
+++ b/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.callbacks.inc
@@ -284,6 +284,9 @@ function _nexteuropa_multilingual_get_language_suffix($language) {
  *   Source path if any, input path if none.
  */
 function _nexteuropa_multilingual_get_source_path($path) {
+  // Depending on the call context, drupal_lookup_path is not available.
+  // Then, ensure it is available.
+  require_once DRUPAL_ROOT . '/includes/path.inc';
   $result = drupal_lookup_path('source', $path);
 
   if (!empty($result)) {

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1053,7 +1053,7 @@ libraries[respond][download][url] = https://raw.githubusercontent.com/scottjehl/
 projects[ec_resp][type] = theme
 projects[ec_resp][download][type] = git
 projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
-projects[ec_resp][download][branch] = 2.3.9
+projects[ec_resp][download][tag] = 2.3.9
 
 projects[atomium][type] = theme
 projects[atomium][version] = 2.8


### PR DESCRIPTION
## NEPT-1974

### Description

- Fix the ec_resp declaration into the multisite_drupal_standard.make to point correctly to the tag 2.3.9;
- Add the "t" function for the TMGT "Add to cart" feature in tmgmt_dgt_connector_cart module;
- Fix the "Call to undefined function drupal_lookup_path()" detected during the QA review.

### Change log

- Added: "t" function in _tmgmt_dgt_connector_cart_sources_add_cart_button().
- Changed: The ec_resp declaration in multisite_drupal_standard.make
- Fixed: Call to undefined function drupal_lookup_path() issue in nexteuropa_multilingual.callbacks.inc
- Security:

### Commands

No command to execute

