### PR TITLE
NEPT-2101: Fix entity translation to support translatable fields use with a content translation content type

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -223,6 +223,13 @@ projects[entity_translation][patch][] = https://www.drupal.org/files/issues/enti
 projects[entity_translation][patch][] = https://www.drupal.org/files/issues/entity_translation-pathauto_update-2743685-2_0.patch
 ; https://www.drupal.org/node/2877074
 projects[entity_translation][patch][] = https://www.drupal.org/files/issues/entity_translation-fix_content_translation_test-2877074-4.patch
+; Refactor the entity_translation_language() callback to make it bundle-specific.
+; The bug only Exists in platform 2.4, The patch does not applied as is. So, we
+; produce a local one without the module tests update.
+; https://www.drupal.org/node/2877074
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2101
+projects[entity_translation][patch][] = patches/et-bundle_language_with_test-2877074-nept-2101.patch
+
 
 projects[entitycache][subdir] = "contrib"
 projects[entitycache][version] = 1.2

--- a/resources/patches/et-bundle_language_with_test-2877074-nept-2101.patch
+++ b/resources/patches/et-bundle_language_with_test-2877074-nept-2101.patch
@@ -1,0 +1,29 @@
+--- entity_translation.module	2018-10-11 11:27:00.560619510 +0200
++++ entity_translation.module	2018-10-11 115:27:12.560619510 +0200
+@@ -1841,9 +1841,14 @@
+   if (empty($handler)) {
+     return LANGUAGE_NONE;
+   }
++  if (entity_translation_enabled($entity_type, $entity)) {
+-  $langcode = $handler->getActiveLanguage();
++    $langcode = $handler->getActiveLanguage();
+-  return !empty($langcode) ? $langcode : $handler->getLanguage();
++    return $langcode ? $langcode : $handler->getLanguage();
+-}
++  }
++  else {
++    return $handler->getLanguage();
++  }
++}
+ 
+ /**
+  * Translation handler factory.
+@@ -1867,6 +1872,8 @@
+     $entity_info = entity_get_info($entity_type);
+     return new EntityTranslationDefaultHandler($entity_type, $entity_info, $entity);
+   }
++
++  return NULL;
+ }
+ 
+ /**


### PR DESCRIPTION
## NEPT-2101

### Description

Content types using translatable fields with content translation meet problem with the field language that do not correspond always with the content language.
The problem was located in Entity translation.

The fix patch included in this release is specific to the version 2.4 of the NE platform and the module version, as it is not present in the version 2.5 of the NE platform.

### Change log

- Added: patches/et-bundle_language_with_test-2877074-nept-2101.patch
- Changed: resources/multisite_drupal_standard.make to include the local patch.

### Commands

drush cc all

