### PR TITLE
NEPT-2093: Upgrade print to 2.2

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -576,7 +576,7 @@ projects[plupload][download][revision] = bba974c6f3224346a1acae4181a700b55129e6e
 projects[plupload][download][type] = git
 
 projects[print][subdir] = "contrib"
-projects[print][version] = "2.0"
+projects[print][version] = "2.2"
 
 projects[quicktabs][subdir] = "contrib"
 projects[quicktabs][version] = "3.6"


### PR DESCRIPTION
## NEPT-2093

### Description

Upgrade print to 2.2.

### Change log

- Changed: resources/multisite_drupal_standard.make to upgrade the print module version.

### Commands

drush cc all