### PR TITLE
NEPT-1986: Remove workbench_og-my_drafts_missing-2006134-4.patch

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -835,10 +835,6 @@ projects[workbench_og][type] = module
 projects[workbench_og][download][type] = git
 projects[workbench_og][download][revision] = 511caed35326ec7f328e794dc4be21eb33c5ae86
 projects[workbench_og][download][branch] = 7.x-2.x
-; Workbench "MY DRAFTS" does not display my drafts
-; Issue https://www.drupal.org/node/2006134
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1866
-projects[workbench_og][patch][] = https://www.drupal.org/files/issues/2018-05-18/workbench_og-my_drafts_missing-2006134-4.patch
 
 projects[wysiwyg][subdir] = "contrib"
 projects[wysiwyg][download][version] = "2.4"

--- a/tests/features/content_accessibility.feature
+++ b/tests/features/content_accessibility.feature
@@ -1,0 +1,70 @@
+@api
+Feature: Content accessibility test
+  In order to detect whether the code base and/or the platform configuration disclose
+  contents to users that should not access them
+  As a front end developer
+  I want to perform a couple of quick checks on the platform
+
+  Scenario: Check that unpublished "Basic page" and "Article" content are not
+   accessible to anonymous users with the default configuration of the platform
+    Given I am an anonymous user
+    And I am viewing an "page" content with "draft" moderation state:
+      | title            | Lorem ipsum dolor sit amet                                      |
+      | field_ne_body    | <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> |
+    Then I should get an access denied error
+    And I should see the text "You are not authorized to access this page."
+    And I should not see the text "Lorem ipsum dolor sit amet"
+    When I am viewing an "article" content with "draft" moderation state:
+      | title            | EC decides tax advantages for Fiat are illegal                        |
+      | body             | Commissioner states tax rulings are not in line with state aid rules. |
+    Then I should get an access denied error
+    And I should see the text "You are not authorized to access this page."
+    And I should not see the text "EC decides tax advantages for Fiat are illegal"
+
+  Scenario: Check that unpublished "Basic page" and "Article" content are
+   accessible to "editor" users with the default configuration of the platform
+    Given I am logged in as a user with the "editor" role
+    And I am viewing an "page" content with "draft" moderation state:
+      | title            | Lorem ipsum dolor sit amet                                      |
+      | field_ne_body    | <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "Lorem ipsum dolor sit amet"
+    When I am viewing an "article" content with "draft" moderation state:
+      | title            | EC decides tax advantages for Fiat are illegal                        |
+      | body             | Commissioner states tax rulings are not in line with state aid rules. |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "EC decides tax advantages for Fiat are illegal"
+
+  Scenario: Check that unpublished "Basic page" and "Article" content are
+   accessible to "contributor" users with the default configuration of the platform
+    Given I am logged in as a user with the "contributor" role
+    And I am viewing an "page" content with "draft" moderation state:
+      | title            | Lorem ipsum dolor sit amet                                      |
+      | field_ne_body    | <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "Lorem ipsum dolor sit amet"
+    When I am viewing an "article" content with "draft" moderation state:
+      | title            | EC decides tax advantages for Fiat are illegal                        |
+      | body             | Commissioner states tax rulings are not in line with state aid rules. |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "EC decides tax advantages for Fiat are illegal"
+
+  Scenario: Check that published "Basic page" and "Article" content are
+   accessible to anonymous users with the default configuration of the platform
+    Given I am an anonymous user
+    And I am viewing an "page" content with "published" moderation state:
+      | title            | Lorem ipsum dolor sit amet                                      |
+      | field_ne_body    | <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "Lorem ipsum dolor sit amet"
+    When I am viewing an "article" content with "published" moderation state:
+      | title            | EC decides tax advantages for Fiat are illegal                        |
+      | body             | Commissioner states tax rulings are not in line with state aid rules. |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "EC decides tax advantages for Fiat are illegal"

--- a/tests/features/content_accessibility.feature
+++ b/tests/features/content_accessibility.feature
@@ -53,6 +53,22 @@ Feature: Content accessibility test
     And I should not see the text "You are not authorized to access this page."
     And I should see the text "EC decides tax advantages for Fiat are illegal"
 
+  Scenario: Check that unpublished "Basic page" and "Article" content are
+  accessible to "administrator" users with the default configuration of the platform
+    Given I am logged in as a user with the "administrator" role
+    And I am viewing an "page" content with "draft" moderation state:
+      | title            | Lorem ipsum dolor sit amet                                      |
+      | field_ne_body    | <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p> |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "Lorem ipsum dolor sit amet"
+    When I am viewing an "article" content with "draft" moderation state:
+      | title            | EC decides tax advantages for Fiat are illegal                        |
+      | body             | Commissioner states tax rulings are not in line with state aid rules. |
+    Then I should not get a "403" HTTP response
+    And I should not see the text "You are not authorized to access this page."
+    And I should see the text "EC decides tax advantages for Fiat are illegal"
+
   Scenario: Check that published "Basic page" and "Article" content are
    accessible to anonymous users with the default configuration of the platform
     Given I am an anonymous user

--- a/tests/features/editorial_workflow.feature
+++ b/tests/features/editorial_workflow.feature
@@ -173,6 +173,9 @@ Feature: Editorial workflow
     Then I should see "Revision state: Validated"
     And I should see the message "This node had the state needs_review and now has the state validated"
 
+    @wip
+    # NEPT-1986: The implementation of the NEPT-1866 ticket has been temporarily removed.
+    # The following test must keep the "wip" state until the NEPT-1866 ticket is definitively done.
     Scenario: A user with contributor role can create content and check it on "My Workbench"
       Given I am logged in as a user with the 'contributor' role
       When I go to "node/add/page"

--- a/tests/src/Context/DrupalContext.php
+++ b/tests/src/Context/DrupalContext.php
@@ -343,4 +343,33 @@ class DrupalContext extends DrupalExtensionDrupalContext {
     return $found_elements;
   }
 
+  /**
+   * Creates content of the given type and a moderation state.
+   *
+   * @param string $type
+   *   The created content type.
+   * @param string $state
+   *   The moderation state of the created content.
+   * @param \Behat\Gherkin\Node\TableNode $fields
+   *   The values set for the content fields.
+   *   The table contains 2 column: one for the field name and one
+   *   for the field value.
+   *
+   * @Given I am viewing a/an :type( content) with :state moderation state:
+   */
+  public function assertViewingNodeWithModerationState($type, $state, TableNode $fields) {
+    $node = (object) array(
+      'type' => $type,
+      'workbench_moderation_state_new' => $state,
+    );
+    foreach ($fields->getRowsHash() as $field => $value) {
+      $node->{$field} = $value;
+    }
+
+    $saved = $this->nodeCreate($node);
+
+    // Set internal browser on the node.
+    $this->getSession()->visit($this->locatePath('/node/' . $saved->nid));
+  }
+
 }


### PR DESCRIPTION
## NEPT-1986

### Description

Remove workbench_og-my_drafts_missing-2006134-4.patch that is problematic for the access to unpublished content.
Add basic Behat tests to check the accessibility to unpublished contents by the default user roles.

### Change log

- Added: tests/features/content_accessibility.feature.
- Changed: resources/multisite_drupal_standard.make to remove the patch.

### Commands

No command

