### PR TITLE
NEPT-1615: Remove dependencies to the outdated module from the platform

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.info
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.info
@@ -29,7 +29,6 @@ dependencies[] = media
 dependencies[] = media_node
 dependencies[] = multisite_settings_core
 dependencies[] = media_wysiwyg
-dependencies[] = media_wysiwyg_view_mode
 dependencies[] = multisite_wysiwyg
 dependencies[] = multisite_config
 dependencies[] = nexteuropa_token_ckeditor

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.info
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.info
@@ -8,5 +8,4 @@ dependencies[] = media_internet
 dependencies[] = wysiwyg
 dependencies[] = media
 dependencies[] = media_wysiwyg
-dependencies[] = media_wysiwyg_view_mode
 features[features_api][] = api:2


### PR DESCRIPTION
## NEPT-1615

### Description

media_wysywig_view_mode is deprecated. Remove from the platform

### Change log

- Removed: dependencies to the module in the info files


