### PR TITLE
NEPT-655:  Update from 1.5 to 1.7 and apply a closed patch.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -231,8 +231,10 @@ projects[entityreference][version] = "1.5"
 projects[entityreference][patch][] = https://www.drupal.org/files/issues/feature--entityreference-alter-items.patch
 
 projects[entityreference_prepopulate][subdir] = "contrib"
-projects[entityreference_prepopulate][version] = "1.5"
-projects[entityreference_prepopulate][patch][] = patches/entityreference_prepopulate-ajax-prepopulation-1958800-1.5.patch
+projects[entityreference_prepopulate][version] = "1.7"
+; Allow friendly field identifiers in URL.
+; https://www.drupal.org/project/entityreference_prepopulate/issues/1809776
+projects[entityreference_prepopulate][patch][] = https://www.drupal.org/files/issues/entityreference_prepopulate-1809776-5-test-only.patch
 
 projects[eu_cookie_compliance][subdir] = "contrib"
 projects[eu_cookie_compliance][version] = "1.14"


### PR DESCRIPTION
## NEPT-655

### Description

Upgrade module entityreference_prepopulate to latest version 7.x-1.7
This pr is the same as this (https://github.com/ec-europa/platform-dev/pull/2263) after changing the name from NEPT-655-2.5 to nept-655-2.5

### Change log
- Changed:
   Update version to 1.7

