### PR TITLE
NEPT-2047: Fasttrack, use the product identifier 'EDT' rather than 'REV'

### DIFF
--- a/profiles/common/modules/features/nexteuropa_dgt_connector/ne_tmgmt_dgt_ftt_translator/src/TMGMTDefaultTranslatorPluginController/TmgmtDgtFttTranslatorPluginController.php
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/ne_tmgmt_dgt_ftt_translator/src/TMGMTDefaultTranslatorPluginController/TmgmtDgtFttTranslatorPluginController.php
@@ -118,6 +118,7 @@ class TmgmtDgtFttTranslatorPluginController extends TMGMTDefaultTranslatorPlugin
     if ($node = $this->getNodeFromTmgmtJob($jobs[0])) {
       // Getting the identifier data.
       $identifier = $this->getIdentifier($jobs[0], $node->nid, $parameters['requester_code']);
+      $identifier['identifier.product'] = 'EDT';
 
       // Getting the request data.
       $data = $this->getRequestData($jobs, $node, $parameters['delay']);

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/ne_tmgmt_dgt_ftt_translator/src/Tools/DataProcessor.php
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/ne_tmgmt_dgt_ftt_translator/src/Tools/DataProcessor.php
@@ -260,7 +260,7 @@ trait DataProcessor {
    * @param string $requester_code
    *   Requester code.
    *
-   * @return array|bool
+   * @return array
    *   An array with an identifier data or FALSE in case of errors.
    */
   public function getIdentifier(TMGMTJob $job, $node_id, $requester_code) {

--- a/resources/composer.json
+++ b/resources/composer.json
@@ -4,7 +4,7 @@
   "require": {
     "php": ">=5.4",
     "guzzlehttp/guzzle": "^6.2.1",
-    "ec-europa/oe-poetry-client": "0.3.5",
+    "ec-europa/oe-poetry-client": "0.3.6",
     "drupol/drupal7_psr3_watchdog": "^1.0"
   },
   "require-dev": {

--- a/resources/composer.lock
+++ b/resources/composer.lock
@@ -68,16 +68,16 @@
         },
         {
             "name": "ec-europa/oe-poetry-client",
-            "version": "0.3.5",
+            "version": "0.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ec-europa/oe-poetry-client.git",
-                "reference": "e70f986de511d1d8293ff3c216d390f0cce231c0"
+                "reference": "0b4b024b2d317302f98d459b74659773b4dab807"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ec-europa/oe-poetry-client/zipball/e70f986de511d1d8293ff3c216d390f0cce231c0",
-                "reference": "e70f986de511d1d8293ff3c216d390f0cce231c0",
+                "url": "https://api.github.com/repos/ec-europa/oe-poetry-client/zipball/0b4b024b2d317302f98d459b74659773b4dab807",
+                "reference": "0b4b024b2d317302f98d459b74659773b4dab807",
                 "shasum": ""
             },
             "require": {

--- a/tests/features/tmgmt/fast-track.feature
+++ b/tests/features/tmgmt/fast-track.feature
@@ -118,7 +118,8 @@ Feature: Fast track
         "DO" : [
           { "ne_dgt_rules_ftt_node_send_translation_request" : {
               "USING" : { "node" : [ "node" ],
-               "delay" : "2017-12-01 15:00:00"
+               "delay" : "2017-12-01 15:00:00",
+               "dgt_ftt_workflow_code" : "STS"
               },
               "PROVIDE" : {
                 "tmgmt_job" : { "tmgmt_job" : "Translation Job" },
@@ -144,11 +145,20 @@ Feature: Fast track
     When I select "Needs Review" from "state"
     And I press "Apply"
     Then I should see "Revision state: Needs Review"
+    And Poetry service received request should contain the following text:
+      | <produit>EDT</produit>                                        |
+      | <titre>Test page</titre>                                      |
+      | <organisationResponsable>DIGIT</organisationResponsable>      |
+      | <organisationAuteur>IE/CE/DIGIT</organisationAuteur>          |
+      | <serviceDemandeur>IE/CE/DIGIT/A/3</serviceDemandeur>          |
+      | <applicationReference>FPFIS</applicationReference>            |
+      | <delai>01/12/2017</delai>                                     |
+      | <attributionsDelai>01/12/2017</attributionsDelai>             |
     When I select "Validated" from "state"
     And I press "Apply"
     Then I should see "Revision state: Validated"
     And Poetry service received request should contain the following text:
-      | <produit>EDT</produit>                                        |
+      | <produit>TRA</produit>                                        |
       | <titre>Test page</titre>                                      |
       | <organisationResponsable>DIGIT</organisationResponsable>      |
       | <organisationAuteur>IE/CE/DIGIT</organisationAuteur>          |

--- a/tests/features/tmgmt/fast-track.feature
+++ b/tests/features/tmgmt/fast-track.feature
@@ -50,7 +50,7 @@ Feature: Fast track
       number: 40012
       version: 0
       part: 0
-      product: REV
+      product: EDT
     status:
       -
         type: request
@@ -148,6 +148,7 @@ Feature: Fast track
     And I press "Apply"
     Then I should see "Revision state: Validated"
     And Poetry service received request should contain the following text:
+      | <produit>EDT</produit>                                        |
       | <titre>Test page</titre>                                      |
       | <organisationResponsable>DIGIT</organisationResponsable>      |
       | <organisationAuteur>IE/CE/DIGIT</organisationAuteur>          |
@@ -188,7 +189,7 @@ Feature: Fast track
       number: 40013
       version: 0
       part: 0
-      product: REV
+      product: EDT
     status:
       -
         type: request

--- a/tests/features/tmgmt/fast-track_custom-delay.feature
+++ b/tests/features/tmgmt/fast-track_custom-delay.feature
@@ -48,7 +48,7 @@ Feature: Fast track
       number: 40012
       version: 0
       part: 0
-      product: REV
+      product: EDT
     status:
       -
         type: request
@@ -150,10 +150,19 @@ Feature: Fast track
     When I select "Needs Review" from "state"
     And I press "Apply"
     Then I should see "Revision state: Needs Review"
+    And Poetry service received request should contain the following text:
+      | <produit>EDT</produit>                                        |
+      | <titre>Test page</titre>                                      |
+      | <organisationResponsable>DIGIT</organisationResponsable>      |
+      | <organisationAuteur>IE/CE/DIGIT</organisationAuteur>          |
+      | <serviceDemandeur>IE/CE/DIGIT/A/3</serviceDemandeur>          |
+      | <applicationReference>FPFIS</applicationReference>            |
+      | <delai>01/12/2017</delai>                                     |
     When I select "Validated" from "state"
     And I press "Apply"
     Then I should see "Revision state: Validated"
     And Poetry service received request should contain the following text:
+      | <produit>TRA</produit>                                        |
       | <titre>Test page</titre>                                      |
       | <organisationResponsable>DIGIT</organisationResponsable>      |
       | <organisationAuteur>IE/CE/DIGIT</organisationAuteur>          |


### PR DESCRIPTION
## NEPT-2046

### Description

Update fast track translation to use the product identifier 'EDT' rather than 'REV'.

### Change log

- Added: Custom product identifier within the review request method to pass 'EDT'.
- Changed: oe-poetry-client to version 0.3.6 which supports custom product identifier's. Additional test coverage of the product identifier within the fast track tests.

### Commands

Not applicable.
