### PR TITLE
 NEPT-1997: Merge from release-2.5 to release-2.6

### DIFF
--- a/build.properties.dist
+++ b/build.properties.dist
@@ -130,6 +130,9 @@ behat.base_url = http://localhost
 # The URL of the Behat webdriver host.
 behat.wd_host.url = http://localhost:8643/wd/hub
 
+# The browser to use for javascript testing.
+behat.browser.name = phantomjs
+
 # The location to search for Behat subcontexts.
 behat.subcontexts.path = ${platform.build.profiles.dir}/common/modules
 

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -579,16 +579,24 @@ function ecas_login_check() {
  * Check to see if we need to display the logout menu.
  *
  * @return bool
- *   TRUE if the user is logged via ECAS, FALSE otherwise.
+ *   TRUE if the user is logged via ECAS,
+ *   FALSE otherwise.
  */
 function ecas_menu_logout_check() {
   global $user;
-  $access = FALSE;
-  if ($user->uid) {
-    // We provide access to this menu entry only if we are logged via ECAS.
-    $access = isset($_SESSION['phpCAS']) && $_SESSION['phpCAS']['user'] === $user->name;
+
+  if (!user_is_logged_in()) {
+    return FALSE;
   }
-  return $access;
+
+  // We provide access to this menu entry only if we are logged via ECAS.
+  if (isset($_SESSION['phpCAS']) && isset($user->name)) {
+    if ($_SESSION['phpCAS']['user'] === $user->name) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
 }
 
 /**

--- a/profiles/common/modules/features/ec_embedded_video/ec_embedded_video.install.inc
+++ b/profiles/common/modules/features/ec_embedded_video/ec_embedded_video.install.inc
@@ -11,139 +11,163 @@
  * Implied media assets are YouTube, Vimeo, Dailymotion and AV portal.
  */
 function _ec_embedded_video_install_soft_configured_file_display() {
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__no_wrapper_media_avportal_video';
-  $file_display->weight = -39;
-  $file_display->status = TRUE;
-  $file_display->settings = array(
-    'width' => '640',
-    'height' => '390',
-  );
-  file_display_save($file_display);
+  // NEPT-2022: For each file display, we must test first that a site has not
+  // the display already defined.
+  // First, clear the cache in order to have the newly displays created in
+  // the same script run.
+  // Then, load the wysiwyg displays.
+  file_info_cache_clear();
+  $existing_fileDisplays = file_displays_load('video', 'wysiwyg', TRUE);
 
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__no_wrapper_media_dailymotion_video';
-  $file_display->weight = -43;
-  $file_display->status = TRUE;
-  $file_display->settings = array(
-    'width' => '560',
-    'height' => '340',
-    'autoplay' => 0,
-    'iframe' => 1,
-  );
-  file_display_save($file_display);
+  if (empty($existing_fileDisplays) || !isset($existing_fileDisplays['no_wrapper_media_avportal_video'])) {
+    $file_display = new stdClass();
+    $file_display->api_version = 1;
+    $file_display->name = 'video__wysiwyg__no_wrapper_media_avportal_video';
+    $file_display->weight = -39;
+    $file_display->status = TRUE;
+    $file_display->settings = array(
+      'width' => '640',
+      'height' => '390',
+    );
+    file_display_save($file_display);
+  }
 
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__no_wrapper_media_vimeo_video';
-  $file_display->weight = -49;
-  $file_display->status = TRUE;
-  $file_display->settings = array(
-    'width' => '640',
-    'height' => '360',
-    'color' => '',
-    'protocol_specify' => 0,
-    'protocol' => 'https://',
-    'autoplay' => 0,
-    'loop' => 0,
-    'title' => 1,
-    'byline' => 1,
-    'portrait' => 1,
-    'api' => 0,
-  );
-  file_display_save($file_display);
+  if (empty($existing_fileDisplays) || !isset($existing_fileDisplays['no_wrapper_media_dailymotion_video'])) {
+    $file_display = new stdClass();
+    $file_display->api_version = 1;
+    $file_display->name = 'video__wysiwyg__no_wrapper_media_dailymotion_video';
+    $file_display->weight = -43;
+    $file_display->status = TRUE;
+    $file_display->settings = array(
+      'width' => '560',
+      'height' => '340',
+      'autoplay' => 0,
+      'iframe' => 1,
+    );
+    file_display_save($file_display);
+  }
 
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__no_wrapper_media_youtube_video';
-  $file_display->weight = -46;
-  $file_display->status = TRUE;
-  $file_display->settings = array(
-    'width' => '640',
-    'height' => '390',
-    'theme' => 'dark',
-    'color' => 'red',
-    'autohide' => '2',
-    'autoplay' => 0,
-    'loop' => 0,
-    'showinfo' => 1,
-    'modestbranding' => 0,
-    'rel' => 1,
-    'nocookie' => 0,
-    'protocol_specify' => 0,
-    'protocol' => 'https:',
-    'enablejsapi' => 0,
-    'origin' => '',
-  );
-  file_display_save($file_display);
+  if (empty($existing_fileDisplays) || !isset($existing_fileDisplays['no_wrapper_media_vimeo_video'])) {
+    $file_display = new stdClass();
+    $file_display->api_version = 1;
+    $file_display->name = 'video__wysiwyg__no_wrapper_media_vimeo_video';
+    $file_display->weight = -49;
+    $file_display->status = TRUE;
+    $file_display->settings = array(
+      'width' => '640',
+      'height' => '360',
+      'color' => '',
+      'protocol_specify' => 0,
+      'protocol' => 'https://',
+      'autoplay' => 0,
+      'loop' => 0,
+      'title' => 1,
+      'byline' => 1,
+      'portrait' => 1,
+      'api' => 0,
+    );
+    file_display_save($file_display);
+  }
 
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__media_avportal_video';
-  $file_display->weight = -41;
-  $file_display->status = FALSE;
-  $file_display->settings = array(
-    'width' => '640',
-    'height' => '390',
-  );
-  file_display_save($file_display);
+  if (empty($existing_fileDisplays) || !isset($existing_fileDisplays['no_wrapper_media_youtube_video'])) {
+    $file_display = new stdClass();
+    $file_display->api_version = 1;
+    $file_display->name = 'video__wysiwyg__no_wrapper_media_youtube_video';
+    $file_display->weight = -46;
+    $file_display->status = TRUE;
+    $file_display->settings = array(
+      'width' => '640',
+      'height' => '390',
+      'theme' => 'dark',
+      'color' => 'red',
+      'autohide' => '2',
+      'autoplay' => 0,
+      'loop' => 0,
+      'showinfo' => 1,
+      'modestbranding' => 0,
+      'rel' => 1,
+      'nocookie' => 0,
+      'protocol_specify' => 0,
+      'protocol' => 'https:',
+      'enablejsapi' => 0,
+      'origin' => '',
+    );
+    file_display_save($file_display);
+  }
 
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__media_dailymotion_video';
-  $file_display->weight = -40;
-  $file_display->status = FALSE;
-  $file_display->settings = array(
-    'width' => '560',
-    'height' => '340',
-    'autoplay' => 0,
-    'iframe' => 1,
-  );
-  file_display_save($file_display);
+  if (empty($existing_fileDisplays) || !isset($existing_fileDisplays['media_avportal_video'])) {
+    $file_display = new stdClass();
+    $file_display->api_version = 1;
+    $file_display->name = 'video__wysiwyg__media_avportal_video';
+    $file_display->weight = -41;
+    $file_display->status = FALSE;
+    $file_display->settings = array(
+      'width' => '640',
+      'height' => '390',
+    );
+    file_display_save($file_display);
+  }
 
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__media_vimeo_video';
-  $file_display->weight = -47;
-  $file_display->status = FALSE;
-  $file_display->settings = array(
-    'width' => '640',
-    'height' => '360',
-    'color' => '',
-    'protocol_specify' => 0,
-    'protocol' => 'https://',
-    'autoplay' => 0,
-    'loop' => 0,
-    'title' => 1,
-    'byline' => 1,
-    'portrait' => 1,
-    'api' => 0,
-  );
-  file_display_save($file_display);
+  if (empty($existing_fileDisplays) || !isset($existing_fileDisplays['media_dailymotion_video'])) {
+    $file_display = new stdClass();
+    $file_display->api_version = 1;
+    $file_display->name = 'video__wysiwyg__media_dailymotion_video';
+    $file_display->weight = -40;
+    $file_display->status = FALSE;
+    $file_display->settings = array(
+      'width' => '560',
+      'height' => '340',
+      'autoplay' => 0,
+      'iframe' => 1,
+    );
+    file_display_save($file_display);
+  }
 
-  $file_display = new stdClass();
-  $file_display->api_version = 1;
-  $file_display->name = 'video__wysiwyg__media_youtube_video';
-  $file_display->weight = -46;
-  $file_display->status = FALSE;
-  $file_display->settings = array(
-    'width' => '640',
-    'height' => '390',
-    'theme' => 'dark',
-    'color' => 'red',
-    'autohide' => '2',
-    'autoplay' => 0,
-    'loop' => 0,
-    'showinfo' => 1,
-    'modestbranding' => 0,
-    'rel' => 1,
-    'nocookie' => 0,
-    'protocol_specify' => 0,
-    'protocol' => 'https:',
-    'enablejsapi' => 0,
-    'origin' => '',
-  );
-  file_display_save($file_display);
+  if (empty($existing_fileDisplays) || !isset($existing_fileDisplays['media_vimeo_video'])) {
+    $file_display = new stdClass();
+    $file_display->api_version = 1;
+    $file_display->name = 'video__wysiwyg__media_vimeo_video';
+    $file_display->weight = -47;
+    $file_display->status = FALSE;
+    $file_display->settings = array(
+      'width' => '640',
+      'height' => '360',
+      'color' => '',
+      'protocol_specify' => 0,
+      'protocol' => 'https://',
+      'autoplay' => 0,
+      'loop' => 0,
+      'title' => 1,
+      'byline' => 1,
+      'portrait' => 1,
+      'api' => 0,
+    );
+    file_display_save($file_display);
+  }
+
+  if (empty($existing_fileDisplays) || !isset($existing_fileDisplays['media_youtube_video'])) {
+    $file_display = new stdClass();
+    $file_display->api_version = 1;
+    $file_display->name = 'video__wysiwyg__media_youtube_video';
+    $file_display->weight = -46;
+    $file_display->status = FALSE;
+    $file_display->settings = array(
+      'width' => '640',
+      'height' => '390',
+      'theme' => 'dark',
+      'color' => 'red',
+      'autohide' => '2',
+      'autoplay' => 0,
+      'loop' => 0,
+      'showinfo' => 1,
+      'modestbranding' => 0,
+      'rel' => 1,
+      'nocookie' => 0,
+      'protocol_specify' => 0,
+      'protocol' => 'https:',
+      'enablejsapi' => 0,
+      'origin' => '',
+    );
+    file_display_save($file_display);
+  }
 }

--- a/profiles/common/modules/features/ecas_env/ecas_env.module
+++ b/profiles/common/modules/features/ecas_env/ecas_env.module
@@ -72,13 +72,29 @@ function ecas_env_menu_alter(&$items) {
 }
 
 /**
- * Function normal_menu_logout_check().
+ * Check to see if we need to display the normal logout menu.
+ *
+ * @see ecas_menu_logout_check()
+ *
+ * @return bool
+ *   TRUE if the user is logged in but not via ECAS,
+ *   FALSE otherwise.
  */
 function normal_menu_logout_check() {
   global $user;
-  $access_ecas = (isset($_SESSION['phpCAS']) && $_SESSION['phpCAS']['user'] === $user->name);
-  $access = (user_is_logged_in() && !$access_ecas);
-  return $access;
+
+  if (!user_is_logged_in()) {
+    return FALSE;
+  }
+
+  // We provide access to this menu entry only if we are not logged via ECAS.
+  if (isset($_SESSION['phpCAS']) && isset($user->name)) {
+    if ($_SESSION['phpCAS']['user'] === $user->name) {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
 }
 
 /**

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -649,11 +649,7 @@ projects[registry_autoload][version] = 1.3
 projects[registry_autoload][patch][2870868] = https://www.drupal.org/files/issues/autoload_bootstrap_dependency_issues-2870868-2.patch
 
 projects[rules][subdir] = "contrib"
-projects[rules][version] = "2.10"
-; #2851567 rules_init() and cache rebuilding are broken
-; https://www.drupal.org/project/rules/issues/2851567
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1325
-projects[rules][patch][2851567] = https://www.drupal.org/files/issues/rules_init_and_cache-2851567-8.patch
+projects[rules][version] = "2.11"
 
 projects[scheduler][subdir] = "contrib"
 projects[scheduler][version] = 1.5

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -865,7 +865,7 @@ projects[workbench_moderation][patch][] = https://www.drupal.org/files/issues/wo
 ; Issue #2825391 Fix current state for transition rules
 ; https://www.drupal.org/node/2825391
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1722
-projects[workbench_moderation][patch][2825391] = https://www.drupal.org/files/issues/2018-05-14/workbench_moderation_fix_rules_current_state-2825391-46.patch 
+projects[workbench_moderation][patch][2825391] = https://www.drupal.org/files/issues/2018-05-14/workbench_moderation_fix_rules_current_state-2825391-46.patch
 
 ; Workbench_og does not have a stable version that allows applying the 2
 ; patches needed to fix the issues NEPT-296 AND NEPT-1866.
@@ -882,6 +882,11 @@ projects[workbench_og][type] = module
 projects[workbench_og][download][type] = git
 projects[workbench_og][download][revision] = 511caed35326ec7f328e794dc4be21eb33c5ae86
 projects[workbench_og][download][branch] = 7.x-2.x
+; Check access for users to view content that was created by them and don't
+; belong to an organic group.
+; Issue https://www.drupal.org/project/workbench_og/issues/2006134
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1866
+projects[workbench_og][patch][] = https://www.drupal.org/files/issues/2018-06-29/workbench_og-my_drafts_missing-2006134-6.patch
 
 projects[wysiwyg][subdir] = "contrib"
 projects[wysiwyg][download][version] = "2.4"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -662,7 +662,7 @@ projects[scheduler_workbench][subdir] = "contrib"
 projects[scheduler_workbench][version] = 1.3
 
 projects[select_or_other][subdir] = "contrib"
-projects[select_or_other][version] = 2.22
+projects[select_or_other][version] = 2.24
 
 projects[simplenews][subdir] = "contrib"
 projects[simplenews][version] = "1.1"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -897,7 +897,7 @@ projects[xml_field][subdir] = "contrib"
 projects[xml_field][version] = "2.2"
 
 projects[xmlsitemap][subdir] = "contrib"
-projects[xmlsitemap][version] = "2.3"
+projects[xmlsitemap][version] = "2.4"
 ; Using rel="alternate" rather than multiple sitemaps by language context
 ; https://www.drupal.org/node/1670086
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-11505

--- a/tests/behat.yml.dist
+++ b/tests/behat.yml.dist
@@ -65,7 +65,9 @@ default:
     Behat\MinkExtension:
       goutte: ~
       javascript_session: 'selenium2'
+      browser_name: '{{ behat.browser.name }}'
       selenium2:
+        browser: '{{ behat.browser.name }}'
         wd_host: '{{ behat.wd_host.url }}'
       base-url: '{{ behat.base_url }}'
       files_path: '{{ platform.build.dir }}'


### PR DESCRIPTION
## NEPT-1997, NEPT-858, NEPT-2033, NEPT-2002, NEPT-2010, NEPT-2022, NEPT-1866

### Description

- NEPT-1997: Avoid PHP error/notices in ecas
- NEPT-858: Restore browser parameters
- NEPT-2033: Upgrade Select (or other) module to 2.24
- NEPT-2002: XML Sitemap reflecting wrong publication status
- NEPT-2010: Upgrade Rules to 2.11
- NEPT-2022: Check the ec_embedded_video file displays exist before creating them
- NEPT-1866: Contributor to see own drafts under Manage Content/My drafts workbench tab

### Change log

- Added: Patch for workbench_og: workbench_og-my_drafts_missing-2006134-6.patch
- Changed: function normal_menu_logout_check()
- Changed: function ecas_menu_logout_check()
- Changed:  behat.yml.dist and build.properties.dist
- Changed: resources/multisite_drupal_standard.make, upgrade the module version.
- Changed: resources/multisite_drupal_standard.make, change the version of the xmlsitemap module.
- Changed: resources/multisite_drupal_standard.make
  - Set the module version to 2.11
  - Remove the obsolete patch rules_init_and_cache-2851567-8.patch
- Changed: _ec_embedded_video_install_soft_configured_file_display(), add test based on the already saved file display.

### Commands

No command to execute

