### PR TITLE
NEPT-2106: Update Drupal Core to 7.60

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = "core"
-projects[drupal][version] = "7.59"
+projects[drupal][version] = "7.60"
 
 ; AJAX callbacks not properly working with the language url suffix.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-4268


### PR DESCRIPTION
## NEPT-2106

### Description

Update Drupal Core to 7.60.

### Change log

- Security: Updated Drupal Core to 7.60.

### Commands

No command.