### PR TITLE
NEPT-2163: Jenkins is failing due to timeout.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,7 @@ void executeStages(String label) {
             sh './bin/drush -r build/ update-website --path=tests/updaters/'
             sh './bin/phpunit -c tests/phpunit.xml'
             wrap([$class: 'AnsiColorBuildWrapper', colorMapName: 'xterm']) {
-                timeout(time: 2, unit: 'HOURS') {
+                timeout(time: 3, unit: 'HOURS') {
                     if (env.WD_BROWSER_NAME == 'phantomjs') {
                         sh "phantomjs --webdriver=${env.WD_HOST}:${env.WD_PORT} &"
                     }


### PR DESCRIPTION
## NEPT-2163

### Description

Jenkins is failing due to timeout.

### Change log

- Changed: Increased timeout to 3h
