### PR TITLE
NEPT-1974: Fixes required by QA about 2.5.36 (#2079)

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.module
+++ b/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.module
@@ -147,6 +147,7 @@ function _nexteuropa_piwik_add_load_js_to_page() {
     drupal_add_js($smartloader_prurl, array(
       'type' => 'external',
       'scope' => 'header',
+      'defer' => TRUE,
       'weight' => 5,
     ));
   }

--- a/profiles/common/modules/features/multisite_multilingual_references/multisite_multilingual_references.module
+++ b/profiles/common/modules/features/multisite_multilingual_references/multisite_multilingual_references.module
@@ -307,97 +307,160 @@ function multisite_multilingual_references_entity_view($entity, $type, $view_mod
     $current_lang_code = _multisite_multilingual_references_get_current_lang();
 
     foreach ($entity->content as $k => $content) {
-
-      // Look for "html" (WYSIWYG) fields.
-      if (isset($content['#field_type']) && ($content['#field_type'] == 'text_with_summary' || $content['#field_type'] == 'text_long')) {
-
-        if (isset($content['#items']) && is_array($content['#items'])) {
-          foreach ($content['#items'] as $item_k => $item) {
-            if (isset($content[$item_k]) && isset($content[$item_k]['#markup']) && !empty($content[$item_k]['#markup'])) {
-              // Get all href to nodes in the field.
-              $dom = new DOMDocument();
-              if (multisite_drupal_toolbox_load_html($dom, mb_convert_encoding($content[$item_k]['#markup'], 'HTML-ENTITIES', 'UTF-8'))) {
-                foreach ($dom->getElementsByTagName('a') as $link_node) {
-                  if ($link_node && $link_node->hasAttributes()) {
-
-                    $path = $link_node->getAttribute('href');
-                    // Process valid paths only.
-                    if (url_is_external($path)) {
-                      continue;
-                    }
-
-                    // If we find the marker attribute (introduced in added
-                    // links to avoid parsing the wrong links), then remove
-                    // marker and skip proccessing this link.
-                    if ($link_node->getAttribute('skipattr')) {
-                      $link_node->removeAttribute('skipattr');
-                      continue;
-                    }
-
-                    list($link_lang, $link_path) = _multisite_multilingual_references_clean_path($path);
-
-                    $source_path = drupal_lookup_path('source', $link_path, $link_lang);
-                    if (!$source_path) {
-                      $source_path = $link_path;
-                    }
-
-                    // Get node object and lang from source path; if no node
-                    // found, skip proccessing this link.
-                    $source_node = menu_get_object('node', 1, $source_path);
-                    if (!$source_node) {
-                      continue;
-                    }
-                    $source_lang = $source_node->language;
-                    $source_title = $link_node->nodeValue;
-
-                    // If is a node link added with 'Link plugin'.
-                    if (strpos($link_node->getAttribute('type'), 'length=0') === FALSE) {
-                      $source_title = $link_node->nodeValue;
-                      $type = 'link';
-                    }
-                    else {
-                      $type = NULL;
-                    }
-
-                    if ($source_lang != LANGUAGE_NONE && $source_lang != $current_lang_code) {
-                      // Languages mismatch. Get a link replacement (either
-                      // changed path to matching language node, or added class
-                      // to later display list of available translations of the
-                      // node).
-                      _multisite_multilingual_references_get_link_replacement(array(&$link_node, &$dom), $current_lang_code, $source_path, $source_title, MULTISITE_MULTILINGUAL_REFERENCES_CLASS, $type);
-                    }
-                  }
-                }
-              }
-
-              // Set new field content.
-              $entity->content[$k][$item_k]['#markup'] = $dom->saveHTML();
-            }
-          }
-        }
+      // If content is not array, then it is not targeted by the
+      // following process.
+      if (!is_array($content)) {
+        continue;
       }
 
-      // Look for "node-reference" fields.
-      if (isset($content['#field_type']) && isset($content['#entity_type']) && 'entityreference' == $content['#field_type']  && 'node' == $content['#entity_type']) {
-        if (isset($content['#items']) && is_array($content['#items'])) {
-          foreach ($content['#items'] as $item_k => $item) {
-            // If the current markup is a link.
-            if (isset($content[$item_k]) && isset($content[$item_k]['#markup']) && FALSE !== strrpos($content[$item_k]['#markup'], '</a>')) {
-              $source_path = 'node/' . $item['entity']->nid;
-              $source_lang = $item['entity']->language;
-              $source_title = $item['entity']->title;
-              if ($source_lang != LANGUAGE_NONE && $source_lang != $current_lang_code) {
-                // Languages mismatch. Get a link replacement (either changed
-                // path to matching language node, or added class to later
-                // display list of available translations of the node).
-                $link_replacement = _multisite_multilingual_references_get_link_replacement($content[$item_k]['#markup'], $current_lang_code, $source_path, $source_title, MULTISITE_MULTILINGUAL_REFERENCES_CLASS);
-                if ($link_replacement) {
-                  $entity->content[$k][$item_k]['#markup'] = $link_replacement;
+      // If content has no field type defined, then it is not targeted by the
+      // following process.
+      if (!isset($content['#field_type'])) {
+        continue;
+      }
+
+      // Look for "html" (WYSIWYG) fields.
+      switch ($content['#field_type']) {
+        case 'text_with_summary':
+        case  'text_long':
+          if (isset($content['#items']) && is_array($content['#items'])) {
+            foreach ($content['#items'] as $item_k => $item) {
+              if (isset($content[$item_k]) && isset($content[$item_k]['#markup']) && !empty($content[$item_k]['#markup'])) {
+                // Get all href to nodes in the field.
+                $dom = new DOMDocument();
+                if (multisite_drupal_toolbox_load_html($dom, mb_convert_encoding($content[$item_k]['#markup'], 'HTML-ENTITIES', 'UTF-8'))) {
+                  _multisite_multilingual_references_add_widget_in_html($dom, $current_lang_code);
                 }
+
+                // Set new field content.
+                $entity->content[$k][$item_k]['#markup'] = $dom->saveHTML();
               }
             }
           }
-        }
+          break;
+
+        case 'entityreference':
+          // Update links only if the 'entityreference' field contains nodes as
+          // items.
+          if (!isset($content['#entity_type']) || ('node' != $content['#entity_type'])) {
+            break;
+          }
+
+          if (!isset($content['#items']) || !is_array($content['#items'])) {
+            break;
+          }
+
+          foreach ($content['#items'] as $item_k => $item) {
+            if (isset($content[$item_k]) && isset($content[$item_k]['#markup'])) {
+              $link_replacement = _multisite_multilingual_references_get_widget_from_entityreference($content[$item_k]['#markup'], $item, $current_lang_code);
+              if ($link_replacement) {
+                $entity->content[$k][$item_k]['#markup'] = $link_replacement;
+              }
+            }
+          }
+          break;
+      }
+    }
+  }
+}
+
+/**
+ * Gets the module's widget from a "entity reference" field item.
+ *
+ * The widget will be used to replace the internal link in the
+ * field item markup.
+ *
+ * @param string $field_item_markup
+ *   The HTML markup of the field item to treat.
+ * @param array $field_item
+ *   The array with the info of the field item to treat.
+ * @param string $lang_code
+ *   The code of the language used as reference for the widget generation.
+ *
+ * @return bool|string
+ *   The HTML of the module's widget or FALSE if the conditions to generate the
+ *   widget are not fulfilled.
+ */
+function _multisite_multilingual_references_get_widget_from_entityreference($field_item_markup, array $field_item, $lang_code) {
+  // Rapid check in order to see if the markup contains a link.
+  // if not, return false.
+  if (FALSE !== strrpos($field_item_markup, '</a>')) {
+    return FALSE;
+  }
+
+  $source_lang = $field_item['entity']->language;
+
+  // Languages match. No need to continue the process.
+  if ($source_lang == LANGUAGE_NONE || $source_lang == $lang_code) {
+    return FALSE;
+  }
+
+  $source_path = 'node/' . $field_item['entity']->nid;
+  $source_title = $field_item['entity']->title;
+
+  // Get a link replacement (either changed
+  // path to matching language node, or added class to later
+  // display list of available translations of the node).
+  return _multisite_multilingual_references_get_link_replacement($field_item_markup, $lang_code, $source_path, $source_title, MULTISITE_MULTILINGUAL_REFERENCES_CLASS);
+}
+
+/**
+ * Replaces internal links in a HTML DOM object by the module's widget.
+ *
+ * @param DOMDocument $dom
+ *   The DOM object where replacing the internal links.
+ * @param string $current_lang_code
+ *   The current interface language.
+ */
+function _multisite_multilingual_references_add_widget_in_html(DOMDocument $dom, $current_lang_code) {
+  foreach ($dom->getElementsByTagName('a') as $link_node) {
+    if ($link_node && $link_node->hasAttributes()) {
+
+      $path = $link_node->getAttribute('href');
+      // Process valid paths only.
+      if (url_is_external($path)) {
+        continue;
+      }
+
+      // If we find the marker attribute (introduced in added
+      // links to avoid parsing the wrong links), then remove
+      // marker and skip proccessing this link.
+      if ($link_node->getAttribute('skipattr')) {
+        $link_node->removeAttribute('skipattr');
+        continue;
+      }
+
+      list($link_lang, $link_path) = _multisite_multilingual_references_clean_path($path);
+
+      $source_path = drupal_lookup_path('source', $link_path, $link_lang);
+      if (!$source_path) {
+        $source_path = $link_path;
+      }
+
+      // Get node object and lang from source path; if no node
+      // found, skip proccessing this link.
+      $source_node = menu_get_object('node', 1, $source_path);
+      if (!$source_node) {
+        continue;
+      }
+      $source_lang = $source_node->language;
+      $source_title = $link_node->nodeValue;
+
+      // If is a node link added with 'Link plugin'.
+      if (strpos($link_node->getAttribute('type'), 'length=0') === FALSE) {
+        $source_title = $link_node->nodeValue;
+        $type = 'link';
+      }
+      else {
+        $type = NULL;
+      }
+
+      if ($source_lang != LANGUAGE_NONE && $source_lang != $current_lang_code) {
+        // Languages mismatch. Get a link replacement (either
+        // changed path to matching language node, or added class
+        // to later display list of available translations of the
+        // node).
+        _multisite_multilingual_references_get_link_replacement(array(&$link_node, &$dom), $current_lang_code, $source_path, $source_title, MULTISITE_MULTILINGUAL_REFERENCES_CLASS, $type);
       }
     }
   }

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
@@ -159,10 +159,10 @@ function _multisite_wysiwyg_get_ckeditor_css_paths($default_theme = NULL) {
 
   // Add the active theme to the list in order to retrieve its css file
   // reference, if exists.
-  $implied_themes[] = $default_theme;
+  $implied_themes[$default_theme] = $default_theme;
 
   // Build the css file paths list.
-  foreach ($implied_themes as $implied_theme) {
+  foreach (array_keys($implied_themes) as $implied_theme) {
     $path_to_theme = drupal_get_path('theme', $implied_theme);
 
     $css_file_paths[] = $path_to_theme . '/wysiwyg/editor.css';

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_dgt_connector/tmgmt_dgt_connector_cart/tmgmt_dgt_connector_cart.module
@@ -443,7 +443,7 @@ function _tmgmt_dgt_connector_cart_sources_add_cart_button(array &$form, array &
   );
   $form['actions']['cart'] = array(
     '#type' => 'submit',
-    '#value' => 'Send to cart',
+    '#value' => t('Send to cart'),
     '#submit' => array('_tmgmt_dgt_connector_cart_form_submit'),
     '#validate' => array('_tmgmt_dgt_connector_cart_form_validate'),
   );

--- a/profiles/common/modules/features/nexteuropa_geofield/js/nexteuropa_geofield.edit.js
+++ b/profiles/common/modules/features/nexteuropa_geofield/js/nexteuropa_geofield.edit.js
@@ -300,6 +300,15 @@
               geojson_map.features[i].geometry.coordinates[id] = parseFloat(geojson_map.features[i].geometry.coordinates[id].toFixed(4));
             }
           }
+          else if (geojson_map.features[i].geometry.type == 'LineString') {
+            for (id in geojson_map.features[i].geometry.coordinates) {
+              if (typeof geojson_map.features[i].geometry.coordinates[0][id] == 'undefined') {
+                continue;
+              }
+              geojson_map.features[i].geometry.coordinates[0][id][0] = parseFloat(geojson_map.features[i].geometry.coordinates[id][0].toFixed(4));
+              geojson_map.features[i].geometry.coordinates[0][id][1] = parseFloat(geojson_map.features[i].geometry.coordinates[id][1].toFixed(4));
+            }
+          }
           else {
             for (id in geojson_map.features[i].geometry.coordinates[0]) {
               geojson_map.features[i].geometry.coordinates[0][id][0] = parseFloat(geojson_map.features[i].geometry.coordinates[0][id][0].toFixed(4));

--- a/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.callbacks.inc
+++ b/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.callbacks.inc
@@ -284,6 +284,9 @@ function _nexteuropa_multilingual_get_language_suffix($language) {
  *   Source path if any, input path if none.
  */
 function _nexteuropa_multilingual_get_source_path($path) {
+  // Depending on the call context, drupal_lookup_path is not available.
+  // Then, ensure it is available.
+  require_once DRUPAL_ROOT . '/includes/path.inc';
   $result = drupal_lookup_path('source', $path);
 
   if (!empty($result)) {

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -835,10 +835,6 @@ projects[workbench_og][type] = module
 projects[workbench_og][download][type] = git
 projects[workbench_og][download][revision] = 511caed35326ec7f328e794dc4be21eb33c5ae86
 projects[workbench_og][download][branch] = 7.x-2.x
-; Workbench "MY DRAFTS" does not display my drafts
-; Issue https://www.drupal.org/node/2006134
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1866
-projects[workbench_og][patch][] = https://www.drupal.org/files/issues/2018-05-18/workbench_og-my_drafts_missing-2006134-4.patch
 
 projects[wysiwyg][subdir] = "contrib"
 projects[wysiwyg][download][version] = "2.4"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1053,7 +1053,7 @@ libraries[respond][download][url] = https://raw.githubusercontent.com/scottjehl/
 projects[ec_resp][type] = theme
 projects[ec_resp][download][type] = git
 projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
-projects[ec_resp][download][branch] = 2.3.9
+projects[ec_resp][download][tag] = 2.3.9
 
 projects[atomium][type] = theme
 projects[atomium][version] = 2.8

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -296,10 +296,7 @@ projects[field_group][version] = "1.5"
 projects[field_group][patch][] = https://www.drupal.org/files/issues/field_group_label_translation_patch.patch
 
 projects[file_entity][subdir] = "contrib"
-projects[file_entity][version] = "2.4"
-; https://www.drupal.org/node/2893132
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-672
-projects[file_entity][patch][] = https://www.drupal.org/files/issues/D7-file_entity-file_description_missing-2893132-2.patch
+projects[file_entity][version] = "2.21"
 
 projects[filefield_sources][subdir] = "contrib"
 projects[filefield_sources][version] = "1.11"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1049,12 +1049,12 @@ projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
 projects[ec_resp][download][tag] = 2.3.9
 
 projects[atomium][type] = theme
-projects[atomium][version] = 2.8
+projects[atomium][version] = 2.11
 
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
-projects[ec_europa][download][tag] = 0.0.11
+projects[ec_europa][download][tag] = 0.0.13
 
 ; ==============
 ; Custom modules

--- a/tests/features/content_accessibility.feature
+++ b/tests/features/content_accessibility.feature
@@ -1,0 +1,86 @@
+@api
+Feature: Content accessibility test
+  In order to detect whether the code base and/or the platform configuration disclose
+  contents to users that should not access them
+  As a front end developer
+  I want to perform a couple of quick checks on the platform
+
+  Scenario: Check that unpublished "Basic page" and "Article" content are not
+   accessible to anonymous users with the default configuration of the platform
+    Given I am an anonymous user
+    And I am viewing an "page" content with "draft" moderation state:
+      | title            | Lorem ipsum dolor sit amet                                      |
+      | field_ne_body    | <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> |
+    Then I should get an access denied error
+    And I should see the text "You are not authorized to access this page."
+    And I should not see the text "Lorem ipsum dolor sit amet"
+    When I am viewing an "article" content with "draft" moderation state:
+      | title            | EC decides tax advantages for Fiat are illegal                        |
+      | body             | Commissioner states tax rulings are not in line with state aid rules. |
+    Then I should get an access denied error
+    And I should see the text "You are not authorized to access this page."
+    And I should not see the text "EC decides tax advantages for Fiat are illegal"
+
+  Scenario: Check that unpublished "Basic page" and "Article" content are
+   accessible to "editor" users with the default configuration of the platform
+    Given I am logged in as a user with the "editor" role
+    And I am viewing an "page" content with "draft" moderation state:
+      | title            | Lorem ipsum dolor sit amet                                      |
+      | field_ne_body    | <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "Lorem ipsum dolor sit amet"
+    When I am viewing an "article" content with "draft" moderation state:
+      | title            | EC decides tax advantages for Fiat are illegal                        |
+      | body             | Commissioner states tax rulings are not in line with state aid rules. |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "EC decides tax advantages for Fiat are illegal"
+
+  Scenario: Check that unpublished "Basic page" and "Article" content are
+   accessible to "contributor" users with the default configuration of the platform
+    Given I am logged in as a user with the "contributor" role
+    And I am viewing an "page" content with "draft" moderation state:
+      | title            | Lorem ipsum dolor sit amet                                      |
+      | field_ne_body    | <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "Lorem ipsum dolor sit amet"
+    When I am viewing an "article" content with "draft" moderation state:
+      | title            | EC decides tax advantages for Fiat are illegal                        |
+      | body             | Commissioner states tax rulings are not in line with state aid rules. |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "EC decides tax advantages for Fiat are illegal"
+
+  Scenario: Check that unpublished "Basic page" and "Article" content are
+  accessible to "administrator" users with the default configuration of the platform
+    Given I am logged in as a user with the "administrator" role
+    And I am viewing an "page" content with "draft" moderation state:
+      | title            | Lorem ipsum dolor sit amet                                      |
+      | field_ne_body    | <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "Lorem ipsum dolor sit amet"
+    When I am viewing an "article" content with "draft" moderation state:
+      | title            | EC decides tax advantages for Fiat are illegal                        |
+      | body             | Commissioner states tax rulings are not in line with state aid rules. |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "EC decides tax advantages for Fiat are illegal"
+
+  Scenario: Check that published "Basic page" and "Article" content are
+   accessible to anonymous users with the default configuration of the platform
+    Given I am an anonymous user
+    And I am viewing an "page" content with "published" moderation state:
+      | title            | Lorem ipsum dolor sit amet                                      |
+      | field_ne_body    | <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "Lorem ipsum dolor sit amet"
+    When I am viewing an "article" content with "published" moderation state:
+      | title            | EC decides tax advantages for Fiat are illegal                        |
+      | body             | Commissioner states tax rulings are not in line with state aid rules. |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "EC decides tax advantages for Fiat are illegal"

--- a/tests/features/editorial_workflow.feature
+++ b/tests/features/editorial_workflow.feature
@@ -173,6 +173,9 @@ Feature: Editorial workflow
     Then I should see "Revision state: Validated"
     And I should see the message "This node had the state needs_review and now has the state validated"
 
+    @wip
+    # NEPT-1986: The implementation of the NEPT-1866 ticket has been temporarily removed.
+    # The following test must keep the "wip" state until the NEPT-1866 ticket is definitively done.
     Scenario: A user with contributor role can create content and check it on "My Workbench"
       Given I am logged in as a user with the 'contributor' role
       When I go to "node/add/page"

--- a/tests/src/Context/DrupalContext.php
+++ b/tests/src/Context/DrupalContext.php
@@ -343,4 +343,33 @@ class DrupalContext extends DrupalExtensionDrupalContext {
     return $found_elements;
   }
 
+  /**
+   * Creates content of the given type and a moderation state.
+   *
+   * @param string $type
+   *   The created content type.
+   * @param string $state
+   *   The moderation state of the created content.
+   * @param \Behat\Gherkin\Node\TableNode $fields
+   *   The values set for the content fields.
+   *   The table contains 2 column: one for the field name and one
+   *   for the field value.
+   *
+   * @Given I am viewing a/an :type( content) with :state moderation state:
+   */
+  public function assertViewingNodeWithModerationState($type, $state, TableNode $fields) {
+    $node = (object) array(
+      'type' => $type,
+      'workbench_moderation_state_new' => $state,
+    );
+    foreach ($fields->getRowsHash() as $field => $value) {
+      $node->{$field} = $value;
+    }
+
+    $saved = $this->nodeCreate($node);
+
+    // Set internal browser on the node.
+    $this->getSession()->visit($this->locatePath('/node/' . $saved->nid));
+  }
+
 }


### PR DESCRIPTION
## NEPT-1974

### Description

- Fix the ec_resp declaration into the multisite_drupal_standard.make to point correctly to the tag 2.3.9;
- Add the t function for the TMGT "Add to cart" feature in tmgmt_dgt_connector_cart module;
- Fix the Call to undefined function drupal_lookup_path() detected during the QA review.

### Change log

- Added: t function in _tmgmt_dgt_connector_cart_sources_add_cart_button().
- Changed: The ec_resp declaration in multisite_drupal_standard.make
- Fixed: Call to undefined function drupal_lookup_path() issue in nexteuropa_multilingual.callbacks.inc
- Security:

### Commands

No command to execute