### PR TITLE
NEPT-2092: Target build-platform-dev seems to not clean properly the contrib folder inside the profile

### DIFF
--- a/build.package.xml
+++ b/build.package.xml
@@ -19,6 +19,8 @@
 
         <echo msg="Delete previous build." />
         <delete dir="${phing.project.build.dir}" includeemptydirs="true" failonerror="false" />
+        <echo msg="Delete previous contrib folder. profiles/${platform.profile.name}/modules/contrib" />
+        <delete dir="profiles/${platform.profile.name}/modules/contrib" includeemptydirs="true" failonerror="false" />
     </target>
 
     <!-- Make Drupal core. -->

--- a/build.package.xml
+++ b/build.package.xml
@@ -19,8 +19,18 @@
 
         <echo msg="Delete previous build." />
         <delete dir="${phing.project.build.dir}" includeemptydirs="true" failonerror="false" />
-        <echo msg="Delete previous contrib folder. profiles/${platform.profile.name}/modules/contrib" />
-        <delete dir="profiles/${platform.profile.name}/modules/contrib" includeemptydirs="true" failonerror="false" />
+
+        <echo msg="Delete profiles/multisite_drupal_standard/modules/contrib folder." />
+        <delete dir="profiles/multisite_drupal_standard/modules/contrib" includeemptydirs="true" failonerror="false" />
+
+        <echo msg="Delete profiles/multisite_drupal_communities/modules/contrib folder." />
+        <delete dir="profiles/multisite_drupal_communities/modules/contrib" includeemptydirs="true" failonerror="false" />
+
+        <echo msg="Delete profiles/multisite_drupal_standard/themes folder." />
+        <delete dir="profiles/multisite_drupal_standard/themes" includeemptydirs="true" failonerror="false" />
+
+        <echo msg="Delete profiles/multisite_drupal_communities/themes folder." />
+        <delete dir="profiles/multisite_drupal_communities/themes" includeemptydirs="true" failonerror="false" />
     </target>
 
     <!-- Make Drupal core. -->


### PR DESCRIPTION
## NEPT-2092

### Description

Delete contrib module folder from profiles when building the platform

### Change log

- Added: phing command to delete modules/contrib module

### Commands

Build platform ./bin/phing build-platform-dev

