### PR TITLE
NEPT-2067: href token replacement

### DIFF
--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.sanitize.inc
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.sanitize.inc
@@ -491,7 +491,6 @@ function multisite_drupal_toolbox_filter_xss_attributes($attr, $element = '') {
           break;
 
         case 'href':
-          // Ensure href tokens are replaced before filtering.
           $tokens = token_scan($attrinfo['value']);
           if (!$tokens) {
             $attrinfo['value'] = multisite_drupal_toolbox_filter_xss_bad_protocol($attrinfo['value']);

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.sanitize.inc
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.sanitize.inc
@@ -491,7 +491,9 @@ function multisite_drupal_toolbox_filter_xss_attributes($attr, $element = '') {
           break;
 
         case 'href':
-          $attrinfo['value'] = filter_xss_bad_protocol($attrinfo['value']);
+          // Ensure href tokens are replaced before filtering.
+          $attrinfo['value'] = token_replace($attrinfo['value']);
+          $attrinfo['value'] = multisite_drupal_toolbox_filter_xss_bad_protocol($attrinfo['value']);
           if ($element == 'a' && !$force_nofollow_rel) {
             $force_nofollow_rel = multisite_drupal_toolbox_is_nofollow_link($attrinfo['value'], $nofollow_policy, $nofollow_domains);
           }

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.sanitize.inc
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.sanitize.inc
@@ -492,8 +492,11 @@ function multisite_drupal_toolbox_filter_xss_attributes($attr, $element = '') {
 
         case 'href':
           // Ensure href tokens are replaced before filtering.
-          $attrinfo['value'] = token_replace($attrinfo['value']);
-          $attrinfo['value'] = multisite_drupal_toolbox_filter_xss_bad_protocol($attrinfo['value']);
+          $tokens = token_scan($attrinfo['value']);
+          if (!$tokens) {
+            $attrinfo['value'] = multisite_drupal_toolbox_filter_xss_bad_protocol($attrinfo['value']);
+          }
+  
           if ($element == 'a' && !$force_nofollow_rel) {
             $force_nofollow_rel = multisite_drupal_toolbox_is_nofollow_link($attrinfo['value'], $nofollow_policy, $nofollow_domains);
           }

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.sanitize.inc
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.sanitize.inc
@@ -496,7 +496,7 @@ function multisite_drupal_toolbox_filter_xss_attributes($attr, $element = '') {
           if (!$tokens) {
             $attrinfo['value'] = multisite_drupal_toolbox_filter_xss_bad_protocol($attrinfo['value']);
           }
-  
+
           if ($element == 'a' && !$force_nofollow_rel) {
             $force_nofollow_rel = multisite_drupal_toolbox_is_nofollow_link($attrinfo['value'], $nofollow_policy, $nofollow_domains);
           }


### PR DESCRIPTION
## NEPT-2067

### Description

Fix the sanitise HTML filter that breaks url token href attributes. 

### Change log

- Changed: sanitise HTML filter that removed some URL token from href attributes.

### Commands

Not applicable.