### PR TITLE
NEPT-2138: Move multisite_mediagallery_community hook_views_pre_render code to appropriate views handlers

### DIFF
--- a/profiles/common/modules/features/multisite_mediagallery_community/multisite_mediagallery_community.info
+++ b/profiles/common/modules/features/multisite_mediagallery_community/multisite_mediagallery_community.info
@@ -18,3 +18,4 @@ features[field_instance][] = node-gallerymedia-group_content_access
 features[field_instance][] = node-gallerymedia-og_group_ref
 features[variable][] = "pathauto_node_gallerymedia_pattern"
 files[] = tests/multisite_mediagallery_community.extra.test
+files[] = views/views_handler_area_media_link.inc

--- a/profiles/common/modules/features/multisite_mediagallery_community/multisite_mediagallery_community.module
+++ b/profiles/common/modules/features/multisite_mediagallery_community/multisite_mediagallery_community.module
@@ -54,37 +54,3 @@ function multisite_mediagallery_community_form_gallerymedia_node_form_alter(&$fo
     }
   }
 }
-
-/**
- * Implemets hook_views_pre_render().
- */
-function multisite_mediagallery_community_views_pre_render(&$view) {
-  if ($view->name == 'galleries' && $view->current_display == 'page') {
-    $output = '';
-    $og = og_context();
-
-    if ($og) {
-      $gid = $og['gid'];
-
-      // Check if user has permissions to create content for the community and
-      // render the button 'Create content'.
-      if (og_is_member('node', $gid) && og_user_access('node', $gid, 'create gallerymedia content') && user_access('create gallerymedia content')) {
-        $output .= l(t('Create a Media Gallery'), 'node/add/gallerymedia', array(
-          'attributes' => array(
-            'type' => 'add',
-            'action_bar' => 'single',
-            'btn_group' => 'single',
-          ),
-          'query' => array(
-            'og_group_ref' => $og['gid'],
-          ),
-        ));
-      }
-    }
-
-    // Add menu to the exsiting header.
-    if (isset($view->header['area'])) {
-      $view->header['area']->options['content'] = $view->header['area']->options['content'] . $output;
-    }
-  }
-}

--- a/profiles/common/modules/features/multisite_mediagallery_community/multisite_mediagallery_community.views.inc
+++ b/profiles/common/modules/features/multisite_mediagallery_community/multisite_mediagallery_community.views.inc
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Provides support for the views module.
+ */
+
+/**
+ * Implements hook_views_data().
+ */
+function multisite_mediagallery_community_views_data() {
+  $data = array();
+  $data['views']['multisite_mediagallery_link'] = array(
+    'title' => t('Create Media Gallery'),
+    'help' => t('Link to create Media Gallery'),
+    'area' => array(
+      'handler' => 'views_handler_area_media_link',
+    ),
+  );
+  return $data;
+}

--- a/profiles/common/modules/features/multisite_mediagallery_community/multisite_mediagallery_community.views_alter.inc
+++ b/profiles/common/modules/features/multisite_mediagallery_community/multisite_mediagallery_community.views_alter.inc
@@ -49,13 +49,12 @@ function multisite_mediagallery_community_views_default_views_alter(&$views) {
     /* Display: Community Galleries */
     $handler = $view->new_display('page', 'Community Galleries', 'galleries_community');
     $handler->display->display_options['defaults']['hide_admin_links'] = FALSE;
+    $handler->display->display_options['defaults']['relationships'] = FALSE;
     $handler->display->display_options['defaults']['header'] = FALSE;
-    /* Header: Global: Text area */
-    $handler->display->display_options['header']['area']['id'] = 'area';
-    $handler->display->display_options['header']['area']['table'] = 'views';
-    $handler->display->display_options['header']['area']['field'] = 'area';
-    $handler->display->display_options['header']['area']['empty'] = TRUE;
-    $handler->display->display_options['header']['area']['format'] = 'full_html';
+    /* Header: Global: Create Media Gallery */
+    $handler->display->display_options['header']['multisite_mediagallery_link']['id'] = 'multisite_mediagallery_link';
+    $handler->display->display_options['header']['multisite_mediagallery_link']['table'] = 'views';
+    $handler->display->display_options['header']['multisite_mediagallery_link']['field'] = 'multisite_mediagallery_link';
     $handler->display->display_options['defaults']['relationships'] = FALSE;
     /* Relationship: OG membership: OG membership from Node */
     $handler->display->display_options['relationships']['og_membership_rel']['id'] = 'og_membership_rel';

--- a/profiles/common/modules/features/multisite_mediagallery_community/views/views_handler_area_media_link.inc
+++ b/profiles/common/modules/features/multisite_mediagallery_community/views/views_handler_area_media_link.inc
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file
+ * Definition of multisite_mediagallery_community.
+ */
+
+/**
+ * Views area handler to display glossary for the list of communities.
+ */
+class views_handler_area_media_link extends views_handler_area {
+
+  /**
+   * Return the glossary.
+   */
+  public function render($empty = FALSE) {
+    $output = '';
+    $og = og_context();
+    if ($og) {
+      $gid = $og['gid'];
+      // Check if user has permissions to create content for the community and
+      // render the button 'Create content'.
+      if (og_is_member('node', $gid) && og_user_access('node', $gid, 'create gallerymedia content') && user_access('create gallerymedia content')) {
+        $output .= l(t('Create a Media Gallery'), 'node/add/gallerymedia', array(
+          'attributes' => array(
+            'type' => 'add',
+            'action_bar' => 'single',
+            'btn_group' => 'single',
+          ),
+          'query' => array(
+            'og_group_ref' => $og['gid'],
+          ),
+        ));
+      }
+    }
+
+    return $output;
+  }
+
+}


### PR DESCRIPTION
## NEPT-2138

### Description

Remove function multisite_mediagallery_community_views_pre_render() and implement it on the view handler views_handler_area_media_link

### Change log

- Added: view handler views_handler_area_media_link
- Changed: view galleries_community to use views_handler_area_media_link
- Removed: function multisite_mediagallery_community_views_pre_render 

### Commands
drush cc all
