### PR TITLE
NEPT-794: Customizable message in workbench moderation is broken (#2209)

### DIFF
--- a/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.module
+++ b/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.module
@@ -371,6 +371,8 @@ function _nexteuropa_multilingual_warning_message(&$form, $node) {
   $warning_message_languages = variable_get('nexteuropa_multilingual_warning_message_languages');
   if (!empty($warning_message_languages)) {
     $message = token_replace($warning_message_languages, array('node' => $node));
+    $allow_tags = array('a', 'em', 'strong', 'cite', 'code', 'b', 'i', 'span');
+    $message = filter_xss($message, $allow_tags);
     $variables = array(
       'message' => $message,
       'message_attributes' => array('id' => 'nexteuropa-multilingual-warning-message-languages'),

--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = "core"
-projects[drupal][version] = "7.59"
+projects[drupal][version] = "7.60"
 
 ; AJAX callbacks not properly working with the language url suffix.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-4268


### PR DESCRIPTION

## NEPT-794
### Description

* NEPT-794: Remove unwanted html tags in nexteuropa multilingual warning message.

* NEPT-794: Add filter_xss.

* NEPT-794: Add array allow_tags.


### Change log

- Changed: profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.module

### Commands

No commands needed
