### PR TITLE
NEPT-900: Decrease current session timeout

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -70,3 +70,7 @@ projects[drupal][patch][] = https://www.drupal.org/files/601776-contact-core-134
 ; https://www.drupal.org/project/drupal/issues/1160764
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1993
 projects[drupal][patch][] = https://www.drupal.org/files/issues/1160764-34-path_load_order.patch
+
+; Set the session's cookie lifetime to 0 so that cookies are deleted when the browser is closed.
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-900
+projects[drupal][patch][] = patches/set-session-cookie-lifetime-0.patch

--- a/resources/patches/set-session-cookie-lifetime-0.patch
+++ b/resources/patches/set-session-cookie-lifetime-0.patch
@@ -1,0 +1,13 @@
+diff --git a/sites/default/default.settings.php b/sites/default/default.settings.php
+index a152b287e9..bc306cd81d 100644
+--- a/sites/default/default.settings.php
++++ b/sites/default/default.settings.php
+@@ -333,7 +333,7 @@ ini_set('session.gc_maxlifetime', 200000);
+  * created to the cookie expires, i.e. when the browser is expected to discard
+  * the cookie. The value 0 means "until the browser is closed".
+  */
+-ini_set('session.cookie_lifetime', 2000000);
++ini_set('session.cookie_lifetime', 0);
+ 
+ /**
+  * If you encounter a situation where users post a large amount of text, and


### PR DESCRIPTION
## NEPT-900

### Description

By default, Drupal ships with a session expiration time of just over 23 days, using this directive in settings.php:

ini_set('session.cookie_lifetime', 2000000);

We decrease the number to 0 in order to delete cookies as soon as the browser is closed.


### Change log


- Changed: Decreased session.cookie_lifetime variable.

