### PR TITLE
NEPT-1820: Add drush command to allow devops to flush cache

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.drush.inc
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.drush.inc
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Varnish drush commands.
+ */
+
+/**
+ * Drush commands.
+ */
+function nexteuropa_varnish_drush_command() {
+  $items = array();
+
+  $items['varnish_flush_cache'] = array(
+    'description' => "Varnish clear cache.",
+    'examples' => array(
+      'drush varnish-flush-cache' => 'Varnish clear cache.',
+    ),
+    'aliases' => array('vcc'),
+  );
+
+  return $items;
+}
+
+/**
+ * Varnish clear cache.
+ */
+function drush_nexteuropa_varnish_varnish_flush_cache() {
+  _nexteuropa_varnish_varnish_requests_send();
+}


### PR DESCRIPTION
## NEPT-1820

### Description

Add drush command to allow devops to flush cache

### Change log

- Added: profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.drush.inc

### Commands

drush cc drush

