### PR TITLE
NEPT-2038: Integrate ec_europa fix for file theme in WYSIWYG display

### DIFF
--- a/build.properties.dist
+++ b/build.properties.dist
@@ -14,7 +14,7 @@ platform.site.theme_default = ec_resp
 ecl.version = 0.21.0
 
 # The default EC Europa theme release
-ec_europa.version = 0.0.11
+ec_europa.version = 0.0.14
 
 # The default Atomium and Europa theme build properties.
 # Used only if default theme is set to "ec_europa".

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1103,7 +1103,7 @@ projects[atomium][version] = 2.11
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
-projects[ec_europa][download][tag] = 0.0.13
+projects[ec_europa][download][tag] = 0.0.14
 
 ; ==============
 ; Custom modules


### PR DESCRIPTION
## NEPT-2038

### Description

Integrate the new ec_europa theme version containing file templates removing the HTMl container around the file HTML tag when displayed in a WYSIWYG field.

### Change log

- Changed: resource/multisite_drupal_standard.make to use the ec_europa version containing the new templates

### Commands

drush cc all