### PR TITLE
NEPT-664: Remove fpa from platform

### DIFF
--- a/profiles/multisite_drupal_communities/multisite_drupal_communities.info
+++ b/profiles/multisite_drupal_communities/multisite_drupal_communities.info
@@ -34,7 +34,6 @@ dependencies[] = file
 dependencies[] = file_entity
 dependencies[] = filefield_sources_plupload
 dependencies[] = flag
-dependencies[] = fpa
 dependencies[] = help
 dependencies[] = i18n
 dependencies[] = i18n_field

--- a/profiles/multisite_drupal_standard/multisite_drupal_standard.info
+++ b/profiles/multisite_drupal_standard/multisite_drupal_standard.info
@@ -86,7 +86,6 @@ dependencies[] = admin_menu
 dependencies[] = tagclouds
 dependencies[] = link
 dependencies[] = transliteration
-dependencies[] = fpa
 dependencies[] = flag
 dependencies[] = entityreference_prepopulate
 dependencies[] = username_enumeration_prevention

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -345,8 +345,6 @@ projects[flexslider_views_slideshow][download][revision] = "0b1f8e7e24c168d1820c
 projects[flexslider_views_slideshow][download][type] = "git"
 projects[flexslider_views_slideshow][download][url] = http://git.drupal.org/project/flexslider_views_slideshow.git
 projects[flexslider_views_slideshow][subdir] = "contrib"
-projects[fpa][subdir] = "contrib"
-projects[fpa][version] = "2.6"
 
 projects[freepager][download][revision] = "c11c40f6e3e54ff728515589600a0d8e26d831f1"
 projects[freepager][download][type] = "git"


### PR DESCRIPTION
## NEPT-664

### Description

Remove fpa from platform. The module should not be used on production since all permissions should be exported.

### Change log

- Changed: multisite_drupal_communities.info, multisite_drupal_standard.info, multisite_drupal_standard.make

### Commands

No commands

