### PR TITLE
Feature: Update existing users with the same email

### DIFF
--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -397,6 +397,13 @@ function ecas_login_check() {
       // @codingStandardsIgnoreEnd
       // Try to log into Drupal.
       $account = user_load_by_name($ecas_name);
+      
+      if (!$account) {
+        // Try to load user by mail
+        $account = user_load_by_mail($ecas_email);
+
+        $account = ecas_upgrade_existing_user($account, $ecas_name);
+      }
 
       // Extra process to filter ECAS user.
       drupal_alter('ecas_extra_filter', $ecas_name, $account, $_SESSION['ecas_goto']);
@@ -729,6 +736,39 @@ function ecas_create_user($ecas_name, $defaults = array()) {
   if ($account) {
     $account = user_load_by_name($account->name);
   }
+
+  return $account;
+}
+
+/**
+ * Updates an existing username with the ECAS name
+ * and registers the user that has ECAS authentication (authmap table).
+ *
+ * @param array $account
+ *    The user account
+ * @param string $ecas_name
+ *    The ECAS name of the user.
+ *
+ * @return FALSE|\stdClass
+ *    The updated user object or FALSE if the user could not be loaded.
+ *
+ * @see ecas_login_check().
+ */
+function ecas_upgrade_existing_user($account, $ecas_name) {
+  if (!$account) {
+    return FALSE;
+  }
+
+  $account->name = $ecas_name;
+  user_save($account);
+
+  db_insert('authmap')
+    ->fields(array(
+      'authname' => $ecas_name,
+      'uid' => $account->uid,
+      'module' => 'ecas',
+    ))
+    ->execute();
 
   return $account;
 }


### PR DESCRIPTION
### Description

Consider the following use case scenario:
A user has registered on the drupal website (not via ecas)
At some point, the user attempts to use the the EU login and enters the same email with the one that is registered on drupal.
Once authenticated, a new account will be created for the user instead of syncing the info with the existing one (assuming that drupal and ecas usernames are different).
That is happening because in the _ecas_login_check()_ function, users are loaded by their username. 
I suggest that in case _user_load_by_name()_ fails, we try loading the user by mail and if that succeeds, register the user to the authmap table and update the username.

### Change log
Changed _profiles/common/modules/custom/ecas/includes/ecas.inc_ in order to provide a solution for the above use case scenario
