### PR TITLE
NEPT-2042: Add facetapi patch to fix the Undefined index: field api bundles notice

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -252,6 +252,13 @@ projects[extlink][version] = "1.18"
 
 projects[facetapi][subdir] = "contrib"
 projects[facetapi][version] = "1.5"
+; facetapi_map_assoc() does not check if index exists.
+; Note: This patch is to be remoaved with the future version 7.x-1.6.
+; Indeed, the patch has already been pushed with the #2373023 d.o. issue.
+; https://www.drupal.org/project/facetapi/issues/2768779 
+; and https://www.drupal.org/node/2373023
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2042
+projects[facetapi][patch][] = https://www.drupal.org/files/issues/facetapi-2768779-facetapi_map_assoc-undefined-index.patch
 
 projects[fast_404][subdir] = "contrib"
 projects[fast_404][version] = "1.5"


### PR DESCRIPTION
## NEPT-2042

### Description

It happens with some site configuration that PHP notices are logged .
The facetapi-2768779-facetapi_map_assoc-undefined-index.patch is fixing this.

### Change log

- Changed: resources/multisite_drupal_standard.make to add the patch reference.

### Commands

None

