### PR TITLE
NEPT-2058: Cast $user_info[cas:groups][cas:group] based on the EAC-EYP patch

### DIFF
--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -393,7 +393,7 @@ function ecas_sync_user_info(&$user, array $user_info, array $args) {
 function ecas_ecas_sync_user_info($user, array $user_info, array &$edit, array $args) {
   $user_cas_groups = array();
   if (!empty($user_info['cas:groups']) && !empty($user_info['cas:groups']['cas:group'])) {
-    $user_cas_groups = $user_info['cas:groups']['cas:group'];
+    $user_cas_groups = (array) $user_info['cas:groups']['cas:group'];
   }
 
   $cem_role = user_role_load_by_name(CCE_BASIC_CONFIG_CEM_ROLE_NAME);


### PR DESCRIPTION
## NEPT-2058
### Description

Cast as array the cas:group parameter in the ecas_ecas_sync_user_info() in order to ensure we treat an array in the CEM role assignment process.

### Change log

- Changed: profiles/common/modules/custom/ecas/includes/ecas.inc: cast cas:groups/cas:group as array in ecas_ecas_sync_user_info().

### Commands

No command to execute

