### PR TITLE
NEPT-2002:  XML Sitemap reflecting wrong publication status

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -882,7 +882,7 @@ projects[xml_field][subdir] = "contrib"
 projects[xml_field][version] = "2.2"
 
 projects[xmlsitemap][subdir] = "contrib"
-projects[xmlsitemap][version] = "2.3"
+projects[xmlsitemap][version] = "2.4"
 ; Using rel="alternate" rather than multiple sitemaps by language context
 ; https://www.drupal.org/node/1670086
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-11505


### PR DESCRIPTION
## NEPT-[Insert ticket number here]

### Description

Upgrade xmlsitemap to 7.x-2.4 in order to fix the issue with  XML Sitemap that does not reflect the publishing status

### Change log

- Changed: resources/multisite_drupal_standard.make, change the version of the xmlsitemap module.

### Commands

drush cc all

