### PR TITLE
NEPT-796 2.5 qa automation update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ try {
                 checkout scm
                 sh 'COMPOSER_CACHE_DIR=/dev/null composer install --no-suggest'
                 sh './bin/phing setup-php-codesniffer'
-                sh './bin/phpcs --standard=Platform --report=full --report=source --report=summary -s'
+                sh './bin/phpcs --standard=Platform --report=full --report=source --report=summary -s ./profiles/'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ try {
                 checkout scm
                 sh 'COMPOSER_CACHE_DIR=/dev/null composer install --no-suggest'
                 sh './bin/phing setup-php-codesniffer'
-                sh './bin/phpcs --report=full --report=source --report=summary -s'
+                sh './bin/phpcs --standard=Platform --report=full --report=source --report=summary -s'
             }
         }
     }

--- a/build.properties.dist
+++ b/build.properties.dist
@@ -211,6 +211,18 @@ phpcs.progress = 1
 # The location of the file containing the global configuration options.
 phpcs.global.config = ${project.basedir}/vendor/squizlabs/php_codesniffer/CodeSniffer.conf
 
+# QA Automation configuration
+# -------------------
+
+# The directory where phpcs can be found.
+toolkit.dir.bin = ${project.basedir}/bin
+
+# The directory to search for modules and themes to review.
+lib.dir = ${project.basedir}/profiles
+
+# The directory where the make files are stored.
+resources.dir = ${project.basedir}/resources
+
 
 # Host configuration
 # ------------------

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "pear/versioncontrol_git": "dev-master",
     "pfrenssen/phpcs-pre-push": "1.0",
     "phing/phing": "~2",
-    "wimg/php-compatibility": "~7.0.7"
+    "wimg/php-compatibility": "^8.1",
+    "squizlabs/php_codesniffer": "2.9.0"
   },
   "prefer-stable": true,
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "43838fd3aa20b57a57c0f61ffacfd05d",
+    "content-hash": "fecc61859f920d26872d96b2f7b448f2",
     "packages": [
         {
             "name": "cpliakas/git-wrapper",
@@ -99,7 +99,7 @@
             "version": "8.2.12",
             "source": {
                 "type": "git",
-                "url": "https://github.com/klausi/coder.git",
+                "url": "https://git.drupal.org/project/coder.git",
                 "reference": "984c54a7b1e8f27ff1c32348df69712afd86b17f"
             },
             "dist": {
@@ -793,7 +793,7 @@
                 }
             ],
             "description": "VersionControl_Git is a library that provides OO interface to handle Git repository.",
-            "time": "2017-08-23 19:37:51"
+            "time": "2017-08-23T19:37:51+00:00"
         },
         {
             "name": "pfrenssen/phpcs-pre-push",
@@ -1020,16 +1020,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+                "reference": "f7dfecbee89d68ab475a6c9e17d22bc9b69aed97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f7dfecbee89d68ab475a6c9e17d22bc9b69aed97",
+                "reference": "f7dfecbee89d68ab475a6c9e17d22bc9b69aed97",
                 "shasum": ""
             },
             "require": {
@@ -1094,7 +1094,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-22T02:43:20+00:00"
+            "time": "2017-05-03T23:30:39+00:00"
         },
         {
             "name": "symfony/console",
@@ -1565,35 +1565,41 @@
         },
         {
             "name": "wimg/php-compatibility",
-            "version": "7.0.8",
+            "version": "8.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wimg/PHPCompatibility.git",
-                "reference": "a3263259daa3629d174d1ac25657466222d6607e"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wimg/PHPCompatibility/zipball/a3263259daa3629d174d1ac25657466222d6607e",
-                "reference": "a3263259daa3629d174d1ac25657466222d6607e",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
                 "shasum": ""
             },
             "require": {
-                "ext-tokenizer": "*",
-                "php": ">=5.1.2",
-                "squizlabs/php_codesniffer": "~2.0"
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
             },
             "require-dev": {
-                "satooshi/php-coveralls": "dev-master"
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
                 "psr-4": {
-                    "PHPCompatibility\\": ""
+                    "PHPCompatibility\\": "PHPCompatibility/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "LGPL-3.0"
+                "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
@@ -1601,14 +1607,14 @@
                     "role": "lead"
                 }
             ],
-            "description": "This is a set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
             "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
             "keywords": [
                 "compatibility",
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-10-30T14:34:26+00:00"
+            "time": "2018-07-17T13:42:26+00:00"
         }
     ],
     "packages-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -377,24 +377,27 @@
         },
         {
             "name": "ec-europa/qa-automation",
-            "version": "3.0.1",
+            "version": "3.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ec-europa/qa-automation.git",
-                "reference": "28a1c4d9eeab90f7d419641c3b0439a577054ba0"
+                "reference": "8ee4f4cf0df04035b983b33670f3628c3456dca4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ec-europa/qa-automation/zipball/28a1c4d9eeab90f7d419641c3b0439a577054ba0",
-                "reference": "28a1c4d9eeab90f7d419641c3b0439a577054ba0",
+                "url": "https://api.github.com/repos/ec-europa/qa-automation/zipball/8ee4f4cf0df04035b983b33670f3628c3456dca4",
+                "reference": "8ee4f4cf0df04035b983b33670f3628c3456dca4",
                 "shasum": ""
             },
             "require": {
                 "cpliakas/git-wrapper": "^1.7",
                 "drupal/coder": "8.2.12",
+                "phing/phing": "~2.16.0",
                 "php": ">=5.2.0",
+                "squizlabs/php_codesniffer": "2.9.0",
                 "symfony/console": "~2.3.10|^2.4.2|~3.0",
-                "symfony/finder": "^3.2"
+                "symfony/finder": "^3.2",
+                "wimg/php-compatibility": "^8.1"
             },
             "require-dev": {
                 "phpunit/phpunit": ">=3.7 <5.0"
@@ -410,7 +413,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "Performs automated QA checks and extra php codesniffs for the subsite starterkit.",
-            "time": "2017-08-11T13:44:36+00:00"
+            "time": "2018-01-26T14:17:36+00:00"
         },
         {
             "name": "jakub-onderka/php-console-color",


### PR DESCRIPTION
## NEPT-796

### Description

Updates dependency of 'wimg/php-compatibility' to ^8.1 and squizlabs/php_codesniffer to use '2.9.0' in order to match the qa-automation requirements.

### Change log

- Changed: Dependencies within the composer.json and added properties within build.properties.dist

### Commands

`composer install`

