### PR TITLE
NEPT-2074: Set language url_suffix as default behaviour while updating to 2.5

### DIFF
--- a/profiles/common/modules/features/multisite_settings/multisite_settings_core/multisite_settings_core.install
+++ b/profiles/common/modules/features/multisite_settings/multisite_settings_core/multisite_settings_core.install
@@ -94,4 +94,9 @@ function multisite_settings_core_update_7124() {
     return t('nexteuropa_admin_language is not enabled because "admin_language" already is.');
   }
   module_enable(array('nexteuropa_admin_language'));
+  // NEPT-2074: Ensure the language negotiations methods required with the
+  // administration language negotiation are correctly set.
+  multisite_config_service('locale')->addLanguageNegotiation('language-administration');
+  multisite_config_service('locale')->addLanguageNegotiation('nexteuropa_multilingual_url_suffix');
+  multisite_config_service('locale')->addLanguageNegotiation('nexteuropa_multilingual_url_suffix', -8, LANGUAGE_TYPE_CONTENT);
 }


### PR DESCRIPTION
## NEPT-2074

### Description

The language configuration should be set for language url_suffix by default, however, this is not the case on 2.3 so while updating to 2.5 the config is not set as expected.

### Change log
- Fixed:
  To fix the issue a sniped code has been added to the update hook, which will fix the issue when any subsite update to 2.5.

### Commands

N/A
