### PR TITLE
NEPT-2093: Upgrade print to 2.2

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -600,7 +600,7 @@ projects[plupload][download][type] = git
 projects[plupload][patch][] = https://www.drupal.org/files/issues/2018-05-22/files_not_uploaded_in_subdir-2974466.patch
 
 projects[print][subdir] = "contrib"
-projects[print][version] = "2.0"
+projects[print][version] = "2.1"
 
 projects[quicktabs][subdir] = "contrib"
 projects[quicktabs][version] = "3.8"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -600,7 +600,7 @@ projects[plupload][download][type] = git
 projects[plupload][patch][] = https://www.drupal.org/files/issues/2018-05-22/files_not_uploaded_in_subdir-2974466.patch
 
 projects[print][subdir] = "contrib"
-projects[print][version] = "2.1"
+projects[print][version] = "2.2"
 
 projects[quicktabs][subdir] = "contrib"
 projects[quicktabs][version] = "3.8"


### PR DESCRIPTION
## NEPT-2093

### Description

Upgrade print to 2.2.

### Change log

- Changed: resources/multisite_drupal_standard.make to upgrade the print module version.

### Commands

drush cc all

