### PR TITLE
NEPT-1995, NEPT-1198: Merge from 2.5 into 2.6

### DIFF
--- a/profiles/common/modules/features/ec_embedded_video/ec_embedded_video.module
+++ b/profiles/common/modules/features/ec_embedded_video/ec_embedded_video.module
@@ -91,13 +91,6 @@ function _ec_embedded_video_preprocess_media_vimeo_video(&$variables) {
  * Preprocess function for media_avportal_video.
  */
 function _ec_embedded_video_preprocess_media_avportal_video(&$variables) {
-  $query = array(
-    'ref' => $variables['video_id'],
-    'starttime' => 0,
-    'endtime' => 0,
-  );
-  $variables['url'] = url('//ec.europa.eu/avservices/play.cfm', array('query' => $query, 'external' => TRUE));
-
   // Don't use cookie compliant for avportal video.
   $variables['ec_embedded_video_url'] = $variables['url'];
 }

--- a/profiles/common/modules/features/ec_embedded_video/themes/media-avportal-video.tpl.php
+++ b/profiles/common/modules/features/ec_embedded_video/themes/media-avportal-video.tpl.php
@@ -2,24 +2,15 @@
 
 /**
  * @file
- * Media_avportal/includes/themes/media-avportal-video.tpl.php.
- *
  * Template file for theme('media_avportal_video').
  *
  * Variables available:
- *  $uri - The media uri for the YouTube video (e.g., avportal://v/xsy7x8c9).
+ *  $uri - The media uri for the AV portal video (e.g., avportal://v/xsy7x8c9).
  *  $video_id - The unique identifier of the YouTube video (e.g., xsy7x8c9).
- *  $id - The file entity ID (fid).
  *  $url - The full url including query options for the Youtube iframe.
- *  $options - An array containing the Media Youtube formatter options.
- *  $api_id_attribute - An id attribute if the Javascript API is enabled;
- *  otherwise NULL.
- *  $width - The width value set in Media: Youtube file display options.
- *  $height - The height value set in Media: Youtube file display options.
- *  $title - The Media: YouTube file's title.
- *  $alternative_content - Text to display for browsers that don't support
- *  iframes.
- *  $no_wrapper - If TRUE, video's wrappers are not displayed.
+ *  $options - An array containing the Media AV portal formatter options.
+ *  $width - The width value set in Media: AV portal file display options.
+ *  $height - The height value set in Media: AV portal file display options.
  */
 ?>
 <iframe 
@@ -28,9 +19,3 @@
     id="videoplayer<?php print $video_id; ?>" scrolling="no" 
     src="<?php print $ec_embedded_video_url ?>">
 </iframe>
-
-<?php if(!empty($language_switcher)) : ?>
-<div class="language-switcher">
-<?php print $language_switcher; ?>
-</div>
-<?php endif; ?>

--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -52,12 +52,12 @@ projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal_add_js_sa
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-doc-theme-attributes-d7-569362-53.patch
 
 ; Fix empty label on validation error message for multiple required textfield.
-; https://www.drupal.org/node/980144#comment-11695545 
+; https://www.drupal.org/node/980144#comment-11695545
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-224
 projects[drupal][patch][] = https://www.drupal.org/files/issues/980144-98_0.patch
 
 ; Reverting to revisions prior to addition of field translations is broken.
-; https://www.drupal.org/node/1992010 
+; https://www.drupal.org/node/1992010
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-495
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-revision-revert-messes-up-field-translation-1992010-31_D7.patch
 
@@ -79,3 +79,8 @@ projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-no_protoc
 ; Set the session's cookie lifetime to 0 so that cookies are deleted when the browser is closed.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-900
 projects[drupal][patch][] = patches/set-session-cookie-lifetime-0.patch
+
+; Filter "Convert URLs into links" doesn't support multilingual web addresses.
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1995
+; See https://www.drupal.org/project/drupal/issues/1657886.
+projects[drupal][patch][] = https://www.drupal.org/files/issues/2018-09-28/filter-urlfilter-i18n-1657886-41.patch

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -452,7 +452,7 @@ projects[media][version] = 2.19
 projects[media][patch][] = https://www.drupal.org/files/issues/media-delete-embedded-document-2028231-11.patch
 
 projects[media_avportal][subdir] = "contrib"
-projects[media_avportal][version] = "1.2"
+projects[media_avportal][version] = "1.3"
 
 projects[media_dailymotion][subdir] = "contrib"
 projects[media_dailymotion][version] = "1.1"


### PR DESCRIPTION
## NEPT-1995, NEPT-1198

### Description

- NEPT-1995: Implement in the _filter_url() function, urt pattern search with unicode and a fallback to hexadecimal values in there is no unicode support.
- NEPT-1198: Upgrade the media_avportal module to 1.3 in order to take the new service into account.


### Change log

- Added: patch https://www.drupal.org/files/issues/2018-09-28/filter-urlfilter-i18n-1657886-41.patch
- Changed: resources/multisite_drupal_standard.make, upgrade media_avportal to 1.3

### Commands

drush cc all

