### PR TITLE
NEPT-1730: PHP version dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 * Composer
 * PHP Phar extension
 * PhantomJS (in order to run JavaScript during Behat tests)
+* PHP 5.6 or higher
 
 ## Install build system
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "php": ">=5.4.0",
+    "php": ">=5.6",
     "drupal/phingdrushtask": "^1.1",
     "drupol/phingbehattask": "^1.0",
     "drush/drush": "8.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "43838fd3aa20b57a57c0f61ffacfd05d",
+    "content-hash": "28aee05baea87dfe25a5f1da8db06211",
     "packages": [
         {
             "name": "cpliakas/git-wrapper",
@@ -99,7 +99,7 @@
             "version": "8.2.12",
             "source": {
                 "type": "git",
-                "url": "https://github.com/klausi/coder.git",
+                "url": "https://git.drupal.org/project/coder.git",
                 "reference": "984c54a7b1e8f27ff1c32348df69712afd86b17f"
             },
             "dist": {
@@ -793,7 +793,7 @@
                 }
             ],
             "description": "VersionControl_Git is a library that provides OO interface to handle Git repository.",
-            "time": "2017-08-23 19:37:51"
+            "time": "2017-08-23T19:37:51+00:00"
         },
         {
             "name": "pfrenssen/phpcs-pre-push",
@@ -1620,7 +1620,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4.0",
+        "php": ">=5.6",
         "ext-json": "*",
         "ext-phar": "*",
         "ext-xml": "*"

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.info
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.info
@@ -2,10 +2,13 @@ name = Multisite WYSIWYG
 description = Alters wysiwyg settings for CKEditor.
 core = 7.x
 package = Multisite Core Features
+php = 5.6
+
 dependencies[] = cce_basic_config
 dependencies[] = features
 dependencies[] = media_internet
 dependencies[] = wysiwyg
 dependencies[] = media
 dependencies[] = media_wysiwyg
+
 features[features_api][] = api:2

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.info
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.info
@@ -2,6 +2,8 @@ name = NextEuropa Core
 description = NextEuropa Core feature.
 core = 7.x
 package = NextEuropa
+php = 5.6
+
 dependencies[] = autologout
 dependencies[] = bean
 dependencies[] = bean_admin_ui

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/tmgmt_poetry_mock.info
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/tmgmt_poetry_mock.info
@@ -2,6 +2,7 @@ name = TMGMT Poetry Mock
 description = Provides a mock of the Poetry API
 package = TMGT Poetry
 core = 7.x
+php = 5.6
 hidden = TRUE
 
 dependencies[] = tmgmt_poetry


### PR DESCRIPTION
## NEPT-1730

### Description

Ensure the specification of a requirement of PHP 5.6 or above.

### Change log

- Changed: Modules that contained the 'use function' function importing technique to directly require a minimum of php 5.6. Update the Readme and composer requirements.

### Commands

Not applicable.

