### PR TITLE
NEPT-1989: Fix the display of internal links using the link theme and contributed in FF or IE.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/plugins/nexteuropa_token_ckeditor/plugin.js
+++ b/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/plugins/nexteuropa_token_ckeditor/plugin.js
@@ -33,6 +33,10 @@
             var type = $(this).attr('token-ckeditor-type');
             if (type != 'url') {
               token = token + '{' + Drupal.t('@label as @mode', {'@label': $(this).attr('token-ckeditor-label'), '@mode': $(this).text()}) + '}';
+
+              if (!Drupal.nexteuropa_token_ckeditor.filter.isBrowserSpaceSafe()) {
+                token = '&nbsp;' + token + '&nbsp;';
+              }
             }
             editor.insertHtml(token);
             CKEDITOR.dialog.getCurrent().hide();
@@ -159,7 +163,7 @@
       // Ensure tokens instead the html element is saved.
       editor.on('setData', function (event) {
         var content = event.data.dataValue;
-        event.data.dataValue = Drupal.nexteuropa_token_ckeditor.filter.replaceTokenWithPlaceholder(content);
+        event.data.dataValue = Drupal.nexteuropa_token_ckeditor.filter.replaceTokenWithPlaceholder(content, false);
       });
 
       // Replace tokens with WYSIWYG placeholders.
@@ -171,7 +175,7 @@
       // Replace tokens with WYSIWYG placeholders.
       editor.on('insertHtml', function (event) {
         var content = event.data.dataValue;
-        event.data.dataValue = Drupal.nexteuropa_token_ckeditor.filter.replaceTokenWithPlaceholder(content);
+        event.data.dataValue = Drupal.nexteuropa_token_ckeditor.filter.replaceTokenWithPlaceholder(content, true);
       });
     }
   });
@@ -222,14 +226,26 @@
      *
      * @param content
      *    Text coming from WYSIWYG.
+     * @param insertHtml
+     *    Check if the calling event is insertHtml (true) or not (false).
      *
      * @returns {string}
+     *   Text with placeholders.
      */
-    replaceTokenWithPlaceholder: function (content) {
+    replaceTokenWithPlaceholder: function (content, isInsertHtml) {
       var matches = content.match(this.regex.get_tokens);
       if (matches) {
         for (var i = 0; i < matches.length; i++) {
-          content = content.replace(matches[i], this.getPlaceholderFromToken(matches[i]));
+          var token = matches[i];
+          // Let's replace the ' ' by &nbsp; for placeholder display.
+          // We avoid to do that during the insertHtml event because the
+          // "content" only contains the just inserted tag.
+          // Then, we leave this process while saving the ckeditor data.
+          if (!this.isBrowserSpaceSafe() && !isInsertHtml) {
+            content = content.replace(token + ' ', token + '&nbsp;');
+            content = content.replace(' ' + token, '&nbsp;' + token);
+          }
+          content = content.replace(token, this.getPlaceholderFromToken(token));
         }
       }
       return content;
@@ -239,16 +255,289 @@
      * Replaces placeholders with tokens.
      *
      * @param content
+     *    Text coming from WYSIWYG.
+     *
+     * @returns {string}
+     *   Text with tokens.
      */
     replacePlaceholderWithToken: function (content) {
+      if (!this.isBrowserSpaceSafe()) {
+        // If the browser does manage very well the white space, clean them
+        // before continuing the process.
+        content = Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInPlaceholders(content);
+      }
       var matches = content.match(this.regex.get_placeholders);
       if (matches) {
         for (var i = 0; i < matches.length; i++) {
-          content = content.replace(matches[i], this.getTokenFromPlaceholder(matches[i]));
+          var placeholder = matches[i];
+          content = content.replace(placeholder, this.getTokenFromPlaceholder(placeholder));
         }
       }
       return content;
-    }
+    },
+
+    /**
+     * Check if the used browser managed correctly the white space.
+     *
+     * For more information, see https://dev.ckeditor.com/ticket/12199.
+     *
+     * @return {boolean}
+     *   true if space safe.
+     */
+    isBrowserSpaceSafe: function () {
+      return (!CKEDITOR.env.gecko && !CKEDITOR.env.ie);
+    },
   };
 
+  // Utility class allowing to clean HTML code before saving WYSIWYG content.
+  // It is used when the used browser does not support space correctly.
+  // See https://dev.ckeditor.com/ticket/12199.
+  Drupal.nexteuropa_token_ckeditor.parser = {
+    /**
+     * Clean a HTML element of extra spaces around "nexteuropatoken" tags.
+     *
+     * @param element
+     *   The HTML element to clean
+     *
+     * @return {CKEDITOR.htmlParser.element}
+     *   The cleaned element.
+     */
+    cleanExtraSpaceInElement: function (element) {
+      if ((typeof element.children == 'undefined') || (element.children.length == 0)) {
+        return element;
+      }
+
+      // Clean first extra space of the HTML block.
+      if (this.isWhiteSpace(element.children[0])) {
+        element.children.splice(0, 1);
+      }
+      // Clean last extra space of the HTML block.
+      if (this.isWhiteSpace(element.children[element.children.length - 1])) {
+        element.children.splice((element.children.length - 1), 1);
+      }
+
+      // Clean extra spaces around "nexteuropatoken" tags in the rest of the element.
+      var i = element.children.length;
+      while (i--) {
+        if (element.children[i]['name'] != 'nexteuropatoken') {
+          continue;
+        }
+        // If the "nexteuropatoken" tag is alnone, no space has been detected.
+        // The loop can stop.
+        if ((typeof element.children[i - 1] == 'undefined') && (typeof element.children[i + 1] == 'undefined')) {
+          break;
+        }
+
+        // Clean potential extra space after the "nexteuropatoken" tag.
+        if ((typeof element.children[i + 1] != 'undefined')) {
+          var secondElementAfterTag = (typeof element.children[i + 2] != 'undefined') ? element.children[i + 2] : '';
+          var cleanedAfterTagElement = this.cleanExtraWhiteSpaceAfterTag(element.children[i + 1], secondElementAfterTag);
+
+          if (cleanedAfterTagElement.length != 0) {
+            element.children[i + 1] = cleanedAfterTagElement;
+          }
+          else {
+            element.children.splice((i + 1), 2, ' ');
+          }
+        }
+
+        // Clean potential extra space before the internal link tag.
+        if ((typeof element.children[i - 1] != 'undefined')) {
+          var secondElementBeforeTag = (typeof element.children[i + 2] != 'undefined') ? element.children[i + 2] : '';
+          var cleanedBeforeTagElement = this.cleanExtraWhiteSpaceBeforeTag(element.children[i - 1], secondElementBeforeTag);
+
+          if (cleanedBeforeTagElement.length != 0) {
+            element.children[i - 1] = cleanedBeforeTagElement;
+          }
+          else {
+            element.children.splice((i - 1), 2, ' ');
+          }
+        }
+      }
+      return element;
+    },
+
+    /**
+     * Cleans a HTML content containing "nexteuropatoken" from extra space.
+     *
+     * @param content
+     *   The HMTL content to clean.
+     *
+     * @return {string}
+     *   The cleaned content.
+     */
+    cleanExtraSpaceInPlaceholders: function (content) {
+      var filter = new CKEDITOR.htmlParser.filter({
+        elements: {
+          address: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          article: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          aside: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          blockquote: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          dd: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          div: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          dt: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          fieldset: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          figcaption: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          footer: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          form: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          h1: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          h2: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          h3: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          h4: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          h5: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          h6: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          header: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          li: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          main: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          nav: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          ol: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          p: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          pre: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          section: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          td: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+          th: function (element) {
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+          },
+        }
+      });
+
+      var fragment = CKEDITOR.htmlParser.fragment.fromHtml(content),
+        writer = new CKEDITOR.htmlParser.basicWriter();
+      filter.applyTo(fragment);
+      fragment.writeHtml(writer);
+      return writer.getHtml();
+    },
+
+    /**
+     * Cleans the element before a HTML tag from extra white space.
+     *
+     * @param elementBeforeTag
+     *   CKEDITOR.htmlParser.element appearing directly before the tag.
+     * @param secondElementBeforeTag
+     *   the second CKEDITOR.htmlParser.element appearing directly before
+     *   the tag.
+     *
+     * @return {CKEDITOR.htmlParser.element|string}
+     *   The tag element cleaned from any extra white space; or an empty string
+     *   if the whole element must be removed.
+     */
+    cleanExtraWhiteSpaceBeforeTag: function (elementBeforeTag, secondElementBeforeTag) {
+      // If the element just before the tag is not a text (value is
+      // "undefined"), there is no extra space before it.
+      if ((typeof elementBeforeTag == 'undefined') && (typeof elementBeforeTag['value'] == 'undefined')) {
+        return '';
+      }
+
+      var firstValue = elementBeforeTag;
+      var secondValue = (typeof secondElementBeforeTag != 'undefined') ? secondElementBeforeTag : '';
+      if (this.isWhiteSpace(firstValue) && this.isWhiteSpace(secondValue)) {
+        return '';
+      }
+
+      // Working on both element did not return results, lt's focus on the first one.
+      elementBeforeTag['value'] = firstValue['value'].replace(/(\s&nbsp;|\s\s|&nbsp;\s)$/, ' ');
+      return elementBeforeTag;
+    },
+
+    /**
+     * Cleans the element after a HTML tag from extra white space.
+     *
+     * @param elementAfterTag
+     *   CKEDITOR.htmlParser.element appearing directly after the tag.
+     * @param secondElementAfterTag
+     *   the second CKEDITOR.htmlParser.element appearing directly after
+     *   the tag.
+     *
+     * @return {CKEDITOR.htmlParser.element|string}
+     *   The tag element cleaned from any extra white space; or an empty string
+     *   if the whole element must be removed.
+     */
+    cleanExtraWhiteSpaceAfterTag: function (elementAfterTag, secondElementAfterTag) {
+      // If the element just after the tag is not a text (value is
+      // "undefined"), there is no extra space before it.
+      if ((typeof elementAfterTag == 'undefined') && (typeof elementAfterTag['value'] == 'undefined')) {
+        return '';
+      }
+
+      var firstValue = elementAfterTag;
+      var secondValue = (typeof secondElementAfterTag != 'undefined') ? secondElementAfterTag : '';
+      if (this.isWhiteSpace(firstValue) && this.isWhiteSpace(secondValue)) {
+        return '';
+      }
+
+      // Working on both element did not return results, lt's focus on the first one.
+      elementAfterTag['value'] = firstValue['value'].replace(/^(\s&nbsp;|\s\s|&nbsp;\s)/, ' ');
+      return elementAfterTag;
+    },
+
+    /**
+     * Check if a CKEDITOR.htmlParser.element is a white space.
+     *
+     * @param element
+     *   The CKEDITOR.htmlParser.element to check.
+     *
+     * @return {boolean}
+     *   true if the element has a ' ' or '&nbsps' value.
+     */
+    isWhiteSpace: function (element) {
+      if (typeof element == 'undefined') {
+        return false;
+      }
+      var value = element['value'];
+      return ((value === ' ' || value == '&nbsp;'))
+    },
+
+  }
 })(jQuery);

--- a/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/plugins/nexteuropa_token_ckeditor/plugin.js
+++ b/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/plugins/nexteuropa_token_ckeditor/plugin.js
@@ -262,7 +262,7 @@
      */
     replacePlaceholderWithToken: function (content) {
       if (!this.isBrowserSpaceSafe()) {
-        // If the browser does manage very well the white space, clean them
+        // If the browser does manage very well the space character, clean them
         // before continuing the process.
         content = Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInPlaceholders(content);
       }
@@ -277,7 +277,7 @@
     },
 
     /**
-     * Check if the used browser managed correctly the white space.
+     * Check if the used browser managed correctly the space character.
      *
      * For more information, see https://dev.ckeditor.com/ticket/12199.
      *
@@ -308,11 +308,11 @@
       }
 
       // Clean first extra space of the HTML block.
-      if (this.isWhiteSpace(element.children[0])) {
+      if (this.isSpaceCharacter(element.children[0])) {
         element.children.splice(0, 1);
       }
       // Clean last extra space of the HTML block.
-      if (this.isWhiteSpace(element.children[element.children.length - 1])) {
+      if (this.isSpaceCharacter(element.children[element.children.length - 1])) {
         element.children.splice((element.children.length - 1), 1);
       }
 
@@ -330,7 +330,7 @@
 
         // Clean potential extra space after the "nexteuropatoken" tag.
         if ((typeof element.children[i + 1] != 'undefined')) {
-          var cleanedAfterTagElement = this.addWhiteSpaceAfterTag(element.children[i + 1]);
+          var cleanedAfterTagElement = this.addSpaceCharacterAfterTag(element.children[i + 1]);
 
           if (cleanedAfterTagElement.length != 0) {
             element.children[i + 1] = cleanedAfterTagElement;
@@ -339,7 +339,7 @@
 
         // Clean potential extra space before the internal link tag.
         if ((typeof element.children[i - 1] != 'undefined')) {
-          var cleanedBeforeTagElement = this.addWhiteSpaceBeforeTag(element.children[i - 1]);
+          var cleanedBeforeTagElement = this.addSpaceCharacterBeforeTag(element.children[i - 1]);
 
           if (cleanedBeforeTagElement.length != 0) {
             element.children[i - 1] = cleanedBeforeTagElement;
@@ -456,17 +456,17 @@
     },
 
     /**
-     * Cleans the element before a HTML tag from extra white space.
+     * Cleans the element before a HTML tag from extra space character.
      *
      * @param elementBeforeTag
      *   CKEDITOR.htmlParser.element appearing directly before the tag and can
-     *   contain white spaces.
+     *   contain space characters.
      *
-     * @return {CKEDITOR.htmlParser.element|boolean}
-     *   The tag element cleaned from any extra white space; or an empty string
+     * @return {CKEDITOR.htmlParser.element}
+     *   The tag element cleaned from any extra space character; or an empty string
      *   if the whole element must be removed.
      */
-    addWhiteSpaceBeforeTag: function (elementBeforeTag) {
+    addSpaceCharacterBeforeTag: function (elementBeforeTag) {
       // If the element just before the tag is not a text (value is
       // "undefined"), there is no extra space before it.
       if (typeof elementBeforeTag == 'undefined') {
@@ -480,7 +480,7 @@
         && this.isInlineElement(elementBeforeTag['name'])
         && (elementBeforeTag.children.length >= 1)) {
         var lastChildToCheck = elementBeforeTag.children[0];
-        return this.addWhiteSpaceAfterTag(lastChildToCheck);
+        return this.addSpaceCharacterBeforeTag(lastChildToCheck);
       }
 
       // Keep untouched the element if no value is set.
@@ -488,7 +488,7 @@
         return elementBeforeTag;
       }
 
-      if (this.isWhiteSpace(elementBeforeTag)) {
+      if (this.isSpaceCharacter(elementBeforeTag)) {
         return elementBeforeTag;
       }
 
@@ -505,17 +505,17 @@
     },
 
     /**
-     * Cleans the element after a HTML tag from extra white space.
+     * Cleans the element after a HTML tag from extra space character.
      *
      * @param elementAfterTag
      *   CKEDITOR.htmlParser.element appearing directly after the tag and can
-     *   contain white spaces.
+     *   contain space characters.
      *
      * @return {CKEDITOR.htmlParser.element}
-     *   The tag element cleaned from any extra white space; or an empty string
+     *   The tag element cleaned from any extra space character; or an empty string
      *   if the whole element must be removed.
      */
-    addWhiteSpaceAfterTag: function (elementAfterTag) {
+    addSpaceCharacterAfterTag: function (elementAfterTag) {
       // If the element just after the tag is not a text (value is
       // "undefined"), there is no extra space before it.
       if (typeof elementAfterTag == 'undefined') {
@@ -529,7 +529,7 @@
         && this.isInlineElement(elementAfterTag['name'])
         && (elementAfterTag.children.length >= 1)) {
         var firstChildToCheck = elementAfterTag.children[0];
-        return this.addWhiteSpaceAfterTag(firstChildToCheck);
+        return this.addSpaceCharacterAfterTag(firstChildToCheck);
       }
 
       // Keep untouched the element if no value is set.
@@ -537,14 +537,14 @@
         return elementAfterTag;
       }
 
-      if (this.isWhiteSpace(elementAfterTag)) {
+      if (this.isSpaceCharacter(elementAfterTag)) {
         return elementAfterTag;
       }
 
       // Working on both element did not return results, lt's focus on the first one.
       var value = elementAfterTag['value'];
       value = value.replace(/^(&nbsp;&nbsp;|\s&nbsp;|\s\s|&nbsp;\s|\s|&nbsp;)/, ' ');
-      // Clean white space before ending sentence punctuations.
+      // Clean space character before ending sentence punctuations.
       if (value.match(/^[a-zA-Z0-9]/)) {
         value = ' ' + value;
       }
@@ -555,7 +555,7 @@
     },
 
     /**
-     * Check if a CKEDITOR.htmlParser.element is a white space.
+     * Check if a CKEDITOR.htmlParser.element is a space character.
      *
      * @param element
      *   The CKEDITOR.htmlParser.element to check.
@@ -563,7 +563,7 @@
      * @return {boolean}
      *   true if the element has a ' ' or '&nbsps' value.
      */
-    isWhiteSpace: function (element) {
+    isSpaceCharacter: function (element) {
       if (typeof element == 'undefined') {
         return false;
       }

--- a/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/plugins/nexteuropa_token_ckeditor/plugin.js
+++ b/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/plugins/nexteuropa_token_ckeditor/plugin.js
@@ -264,7 +264,7 @@
       if (!this.isBrowserSpaceSafe()) {
         // If the browser does manage very well the white space, clean them
         // before continuing the process.
-        content = Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInPlaceholders(content);
+        content = Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInPlaceholders(content);
       }
       var matches = content.match(this.regex.get_placeholders);
       if (matches) {
@@ -302,7 +302,7 @@
      * @return {CKEDITOR.htmlParser.element}
      *   The cleaned element.
      */
-    cleanExtraSpaceInElement: function (element) {
+    cleanSpaceInElement: function (element) {
       if ((typeof element.children == 'undefined') || (element.children.length == 0)) {
         return element;
       }
@@ -322,7 +322,7 @@
         if (element.children[i]['name'] != 'nexteuropatoken') {
           continue;
         }
-        // If the "nexteuropatoken" tag is alnone, no space has been detected.
+        // If the "nexteuropatoken" tag is alone, no space has been detected.
         // The loop can stop.
         if ((typeof element.children[i - 1] == 'undefined') && (typeof element.children[i + 1] == 'undefined')) {
           break;
@@ -330,27 +330,19 @@
 
         // Clean potential extra space after the "nexteuropatoken" tag.
         if ((typeof element.children[i + 1] != 'undefined')) {
-          var secondElementAfterTag = (typeof element.children[i + 2] != 'undefined') ? element.children[i + 2] : '';
-          var cleanedAfterTagElement = this.cleanExtraWhiteSpaceAfterTag(element.children[i + 1], secondElementAfterTag);
+          var cleanedAfterTagElement = this.addWhiteSpaceAfterTag(element.children[i + 1]);
 
           if (cleanedAfterTagElement.length != 0) {
             element.children[i + 1] = cleanedAfterTagElement;
-          }
-          else {
-            element.children.splice((i + 1), 2, ' ');
           }
         }
 
         // Clean potential extra space before the internal link tag.
         if ((typeof element.children[i - 1] != 'undefined')) {
-          var secondElementBeforeTag = (typeof element.children[i + 2] != 'undefined') ? element.children[i + 2] : '';
-          var cleanedBeforeTagElement = this.cleanExtraWhiteSpaceBeforeTag(element.children[i - 1], secondElementBeforeTag);
+          var cleanedBeforeTagElement = this.addWhiteSpaceBeforeTag(element.children[i - 1]);
 
           if (cleanedBeforeTagElement.length != 0) {
             element.children[i - 1] = cleanedBeforeTagElement;
-          }
-          else {
-            element.children.splice((i - 1), 2, ' ');
           }
         }
       }
@@ -366,95 +358,98 @@
      * @return {string}
      *   The cleaned content.
      */
-    cleanExtraSpaceInPlaceholders: function (content) {
+    cleanSpaceInPlaceholders: function (content) {
       var filter = new CKEDITOR.htmlParser.filter({
+        text: function (value) {
+          return value;
+        },
         elements: {
           address: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           article: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           aside: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           blockquote: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           dd: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           div: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           dt: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           fieldset: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           figcaption: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           footer: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           form: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           h1: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           h2: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           h3: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           h4: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           h5: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           h6: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           header: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           li: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           main: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           nav: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           ol: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           p: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           pre: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           section: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           td: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
           th: function (element) {
-            return Drupal.nexteuropa_token_ckeditor.parser.cleanExtraSpaceInElement(element);
+            return Drupal.nexteuropa_token_ckeditor.parser.cleanSpaceInElement(element);
           },
         }
       });
 
-      var fragment = CKEDITOR.htmlParser.fragment.fromHtml(content),
-        writer = new CKEDITOR.htmlParser.basicWriter();
+      var fragment = CKEDITOR.htmlParser.fragment.fromHtml(content);
+      var writer = new CKEDITOR.htmlParser.basicWriter();
       filter.applyTo(fragment);
       fragment.writeHtml(writer);
       return writer.getHtml();
@@ -464,61 +459,98 @@
      * Cleans the element before a HTML tag from extra white space.
      *
      * @param elementBeforeTag
-     *   CKEDITOR.htmlParser.element appearing directly before the tag.
-     * @param secondElementBeforeTag
-     *   the second CKEDITOR.htmlParser.element appearing directly before
-     *   the tag.
+     *   CKEDITOR.htmlParser.element appearing directly before the tag and can
+     *   contain white spaces.
      *
-     * @return {CKEDITOR.htmlParser.element|string}
+     * @return {CKEDITOR.htmlParser.element|boolean}
      *   The tag element cleaned from any extra white space; or an empty string
      *   if the whole element must be removed.
      */
-    cleanExtraWhiteSpaceBeforeTag: function (elementBeforeTag, secondElementBeforeTag) {
+    addWhiteSpaceBeforeTag: function (elementBeforeTag) {
       // If the element just before the tag is not a text (value is
       // "undefined"), there is no extra space before it.
-      if ((typeof elementBeforeTag == 'undefined') && (typeof elementBeforeTag['value'] == 'undefined')) {
-        return '';
+      if (typeof elementBeforeTag == 'undefined') {
+        return elementBeforeTag;
       }
 
-      var firstValue = elementBeforeTag;
-      var secondValue = (typeof secondElementBeforeTag != 'undefined') ? secondElementBeforeTag : '';
-      if (this.isWhiteSpace(firstValue) && this.isWhiteSpace(secondValue)) {
-        return '';
+      // If the element is another HTML element, check the last child to see
+      // if it contains a space or not.
+      // If it is a block HTML element, nothing to do.
+      if (typeof elementBeforeTag['name'] != 'undefined'
+        && this.isInlineElement(elementBeforeTag['name'])
+        && (elementBeforeTag.children.length >= 1)) {
+        var lastChildToCheck = elementBeforeTag.children[0];
+        return this.addWhiteSpaceAfterTag(lastChildToCheck);
+      }
+
+      // Keep untouched the element if no value is set.
+      if (typeof elementBeforeTag['value'] == 'undefined') {
+        return elementBeforeTag;
+      }
+
+      if (this.isWhiteSpace(elementBeforeTag)) {
+        return elementBeforeTag;
       }
 
       // Working on both element did not return results, lt's focus on the first one.
-      elementBeforeTag['value'] = firstValue['value'].replace(/(\s&nbsp;|\s\s|&nbsp;\s)$/, ' ');
-      return elementBeforeTag;
+      var value = elementBeforeTag['value'];
+      value = value.replace(/(&nbsp;&nbsp;|\s&nbsp;|\s\s|&nbsp;\s|\s|&nbsp;|)$/, ' ');
+      // Add space after the character that precedes the tag.
+      if (value.match(/[a-zA-Z0-9.,;:!?]$/)) {
+        value += ' ';
+      }
+      value = value.replace(/^¡\s/, '¡');
+      elementBeforeTag['value'] = value.replace(/^¿\s/, '¿');
+      return  elementBeforeTag;
     },
 
     /**
      * Cleans the element after a HTML tag from extra white space.
      *
      * @param elementAfterTag
-     *   CKEDITOR.htmlParser.element appearing directly after the tag.
-     * @param secondElementAfterTag
-     *   the second CKEDITOR.htmlParser.element appearing directly after
-     *   the tag.
+     *   CKEDITOR.htmlParser.element appearing directly after the tag and can
+     *   contain white spaces.
      *
-     * @return {CKEDITOR.htmlParser.element|string}
+     * @return {CKEDITOR.htmlParser.element}
      *   The tag element cleaned from any extra white space; or an empty string
      *   if the whole element must be removed.
      */
-    cleanExtraWhiteSpaceAfterTag: function (elementAfterTag, secondElementAfterTag) {
+    addWhiteSpaceAfterTag: function (elementAfterTag) {
       // If the element just after the tag is not a text (value is
       // "undefined"), there is no extra space before it.
-      if ((typeof elementAfterTag == 'undefined') && (typeof elementAfterTag['value'] == 'undefined')) {
-        return '';
+      if (typeof elementAfterTag == 'undefined') {
+        return elementAfterTag;
       }
 
-      var firstValue = elementAfterTag;
-      var secondValue = (typeof secondElementAfterTag != 'undefined') ? secondElementAfterTag : '';
-      if (this.isWhiteSpace(firstValue) && this.isWhiteSpace(secondValue)) {
-        return '';
+      // If the element is an inline HTML element, check the first child to see
+      // if it contains a space or not.
+      // If it is a block HTML element, nothing to do.
+      if (typeof elementAfterTag['name'] != 'undefined'
+        && this.isInlineElement(elementAfterTag['name'])
+        && (elementAfterTag.children.length >= 1)) {
+        var firstChildToCheck = elementAfterTag.children[0];
+        return this.addWhiteSpaceAfterTag(firstChildToCheck);
+      }
+
+      // Keep untouched the element if no value is set.
+      if (typeof elementAfterTag['value'] == 'undefined') {
+        return elementAfterTag;
+      }
+
+      if (this.isWhiteSpace(elementAfterTag)) {
+        return elementAfterTag;
       }
 
       // Working on both element did not return results, lt's focus on the first one.
-      elementAfterTag['value'] = firstValue['value'].replace(/^(\s&nbsp;|\s\s|&nbsp;\s)/, ' ');
+      var value = elementAfterTag['value'];
+      value = value.replace(/^(&nbsp;&nbsp;|\s&nbsp;|\s\s|&nbsp;\s|\s|&nbsp;)/, ' ');
+      // Clean white space before ending sentence punctuations.
+      if (value.match(/^[a-zA-Z0-9]/)) {
+        value = ' ' + value;
+      }
+      value = value.replace(/^\s\./, '.');
+      value = value.replace(/^\s!/, '!');
+      elementAfterTag['value'] = value.replace(/^\s\?/, '?');
       return elementAfterTag;
     },
 
@@ -538,6 +570,42 @@
       var value = element['value'];
       return ((value === ' ' || value == '&nbsp;'))
     },
+
+    isInlineElement: function (elementName) {
+      var inlineBlockList = [
+        'b',
+        'big',
+        'i',
+        'small',
+        'tt',
+        'abbr',
+        'acronym',
+        'cite',
+        'code',
+        'dfn',
+        'em',
+        'kbd',
+        'strong',
+        'samp',
+        'var',
+        'a',
+        'bdo',
+        'br',
+        'img',
+        'map',
+        'object',
+        'q',
+        'span',
+        'sub',
+        'sup',
+        'button',
+        'input',
+        'label',
+        'select',
+        'textarea',
+      ];
+      return (inlineBlockList.indexOf(elementName) > -1);
+    }
 
   }
 })(jQuery);

--- a/profiles/common/modules/custom/nexteuropa_token/src/Entity/LinkTokenHandler.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/Entity/LinkTokenHandler.php
@@ -51,7 +51,10 @@ class LinkTokenHandler extends TokenAbstractHandler {
           if ($entity = $entity_info['load hook']($entity_id)) {
             $label = entity_label($entity_type, $entity);
             $uri = entity_uri($entity_type, $entity);
-            $replacements[$original] = l($label, $uri['path'], array('absolute' => TRUE));
+            $link_from_token = l($label, $uri['path'], array('absolute' => TRUE));
+            // Use trim() in order to remove unwanted characters around the
+            // link that the "link" theming could add.
+            $replacements[$original] = rtrim($link_from_token);
           }
           else {
             $this->watchdogTokenNotFound($data, $original);


### PR DESCRIPTION
## NEPT-1989

### Description

- Strip the hyperlink generated for an internal link (nexteuropa_token) in order to ensure that unwanted line break or empty space are displayed with link. 
- Improve the management of the nexteuropatoken tag insertions in the WYSIWYG content when the contribution is done in Firefox or I.E..
These browsers managed badly the space when they process ckeditor content. The new implementation take into account as much as possible of this limitation.

### Change log

- Changed: nexteuropa_token/src/Entity/LinkTokenHandler.php: Trim on the replacement link in the method hookTokens()
- Changed: nexteuropa_token_ckeditor/plugin.js: Add the process controlling the space around nexteuropatoken tags.

### Commands

drush cc all

The contributor should be notified they need to clean the cache of their browser.