### PR TITLE
NEPT-900/2036: Merge from 2.5 to 2.6

### DIFF
--- a/profiles/common/modules/features/nexteuropa_europa_search/nexteuropa_europa_search.module
+++ b/profiles/common/modules/features/nexteuropa_europa_search/nexteuropa_europa_search.module
@@ -5,7 +5,7 @@
  * EUROPA search module.
  */
 
-define('NEXTEUROPA_EUROPA_SEARCH_EUROPA_SEARCH_URL', 'http://ec.europa.eu/geninfo/query/resultaction.jsp');
+define('NEXTEUROPA_EUROPA_SEARCH_EUROPA_SEARCH_URL', 'https://ec.europa.eu/search');
 define('NEXTEUROPA_EUROPA_SEARCH_EUROPA_SEARCH_QUERY_SOURCE', '');
 
 /**

--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -76,3 +76,6 @@ projects[drupal][patch][] = https://www.drupal.org/files/issues/1160764-34-path_
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2001
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-no_protocol_filter-2105841-111-D7.patch
 
+; Set the session's cookie lifetime to 0 so that cookies are deleted when the browser is closed.
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-900
+projects[drupal][patch][] = patches/set-session-cookie-lifetime-0.patch

--- a/resources/patches/set-session-cookie-lifetime-0.patch
+++ b/resources/patches/set-session-cookie-lifetime-0.patch
@@ -1,0 +1,13 @@
+diff --git a/sites/default/default.settings.php b/sites/default/default.settings.php
+index a152b287e9..bc306cd81d 100644
+--- a/sites/default/default.settings.php
++++ b/sites/default/default.settings.php
+@@ -333,7 +333,7 @@ ini_set('session.gc_maxlifetime', 200000);
+  * created to the cookie expires, i.e. when the browser is expected to discard
+  * the cookie. The value 0 means "until the browser is closed".
+  */
+-ini_set('session.cookie_lifetime', 2000000);
++ini_set('session.cookie_lifetime', 0);
+ 
+ /**
+  * If you encounter a situation where users post a large amount of text, and


### PR DESCRIPTION
## NEPT-900, NEPT-2036

### Description
#### NEPT-900

By default, Drupal ships with a session expiration time of just over 23 days, using this directive in settings.php:

ini_set('session.cookie_lifetime', 2000000);

We decrease the number to 0 in order to delete cookies as soon as the browser is closed.

#### NEPT-2036
The Europa Search service URL that issued by the nexteuropa_europa_search module, has changed.
The default URL value set in the module has been changed to point to the new URL.

### Change log

- Changed: nexteuropa_europa_search.module, the default value of the nexteuropa_europa_search_url variable 
- Changed: Decreased session.cookie_lifetime variable.

### Commands

drush cc all