### PR TITLE
NEPT-1987: Fix in i18n Fatal Error Call to undefined method i18n_object_wrapper::strings_update()

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -383,7 +383,7 @@ projects[i18n][patch][] = https://www.drupal.org/files/issues/i18n-2092883-5-ter
 ; of the platform.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1987
 ; https://www.drupal.org/node/2082573
-projects[i18n][patch][] = https://www.drupal.org/files/issues/2018-06-07/i18n-2082573-52-fatal.patch
+projects[i18n][patch][] = https://www.drupal.org/files/issues/2018-06-24/i18n-fatal-error-undefined-strings_update-2082573-54.patch
 
 projects[i18nviews][subdir] = "contrib"
 projects[i18nviews][version] = "3.0-alpha1"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -372,6 +372,10 @@ projects[i18n][version] = "1.13"
 ; Also requires a patch for Drupal core issue https://www.drupal.org/node/1256368,
 ; you can find it in drupal-core.make.
 projects[i18n][patch][] = https://www.drupal.org/files/i18n-hide_language_by_default-1350638-5.patch
+; Term field not displayed & Notice: Undefined index: taxonomy_term in 
+; i18n_taxonomy_field_formatter_view() in node preview
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-8408
+; https://www.drupal.org/node/2092883
 projects[i18n][patch][] = https://www.drupal.org/files/issues/i18n-2092883-5-term%20field-not%20displayed.patch
 
 projects[i18nviews][subdir] = "contrib"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -377,6 +377,13 @@ projects[i18n][patch][] = https://www.drupal.org/files/i18n-hide_language_by_def
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-8408
 ; https://www.drupal.org/node/2092883
 projects[i18n][patch][] = https://www.drupal.org/files/issues/i18n-2092883-5-term%20field-not%20displayed.patch
+; PHP Fatal Error Call to undefined method i18n_object_wrapper::
+; strings_update().
+; It fixes a bug reproducible on sub-sites like BRP but not on fresh install
+; of the platform.
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1987
+; https://www.drupal.org/node/2082573
+projects[i18n][patch][] = https://www.drupal.org/files/issues/2018-06-07/i18n-2082573-52-fatal.patch
 
 projects[i18nviews][subdir] = "contrib"
 projects[i18nviews][version] = "3.0-alpha1"


### PR DESCRIPTION
## NEPT-1987

### Description

Add patch of D.o issue 2082573 related to I18n module ini order to fix the fatal error "call to undefined method".
This fatal error occurs on some sub-sites when they install/enable a new module on their site.
The patch fixes the issue by resetting the static caches used by I18n module. 

### Change log

- Changed: multisite_drupal_standard.make, add the line declaring the 2082573 patch

### Commands

No drush command

