### PR TITLE
NEPT-2111: Remove timezone override on mpdf library

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1052,6 +1052,14 @@ libraries[mpdf][download][request_type]= "get"
 libraries[mpdf][download][file_type] = "zip"
 libraries[mpdf][download][url] = https://github.com/mpdf/mpdf/archive/v6.1.4.zip
 libraries[mpdf][destination] = "libraries"
+; The Drupal timezone is overridden by the mpdf one.
+; As the version 6.1 is frozen, the patch has not been accepted.
+; That is why it is a "local" patch.
+; Nevertheless, the fix has been introduced in mpdf 7+.
+; So, it will be removed when the library will be upgraded in version
+; 2.6 of the platform.
+; https://github.com/mpdf/mpdf/pull/892
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2111
 libraries[mpdf][patch][] = patches/mpdf_timezone.patch
 
 ; Leaflet

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -306,7 +306,7 @@ projects[field_group][version] = "1.6"
 ; https://www.drupal.org/node/2604284
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-6603
 projects[field_group][patch][] = https://www.drupal.org/files/issues/field_group_label_translation_patch.patch
-; After update from 1.5 to 1.6 empty field groups (because of field permissions) 
+; After update from 1.5 to 1.6 empty field groups (because of field permissions)
 ; are now being displayed as empty groups
 ; https://www.drupal.org/node/2926605
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2016
@@ -1052,6 +1052,7 @@ libraries[mpdf][download][request_type]= "get"
 libraries[mpdf][download][file_type] = "zip"
 libraries[mpdf][download][url] = https://github.com/mpdf/mpdf/archive/v6.1.4.zip
 libraries[mpdf][destination] = "libraries"
+libraries[mpdf][patch][] = patches/mpdf_timezone.patch
 
 ; Leaflet
 libraries[leaflet][destination] = "libraries"

--- a/resources/patches/mpdf_timezone.patch
+++ b/resources/patches/mpdf_timezone.patch
@@ -1,0 +1,16 @@
+diff --git a/mpdf.php b/mpdf.php
+index aebeefb..caf1c84 100755
+--- a/mpdf.php
++++ b/mpdf.php
+@@ -90,11 +90,6 @@ $errorlevel = error_reporting($errorlevel & ~E_NOTICE);
+ 
+ //error_reporting(E_ALL);
+ 
+-if (function_exists("date_default_timezone_set")) {
+-	if (ini_get("date.timezone") == "") {
+-		date_default_timezone_set("Europe/London");
+-	}
+-}
+ 
+ if (!function_exists('mb_strlen')) {
+ 	throw new MpdfException('mPDF requires mb_string functions. Ensure that mb_string extension is loaded.');


### PR DESCRIPTION
## NEPT-2111

### Description
 The library mpdf has a bug that overrides the platform timezone, as the version 6 of mpdf is fronzen, we created a local patch to remove the override.


### Change log

- Added: patch resources/patches/mpdf_timezone.patch



