### PR TITLE
NEPT-2098: Update Advagg version 2.30 to 2.33

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -18,7 +18,7 @@ projects[administration_language_negotiation][subdir] = "contrib"
 projects[administration_language_negotiation][version] = "1.4"
 
 projects[advagg][subdir] = "contrib"
-projects[advagg][version] = "2.30"
+projects[advagg][version] = "2.33"
 
 projects[advanced_help][subdir] = "contrib"
 projects[advanced_help][version] = "1.3"


### PR DESCRIPTION
## NEPT-2098

### Description

Update Advagg version 2.30 to 2.33

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

[Insert commands here]

