### PR TITLE
NEPT-2065: remove variable that is no longer used.

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -2094,3 +2094,10 @@ function cce_basic_config_update_7226() {
 
   features_revert($components_to_revert);
 }
+
+/**
+ * Remove the multisite_version variable NEPT-2065.
+ */
+function cce_basic_config_update_7227() {
+  variable_del('multisite_version');
+}


### PR DESCRIPTION
## NEPT-2065

### Description

multisite_version variable is no longer used in 2.5, we remove it from the db.

### Change log

- Removed: multisite_version variable


### Commands

`drush updb`

