### PR TITLE
NEPT-1915: Add Redirect module to the platform stack

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -157,7 +157,7 @@ projects[context_entity_field][version] = "1.1"
 projects[context_entity_field][patch][] = https://www.drupal.org/files/add-entity-references.patch
 
 projects[context_og][subdir] = "contrib"
-projects[context_og][version] = "2.1" 
+projects[context_og][version] = "2.1"
 
 projects[ctools][subdir] = "contrib"
 projects[ctools][download][branch] = 7.x-1.x
@@ -603,6 +603,9 @@ projects[realname][version] = "1.3"
 
 projects[redirect][subdir] = "contrib"
 projects[redirect][version] = "1.0-rc3"
+; https://www.drupal.org/project/redirect/issues/2057615
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1943
+projects[redirect][patch][] = https://www.drupal.org/files/issues/2018-06-24/redirect-increase-size-fields-to-900-2057615-35.patch
 
 projects[registration][subdir] = "contrib"
 projects[registration][version] = "1.6"
@@ -698,7 +701,7 @@ projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2018-04-17/295524
 projects[token][subdir] = "contrib"
 projects[token][version] = "1.7"
 ; #1058912: Prevent recursive tokens
-; https://www.drupal.org/node/1058912          
+; https://www.drupal.org/node/1058912
 projects[token][patch][] = https://www.drupal.org/files/token-1058912-88-limit-token-depth.patch
 
 projects[token_filter][subdir] = "contrib"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -599,10 +599,16 @@ projects[realname][subdir] = "contrib"
 projects[realname][version] = "1.3"
 
 projects[redirect][subdir] = "contrib"
-projects[redirect][version] = "1.0-rc3"
+; In order to be able to #1396446 patch the module we need to point to the latest dev commit.
+projects[redirect][download][branch] = 7.x-1.x
+projects[redirect][download][revision] = add3c695f613fbeec23b7259e59936f60a6b6da6
 ; https://www.drupal.org/project/redirect/issues/2057615
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1943
 projects[redirect][patch][] = https://www.drupal.org/files/issues/2018-06-24/redirect-increase-size-fields-to-900-2057615-35.patch
+; Prevent new redirects from being deleted on cron runs.
+; https://www.drupal.org/node/1396446 
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1945
+projects[redirect][patch][1396446] = https://www.drupal.org/files/issues/2018-05-09/redirect-purge-from-created-1396446-54.patch
 
 projects[registration][subdir] = "contrib"
 projects[registration][version] = "1.6"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -602,6 +602,7 @@ projects[redirect][subdir] = "contrib"
 ; In order to be able to #1396446 patch the module we need to point to the latest dev commit.
 projects[redirect][download][branch] = 7.x-1.x
 projects[redirect][download][revision] = add3c695f613fbeec23b7259e59936f60a6b6da6
+; Increase size of source field to hold long URLs
 ; https://www.drupal.org/project/redirect/issues/2057615
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1943
 projects[redirect][patch][] = https://www.drupal.org/files/issues/2018-06-24/redirect-increase-size-fields-to-900-2057615-35.patch
@@ -609,6 +610,14 @@ projects[redirect][patch][] = https://www.drupal.org/files/issues/2018-06-24/red
 ; https://www.drupal.org/node/1396446 
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1945
 projects[redirect][patch][1396446] = https://www.drupal.org/files/issues/2018-05-09/redirect-purge-from-created-1396446-54.patch
+; Prevent duplicate hashes causing database exceptions
+; https://www.drupal.org/node/2260499
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1946
+; The creation of a specific patch based on
+; https://www.drupal.org/files/issues/redirect-duplicate_redirect_save_handling-2260499-11.patch
+; is necessary because it is in conflict with the 2 other "Redirect" patches and rerolling the D.o issue 
+; is not possible as the 2 others are not committed in the DEV branch.
+projects[redirect][patch][] = patches/redirect-duplicate_redirect_save_handling-2260499-nept-1946.patch 
 
 projects[registration][subdir] = "contrib"
 projects[registration][version] = "1.6"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -601,6 +601,9 @@ projects[rate][patch][] = patches/rate-translate_description-1178.patch
 projects[realname][subdir] = "contrib"
 projects[realname][version] = "1.3"
 
+projects[redirect][subdir] = "contrib"
+projects[redirect][version] = "1.0-rc3"
+
 projects[registration][subdir] = "contrib"
 projects[registration][version] = "1.6"
 

--- a/resources/patches/redirect-duplicate_redirect_save_handling-2260499-nept-1946.patch
+++ b/resources/patches/redirect-duplicate_redirect_save_handling-2260499-nept-1946.patch
@@ -1,0 +1,17 @@
+--- a/redirect.module        2018-06-28 10:38:37.882334071 +0200
++++ b/redirect.module        2018-06-28 10:40:41.370832147 +0200
+@@ -812,6 +812,14 @@
+       $redirect->is_new = FALSE;
+     }
+ 
++    // If a duplicate redirect exists, we need to update it, rather than save a
++    // new one because the UUID hash will be the same. This will produce an
++    // integrity constraint violation in MySQL.
++    if ($exists = redirect_load_by_hash($redirect->hash)) {
++      $redirect->rid = $exists->rid;
++      $redirect->is_new = FALSE;
++    }
++
+     // Save the redirect to the database and invoke the post-save hooks.
+     if ($redirect->is_new) {
+       drupal_write_record('redirect', $redirect);


### PR DESCRIPTION
## NEPT-1915

### Description

Add Redirect module to the platform stack. 

The chosen version included extra commits compared to the current official version 7.x-1.0-rc3:
- Issue #2574593: Fixed watchdog variables in redirect_change_status_multiple();
- Issue #2541304: Fixed errors in cases where redirect_update_7101() needs to run more than once;
- Issue #1961530: Added a limit to how many redirects are purged for each cron run.
- Issue #1768530: Integrate the redirect textfield with the Menu Path Autocomplete (mpac) module if it is available;

Some non committed patches have been also added:
- Issue #2057615: Increase size of source field to hold long URLs;
- Issue #2260499: Generate redirects (Duplicate entry for key hash);
- Issue #1396446: Redirects deleted too early (New redirects being deleted by cron)

The module comes with its default configuration and is not enabled by default on sites.

### Change log

- Changed: resources/multisite_drupal_standard.make to include Redirect and the patch listed above.

### Commands

No command to execute

