### PR TITLE
NEPT-2036: Change the default value for the Europa Search service URL

### DIFF
--- a/profiles/common/modules/features/nexteuropa_europa_search/nexteuropa_europa_search.module
+++ b/profiles/common/modules/features/nexteuropa_europa_search/nexteuropa_europa_search.module
@@ -5,7 +5,7 @@
  * EUROPA search module.
  */
 
-define('NEXTEUROPA_EUROPA_SEARCH_EUROPA_SEARCH_URL', 'http://ec.europa.eu/geninfo/query/resultaction.jsp');
+define('NEXTEUROPA_EUROPA_SEARCH_EUROPA_SEARCH_URL', 'https://ec.europa.eu/search');
 define('NEXTEUROPA_EUROPA_SEARCH_EUROPA_SEARCH_QUERY_SOURCE', '');
 
 /**


### PR DESCRIPTION
## NEPT-2036

### Description

The Europa Search service URL that issued by the nexteuropa_europa_search module, has changed.
The default URL value set in the module has been changed to point to the new URL.

### Change log

- Changed: nexteuropa_europa_search.module, the default value of the nexteuropa_europa_search_url variable 

### Commands

drush cc all