### PR TITLE
NEPT-1995: CLONE - INFO - URL with brackets gets incorrectly linked

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -52,12 +52,12 @@ projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal_add_js_sa
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-doc-theme-attributes-d7-569362-53.patch
 
 ; Fix empty label on validation error message for multiple required textfield.
-; https://www.drupal.org/node/980144#comment-11695545 
+; https://www.drupal.org/node/980144#comment-11695545
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-224
 projects[drupal][patch][] = https://www.drupal.org/files/issues/980144-98_0.patch
 
 ; Reverting to revisions prior to addition of field translations is broken.
-; https://www.drupal.org/node/1992010 
+; https://www.drupal.org/node/1992010
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-495
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-revision-revert-messes-up-field-translation-1992010-31_D7.patch
 
@@ -79,3 +79,8 @@ projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-no_protoc
 ; Set the session's cookie lifetime to 0 so that cookies are deleted when the browser is closed.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-900
 projects[drupal][patch][] = patches/set-session-cookie-lifetime-0.patch
+
+; Allow urls with ( and ) https://www.drupal.org/files/issues/filter-urlfilter-i18n-1657886-39.patch.
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1995
+; See https://www.drupal.org/project/drupal/issues/1657886.
+projects[drupal][patch][] = https://www.drupal.org/files/issues/2018-09-28/filter-urlfilter-i18n-1657886-40.patch

--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -83,4 +83,4 @@ projects[drupal][patch][] = patches/set-session-cookie-lifetime-0.patch
 ; Filter "Convert URLs into links" doesn't support multilingual web addresses.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1995
 ; See https://www.drupal.org/project/drupal/issues/1657886.
-projects[drupal][patch][] = https://www.drupal.org/files/issues/2018-09-28/filter-urlfilter-i18n-1657886-40.patch
+projects[drupal][patch][] = https://www.drupal.org/files/issues/2018-09-28/filter-urlfilter-i18n-1657886-41.patch

--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -80,7 +80,7 @@ projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-no_protoc
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-900
 projects[drupal][patch][] = patches/set-session-cookie-lifetime-0.patch
 
-; Allow urls with ( and ) https://www.drupal.org/files/issues/filter-urlfilter-i18n-1657886-39.patch.
+; Filter "Convert URLs into links" doesn't support multilingual web addresses.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1995
 ; See https://www.drupal.org/project/drupal/issues/1657886.
 projects[drupal][patch][] = https://www.drupal.org/files/issues/2018-09-28/filter-urlfilter-i18n-1657886-40.patch


### PR DESCRIPTION
## NEPT-1995

### Description

Implement in the _filter_url() function, urt pattern search with unicode and a fallback to hexadecimal values in there is no unicode support

### Change log

- Added: patch https://www.drupal.org/files/issues/2018-09-28/filter-urlfilter-i18n-1657886-40.patch
