### PR TITLE
NEPT-1542: Add the possibility to remove only Varnish cache (w/o cc all)

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.admin.inc
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.admin.inc
@@ -17,16 +17,24 @@ function nexteuropa_varnish_admin_settings_form($form, $form_state) {
   $form['purge_cache'] = array(
     '#type' => 'fieldset',
     '#title' => t('Purge caches'),
-    '#description' => t('Flush all caches (Drupal & Varnish)'),
+    '#description' => t('The operation will clear Varnish cache.
+    Click the checkbox to also clear Drupal cache.'),
   );
 
   // If the purge mechanism is prevented to work, then the button must be
   // disabled and a warning message must be displayed.
   $disabled = _nexteuropa_varnish_temporary_message();
 
+  $form['purge_cache']['purge_drupal'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Clear drupal cache as well'),
+    '#return_value' => 1,
+    '#default_value' => 0,
+  );
+
   $form['purge_cache']['purge'] = array(
     '#type' => 'submit',
-    '#value' => t('Purge all caches'),
+    '#value' => t('Purge caches'),
     '#submit' => array('nexteuropa_varnish_purge_all_confirm'),
     '#disabled' => $disabled,
   );
@@ -46,7 +54,6 @@ function nexteuropa_varnish_admin_settings_form($form, $form_state) {
   );
 
   $form['#submit'][] = 'nexteuropa_varnish_admin_settings_cache_clear_submit';
-
   return system_settings_form($form);
 }
 
@@ -63,15 +70,21 @@ function nexteuropa_varnish_admin_settings_cache_clear_submit($form, &$form_stat
  * Redirect the user from "General" page to the "purge all" confirmation form.
  */
 function nexteuropa_varnish_purge_all_confirm($form, &$form_state) {
-  $form_state['redirect'] = 'admin/config/system/nexteuropa-varnish/purge_all';
+  if ($form_state['values']['purge_drupal']) {
+    $form_state['redirect'] = 'admin/config/system/nexteuropa-varnish/purge/all';
+  }
+  else {
+    $form_state['redirect'] = 'admin/config/system/nexteuropa-varnish/purge/varnish';;
+  }
 }
 
 /**
  * Generates the form allowing triggering the full cache purge.
  */
-function nexteuropa_varnish_purge_all_form($form, &$form_state) {
+function nexteuropa_varnish_purge_all_form($form, &$form_state, $arg) {
   $description = t("The action you are about to perform has a deep impact on the site's performance!");
-  $confirm_message = t("Are you sure you want to purge all site's caches (Varnish included)?");
+  $arg == 'all' ? $type = "Varnish and Drupal" : $type = "Varnish";
+  $confirm_message = t("Are you sure you want to purge !type cache ?", array('!type' => $type));
   return confirm_form($form,
     $confirm_message,
     'admin/config/system/nexteuropa-varnish/general',
@@ -82,17 +95,21 @@ function nexteuropa_varnish_purge_all_form($form, &$form_state) {
 }
 
 /**
- * Processes the full flush cache triggered by the "Purge all caches" button.
+ * Processes the flush cache triggered by the "Purge caches" button.
  *
  * @see nexteuropa_varnish_admin_settings_form()
  */
 function nexteuropa_varnish_purge_all_form_submit($form, &$form_state) {
-  $confirm_message = t('The Drupal and Varnish caches have been fully flushed.');
+  $arg = $form_state['build_info']['args'][0];
+  $arg == 'all' ? $type = "Drupal and Varnish" : $type = "Varnish";
+  $confirm_message = t('The !type caches have been fully flushed.', array('type' => $type));
   $message_level = 'status';
   // First clear the actual backend cache (usually DrupalDatabaseCache).
   // Otherwise the web frontend cache will receive again outdated cached
   // versions of pages.
-  drupal_flush_all_caches();
+  if ($arg == 'all') {
+    drupal_flush_all_caches();
+  }
 
   // Treating Varnish flushing (inspired by "flexibe_purge" contrib module).
   $send_success = _nexteuropa_varnish_varnish_requests_send();

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.admin.inc
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.admin.inc
@@ -74,7 +74,7 @@ function nexteuropa_varnish_purge_all_confirm($form, &$form_state) {
     $form_state['redirect'] = 'admin/config/system/nexteuropa-varnish/purge/all';
   }
   else {
-    $form_state['redirect'] = 'admin/config/system/nexteuropa-varnish/purge/varnish';;
+    $form_state['redirect'] = 'admin/config/system/nexteuropa-varnish/purge/varnish';
   }
 }
 

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -24,11 +24,11 @@ function nexteuropa_varnish_menu() {
     'file' => 'nexteuropa_varnish.admin.inc',
   );
 
-  $items['admin/config/system/nexteuropa-varnish/purge_all'] = array(
+  $items['admin/config/system/nexteuropa-varnish/purge/%'] = array(
     'title' => 'Next Europa Varnish - Purge confirmation',
-    'description' => 'Confirmation form for the varnish purge flush.',
+    'description' => 'Confirmation form for Drupal and Varnish purge.',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('nexteuropa_varnish_purge_all_form'),
+    'page arguments' => array('nexteuropa_varnish_purge_all_form', 5),
     'access callback' => '_nexteuropa_varnish_purge_all_access',
     'file' => 'nexteuropa_varnish.admin.inc',
     'type' => MENU_CALLBACK,


### PR DESCRIPTION
## NEPT-1542

### Description

Add the possibility to remove only Varnish cache 

### Change log

- Changed: Varnish menu items, to launch only drupal cache clear when checkbox is ticked

### Commands

`drush cc all`

