### PR TITLE
NEPT-2082: Fix fatal error during the cron execution on xmlsitemap_node.module

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -880,6 +880,12 @@ projects[xmlsitemap][version] = "2.4"
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-11505
 projects[xmlsitemap][patch][] = https://www.drupal.org/files/issues/xmlsitemap-using_rel_alternate-1670086-50.patch
 projects[xmlsitemap][patch][] = patches/xmlsitemap-using_rel_alternate-nexteuropa_multilingual_url_suffix.patch
+; TypeError: Argument 1 passed to xmlsitemap_node_create_link() must be an instance of stdClass, boolean given.
+; The issue contain 2 patches but only one is applicable for the version 2.4.
+; The second will be necessary with 2.5.
+; https://www.drupal.org/project/xmlsitemap/issues/2986847
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2082
+projects[xmlsitemap][patch][] = https://www.drupal.org/files/issues/2018-07-19/xmlsitemap-2986847-2.patch
 
 
 ; =========


### PR DESCRIPTION
## NEPT-2082

### Description

Fix the fatal error 

Argument 1 passed to xmlsitemap_node_create_link() must be an instance of stdClass, boolean given, called in .../xmlsitemap/xmlsitemap_node/xmlsitemap_node.module
on line 28 and defined xmlsitemap_node.module:194

### Change log

- Changed: resources/multisite_drupal_standard.make, add xmlsitemap-2986847-2.patch reference

### Commands

No command to execute