### PR TITLE
NEPT-1615, NEPT-2052, NEPT-2057, NEPT-2067: Merge from 2.5 into 2.6 

### DIFF
--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.sanitize.inc
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.sanitize.inc
@@ -491,7 +491,11 @@ function multisite_drupal_toolbox_filter_xss_attributes($attr, $element = '') {
           break;
 
         case 'href':
-          $attrinfo['value'] = filter_xss_bad_protocol($attrinfo['value']);
+          $tokens = token_scan($attrinfo['value']);
+          if (!$tokens) {
+            $attrinfo['value'] = multisite_drupal_toolbox_filter_xss_bad_protocol($attrinfo['value']);
+          }
+
           if ($element == 'a' && !$force_nofollow_rel) {
             $force_nofollow_rel = multisite_drupal_toolbox_is_nofollow_link($attrinfo['value'], $nofollow_policy, $nofollow_domains);
           }

--- a/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/plugins/nexteuropa_token_ckeditor/plugin.js
+++ b/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/plugins/nexteuropa_token_ckeditor/plugin.js
@@ -449,7 +449,7 @@
       });
 
       var fragment = CKEDITOR.htmlParser.fragment.fromHtml(content);
-      var writer = new CKEDITOR.htmlParser.basicWriter();
+      var writer = new CKEDITOR.htmlWriter();
       filter.applyTo(fragment);
       fragment.writeHtml(writer);
       return writer.getHtml();

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.info
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.info
@@ -29,7 +29,6 @@ dependencies[] = media
 dependencies[] = media_node
 dependencies[] = multisite_settings_core
 dependencies[] = media_wysiwyg
-dependencies[] = media_wysiwyg_view_mode
 dependencies[] = multisite_wysiwyg
 dependencies[] = multisite_config
 dependencies[] = nexteuropa_token_ckeditor

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.info
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.info
@@ -8,5 +8,4 @@ dependencies[] = media_internet
 dependencies[] = wysiwyg
 dependencies[] = media
 dependencies[] = media_wysiwyg
-dependencies[] = media_wysiwyg_view_mode
 features[features_api][] = api:2

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -597,6 +597,7 @@ projects[plupload][subdir] = "contrib"
 projects[plupload][download][branch] = 7.x-1.x
 projects[plupload][download][revision] = bba974c6f3224346a1acae4181a700b55129e6e1
 projects[plupload][download][type] = git
+projects[plupload][patch][] = https://www.drupal.org/files/issues/2018-05-22/files_not_uploaded_in_subdir-2974466.patch
 
 projects[print][subdir] = "contrib"
 projects[print][version] = "2.0"


### PR DESCRIPTION
## NEPT-1615, NEPT-2052, NEPT-2057, NEPT-2067

### Description

- NEPT-1615: Remove dependencies to the outdated module from the platform
- NEPT-2052: Add plupload patch to allow sub directories with S3
- NEPT-2057: Ensure that nexteuropa_token plugin respects the source formatting rules.
- NEPT-2067: Fix the sanitise HTML filter that breaks url token href attributes.

### Change log

- Added: Patch (#2974466) to plupload module.
- Changed:
   - Replaced the use of htmlParser.basicWriter method with the correct CKEDITOR.htmlWriter method that respects the formatting configuration.
   - Sanitise HTML filter that removed some URL token from href attributes.
- Removed: dependencies to the module in the info files

### Commands

Not applicable

