### PR TITLE
 NEPT-2065, NEPT-2076: Merge from 2.5 to 2.6

### DIFF
--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.sanitize.inc
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.sanitize.inc
@@ -765,45 +765,44 @@ function multisite_drupal_toolbox_filter_xss_style_attribute($style_value, array
 }
 
 /**
- * Processes an style property value.
- *
- * Also ensures it does not contain an URL with a disallowed protocol (only
- * http/https are allowed here).
+ * Filters bad protocols from a given string.
  *
  * This function is based on Drupal's filter_xss_bad_protocol(). Differences:
- * 1) It does not decode input string.
- *    It should be done by the caller before calling us.
- * 2) It does not apply check_plain() to result.
- *    It should be done by the caller after calling us.
- * 3) It allows a lot less protocols.
+ *   - It does not decode input string, this should be done by the calling
+ *     function
+ *   - Output is not filtered using check_plain, this should be done by the
+ *     calling function after this function has been called.
+ *   - This function limits protocols to: http, https, mailto or tel.
  *
  * @param string $string
- *   The string with the style property value.
+ *   The string to filter the bad protocols.
  *
  * @return string
  *   Cleaned up version of $string.
  *
- * @see wysiwyg_filter_xss_bad_protocol()
+ * @see filter_xss_bad_protocol()
  */
 function multisite_drupal_toolbox_filter_xss_bad_protocol($string) {
   $allowed_protocols = array(
     'http' => 1,
     'https' => 1,
+    'mailto' => 1,
+    'tel' => 1,
   );
 
-  // Iteratively remove any invalid protocol found.
   do {
     $before = $string;
     $colonpos = strpos($string, ':');
     if ($colonpos > 0) {
-      // We found a colon, possibly a protocol. Verify.
+      // We found a colon, possibly a protocol.
       $protocol = drupal_substr($string, 0, $colonpos);
-      // If a colon is preceded by a slash, question mark or hash, it cannot
-      // possibly be part of the URL scheme. This must be a relative URL,
-      // which inherits the (safe) protocol of the base document.
+
+      // If the potential protocol contains a slash, question mark or hash, it
+      // cannot be part of the URL scheme.
       if (preg_match('![/?#]!', $protocol)) {
         break;
       }
+
       // Per RFC2616, section 3.2.3 (URI Comparison) scheme comparison must
       // be case-insensitive Check if this is a disallowed protocol.
       if (!isset($allowed_protocols[drupal_strtolower($protocol)])) {
@@ -811,5 +810,6 @@ function multisite_drupal_toolbox_filter_xss_bad_protocol($string) {
       }
     }
   } while ($before != $string);
+
   return $string;
 }

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.info
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.info
@@ -156,7 +156,6 @@ features[variable][] = media__wysiwyg_browser_plugins
 features[variable][] = media__wysiwyg_upload_directory
 features[variable][] = menu_options_article
 features[variable][] = menu_parent_article
-features[variable][] = multisite_version
 features[variable][] = node_admin_theme
 features[variable][] = node_options_article
 features[variable][] = node_preview_article

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -18,33 +18,61 @@ module_load_include('inc', 'cce_basic_config', 'cce_basic_config.install');
  */
 function cce_basic_config_requirements($phase) {
   $t = get_t();
+
+  if ($phase != 'runtime') {
+    return array();
+  }
+
+  $requirements = array();
+  $default_message = $t('Information not available on the server.');
+
+  // Platform version number; tag.
+  $version = $default_message;
+  $version_severity = REQUIREMENT_WARNING;
+  if (file_exists(DRUPAL_ROOT . '/.version')) {
+    $version = file_get_contents(DRUPAL_ROOT . '/.version');
+    $version = trim($version);
+    $version_severity = REQUIREMENT_INFO;
+  }
   $requirements['install_tag'] = array(
-    'title' => $t('Tag'),
-    'value' => $t('%profile_tag ', array(
-      '%profile_tag' => variable_get('multisite_version'),
-    )),
-    'severity' => REQUIREMENT_INFO,
-    'weight' => -8,
+    'title' => $t('Platform Tag'),
+    'value' => $version,
+    'severity' => $version_severity,
+    'weight' => -7,
   );
 
-  if (file_exists(DRUPAL_ROOT . '/continuousphp.package')) {
-    if ($continuousphp_package = file_get_contents(DRUPAL_ROOT . '/continuousphp.package')) {
-      $info = drupal_json_decode($continuousphp_package, TRUE);
-      $t = get_t();
-      $requirements['git_ref'] = array(
-        'title' => $t('Git ref'),
-        'value' => $info['ref'],
-        'severity' => REQUIREMENT_INFO,
-        'weight' => -7,
-      );
-      $requirements['git_commit'] = array(
-        'title' => $t('Git commit'),
-        'value' => l($info['commit'], 'https://github.com/ec-europa/platform-dev/commit/' . $info['commit']),
-        'severity' => REQUIREMENT_INFO,
-        'weight' => -7,
-      );
-    }
+  // Platform release related commit.
+  $commit_link = $default_message;
+  $commit_severity = REQUIREMENT_WARNING;
+  if (file_exists(DRUPAL_ROOT . '/.commit')) {
+    $commit = file_get_contents(DRUPAL_ROOT . '/.commit');
+    $commit = trim($commit);
+    $commit_link = l($commit, 'https://github.com/ec-europa/platform-dev/commit/' . $commit);
+    $commit_severity = REQUIREMENT_INFO;
   }
+  $requirements['commit_nr'] = array(
+    'title' => $t('Commit number'),
+    'value' => $commit_link,
+    'severity' => $commit_severity,
+    'weight' => -6,
+  );
+
+  // Platform installation time.
+  $timestamp = $default_message;
+  $timestamp_severity = REQUIREMENT_WARNING;
+  if (file_exists(DRUPAL_ROOT . '/.timestamp')) {
+    $timestamp = file_get_contents(DRUPAL_ROOT . '/.timestamp');
+    $timestamp = trim($timestamp);
+    $timestamp = format_date($timestamp, 'long');
+    $timestamp_severity = REQUIREMENT_INFO;
+  }
+  $requirements['install_stamp'] = array(
+    'title' => $t('Installation time'),
+    'value' => $timestamp,
+    'severity' => $timestamp_severity,
+    'weight' => -5,
+  );
+
   return $requirements;
 }
 

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.strongarm.inc
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.strongarm.inc
@@ -358,15 +358,6 @@ example.org';
 
   $strongarm->disabled = FALSE;
   $strongarm->api_version = 1;
-  $strongarm->name = 'multisite_version';
-  $strongarm->value = '2.3';
-  $export['multisite_version'] = $strongarm;
-
-  $strongarm = new stdClass();
-  /* Edit this to true to make a default strongarm disabled initially */
-
-  $strongarm->disabled = FALSE;
-  $strongarm->api_version = 1;
   $strongarm->name = 'node_admin_theme';
   $strongarm->value = '0';
   $export['node_admin_theme'] = $strongarm;

--- a/tests/features/status_page.feature
+++ b/tests/features/status_page.feature
@@ -22,14 +22,21 @@ Scenario: Show git informations in report
   I need to be able to see the git branch and latest commit message
 
   Given I am logged in as an administrator
-  Given a file named "continuousphp.package" with:
+  Given a file named ".commit" with:
     """
-      {"build_id":"1439fb37-6ba2-44f1-9a04-0db661589364","ref":"refs\/tags\/2.1.39","commit":"a6e6719f52250422dbe8e80e39494199d97754c0"}
+      cacf5a1ae174810f50575478206055bd5668e058
+    """
+  Given a file named ".version" with:
+    """
+     2.1.39
     """
   When I visit "admin/reports/status"
-  Then I should see "Git ref" in the "nept_element:system-status-report" element
-  Then I should see "refs/tags/2.1.39" in the "nept_element:system-status-report" element
+  Then I should see "Platform Tag" in the "nept_element:system-status-report" element
+  Then I should see "2.1.39" in the "nept_element:system-status-report" element
+  # Test the absence of the file file with the installtion date
+  Then I should see "Installation time" in the "nept_element:system-status-report" element
+  Then I should see "Information not available on the server." in the "nept_element:system-status-report" element
   # Test that the commit is shown and links to Github.
-  And I should see "Git commit" in the "nept_element:system-status-report" element
-  When I click 'a6e6719f52250422dbe8e80e39494199d97754c0'
-  Then I should see the text "NEXTEUROPA-6056"
+  Then I should see "Commit number" in the "nept_element:system-status-report" element
+  When I click 'cacf5a1ae174810f50575478206055bd5668e058'
+  Then I should see the text "NEPT-1615"


### PR DESCRIPTION
## NEPT-2065, NEPT-2076 

### Description

-  NEPT-2065: Fix the display of version tag and commit id. Add the timestamp information.
- NEPT-2076: Add the ability to use the mailto, tel protocols within anchor href attributes.

### Change log

- Added: Timestamp information in the status report in the UI.
- Changed: 
   - Point the Tag and Commit information to the files generated by fpfis-scheduler during the deployment process.
   - Sanitise HTML filter, to allow the mailto, and tel protocols. These are allowed by default in core.
- Deprecated: variable multisite_version will be uninstalled from 2.6
- Removed: variable multisite_version is still present but no longer displayed in UI
- Security:

### Commands

Not applicable.

