### PR TITLE
NEPT-2038: Integrate ec_europa fix for file theme in WYSIWYG display

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1106,7 +1106,11 @@ projects[atomium][version] = 2.11
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
-projects[ec_europa][download][tag] = 0.0.13
+; The line below is to uncomment once the code review of nept-2038 is done.
+; projects[ec_europa][download][tag] = 0.0.14
+; The lineand the one below below are to be removed once the code review of
+; nept-2038 is done.
+projects[ec_europa][download][branch] = nept-2038
 
 ; ==============
 ; Custom modules


### PR DESCRIPTION
## NEPT-2038

### Description

Integrate the new ec_europa theme version containing file templates removing the HTMl container around the file HTML tag when displayed in a WYSIWYG field.

### Change log

- Changed: resource/multisite_drupal_standard.make to use the ec_europa version containing the new templates

### Commands

drush cc all