### PR TITLE
NEPT-834: Add Honeypot to the platform

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.info
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.info
@@ -32,6 +32,7 @@ dependencies[] = media_wysiwyg
 dependencies[] = media_wysiwyg_view_mode
 dependencies[] = multisite_wysiwyg
 dependencies[] = multisite_config
+dependencies[] = nexteuropa_security
 dependencies[] = nexteuropa_token_ckeditor
 dependencies[] = node
 dependencies[] = options

--- a/profiles/common/modules/features/nexteuropa_security/nexteuropa_security.info
+++ b/profiles/common/modules/features/nexteuropa_security/nexteuropa_security.info
@@ -1,0 +1,7 @@
+name = Nexteuropa security
+description = Set up the settings for honeypot module
+package = Nexteuropa
+core = 7.x
+dependencies[] = features
+dependencies[] = honeypot
+features[features_api][] = api:2

--- a/profiles/common/modules/features/nexteuropa_security/nexteuropa_security.install
+++ b/profiles/common/modules/features/nexteuropa_security/nexteuropa_security.install
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Install the feature nexteuropa_security.
+ */
+
+/**
+ * Implements hook_enable().
+ */
+function nexteuropa_security_enable() {
+  // Activation message.
+  drupal_set_message(t('Nexteuropa security feature is now active on your site.'));
+
+  // Configuration for the system settings and the honeypot module.
+  module_load_include('module', 'honeypot');
+  variable_set('honeypot_protect_all_forms', 1);
+}

--- a/profiles/common/modules/features/nexteuropa_security/nexteuropa_security.module
+++ b/profiles/common/modules/features/nexteuropa_security/nexteuropa_security.module
@@ -2,7 +2,5 @@
 
 /**
  * @file
- * Nexteuropa_security_error definition module.
+ * Nexteuropa_security definition module.
  */
-
-

--- a/profiles/common/modules/features/nexteuropa_security/nexteuropa_security.module
+++ b/profiles/common/modules/features/nexteuropa_security/nexteuropa_security.module
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Nexteuropa_security_error definition module.
+ */
+
+

--- a/profiles/multisite_drupal_communities/modules/features/nexteuropa_security
+++ b/profiles/multisite_drupal_communities/modules/features/nexteuropa_security
@@ -1,0 +1,1 @@
+../../../common/modules/features/nexteuropa_security

--- a/profiles/multisite_drupal_standard/modules/features/nexteuropa_security
+++ b/profiles/multisite_drupal_standard/modules/features/nexteuropa_security
@@ -1,0 +1,1 @@
+../../../common/modules/features/nexteuropa_security

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -259,7 +259,7 @@ projects[facetapi][version] = "1.5"
 ; facetapi_map_assoc() does not check if index exists.
 ; Note: This patch is to be remoaved with the future version 7.x-1.6.
 ; Indeed, the patch has already been pushed with the #2373023 d.o. issue.
-; https://www.drupal.org/project/facetapi/issues/2768779 
+; https://www.drupal.org/project/facetapi/issues/2768779
 ; and https://www.drupal.org/node/2373023
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2042
 projects[facetapi][patch][] = https://www.drupal.org/files/issues/facetapi-2768779-facetapi_map_assoc-undefined-index.patch
@@ -292,15 +292,15 @@ projects[feeds][version] = "2.0-beta3"
 projects[feeds][patch][] = https://www.drupal.org/files/issues/feeds-moved-module-2828605-7.patch
 
 ; "Feeds: Entity Translation" is a dependency for nexteuropa_newsroom module.
-; So far, the module does not have any official release. 
-; The following declaration is based on the one recommended by the 
-; nexteuropa_newsroom team to sub-sites; including the patch 
+; So far, the module does not have any official release.
+; The following declaration is based on the one recommended by the
+; nexteuropa_newsroom team to sub-sites; including the patch
 ; "feeds_et_link_support-2078069-3.patch".
 projects[feeds_et][subdir] = "contrib"
 projects[feeds_et][download][type] = git
 projects[feeds_et][download][revision] = bf0d6d00b1a80a630d4266b04c254f2335177346
 projects[feeds_et][download][branch] = 7.x-1.x
-; Add support for link fields, patch required for the nexteuropa_newsroom module; 
+; Add support for link fields, patch required for the nexteuropa_newsroom module;
 ; see module README file.
 ; https://www.drupal.org/node/2078069
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2018
@@ -379,6 +379,9 @@ projects[geophp][download][revision] = 2777c5e
 projects[geophp][download][type] = git
 projects[geophp][subdir] = "contrib"
 
+projects[honeypot][subdir] = "contrib"
+projects[honeypot][version] = "1.25"
+
 projects[hidden_captcha][subdir] = "contrib"
 projects[hidden_captcha][version] = "1.0"
 
@@ -390,7 +393,7 @@ projects[i18n][version] = "1.24"
 ; Also requires a patch for Drupal core issue https://www.drupal.org/node/1256368,
 ; you can find it in drupal-core.make.
 projects[i18n][patch][] = https://www.drupal.org/files/i18n-hide_language_by_default-1350638-5.patch
-; Call "18n_taxonomy_translate_terms" on a non-translated taxonomy term 
+; Call "18n_taxonomy_translate_terms" on a non-translated taxonomy term
 ; triggers a "PHP Fatal error: Call to a member function get_translations() on boolean"
 ; https://www.drupal.org/project/i18n/issues/2984895
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2006

--- a/tests/features/nexteuropa_security.feature
+++ b/tests/features/nexteuropa_security.feature
@@ -1,0 +1,10 @@
+@api
+Feature: Nexteuropa Security
+  In order to ensure the settings of honeypot are correctly set
+  As a site administrator
+  I want to be able to check that the module is installed by default and the settings of honeypot are right
+
+   Scenario: Honeypot is enforced in all forms
+    Given I am logged in as a user with the 'administrator' role
+    When  I go to "admin/config/content/honeypot_en"
+    Then  the "edit-honeypot-protect-all-forms" checkbox should be checked


### PR DESCRIPTION
## NEPT-834

### Description

Add honeypot to the platform enabled by default and enforced on public forms

### Change log

- Added: 
  - nexteuropa_security feature module
  - behat test
- Changed: 
  - cce_basic_config.info: dependency added
  - multisite_drupal_standard.make: add honeypot module

### Commands

No commands
