### PR TITLE
NEPT-1987: Fix in i18n Fatal Error Call to undefined method i18n_object_wrapper::strings_update()

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -664,6 +664,13 @@ projects[term_reference_tree][patch][1514794] = https://www.drupal.org/files/i18
 ; https://www.drupal.org/project/term_reference_tree/issues/1277268
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-2000
 projects[term_reference_tree][patch][] = https://www.drupal.org/files/issues/slider_layout_broken_in_ie8-1277268-25.patch
+; PHP Fatal Error Call to undefined method i18n_object_wrapper::
+; strings_update().
+; It fixes a bug reproducible on sub-sites like BRP but not on fresh install
+; of the platform.
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1987
+; https://www.drupal.org/node/2082573
+projects[i18n][patch][] = https://www.drupal.org/files/issues/2018-06-24/i18n-fatal-error-undefined-strings_update-2082573-54.patch
 
 projects[title][download][branch] = 7.x-1.x
 projects[title][download][revision] = 8119fa2


### PR DESCRIPTION
## NEPT-1987

### Description

Add patch of D.o issue 2082573 related to I18n module ini order to fix the fatal error call to undefined method.
This fatal error occurs on some sub-sites when they install/enable a new module on their site.
The patch fixes the issue by resetting the static caches used by I18n module. 

### Change log

- Changed: multisite_drupal_standard.make, add the line declaring the 2082573 patch

### Commands

No drush command
