### PR TITLE
NEPT-762: Remove date_api_version variable from cce_basic_config

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.info
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.info
@@ -119,7 +119,6 @@ features[variable][] = comment_article
 features[variable][] = comment_default_mode_article
 features[variable][] = comment_preview_article
 features[variable][] = comment_subject_field_article
-features[variable][] = date_api_version
 features[variable][] = date_default_timezone
 features[variable][] = date_first_day
 features[variable][] = date_format_long

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -1946,8 +1946,8 @@ function cce_basic_config_update_7228() {
 /**
  * Set new value for cce_basic_config feature in database.
  * 
- * date_api_version must be removed from cce_basic_config feature and this
- * feature must not be reverted. 
+ * Variable date_api_version must be removed from cce_basic_config feature and 
+ * this feature must not be reverted.
  * Recreate the value of the feature in database without the variable.
  */
 function cce_basic_config_update_7229() {

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -1942,3 +1942,11 @@ function cce_basic_config_update_7228() {
   // Configuration for the settings of honeypot module.
   variable_set('honeypot_protect_all_forms', 1);
 }
+
+/**
+ * Set value for cce_basic_config feature in database after removing var date_api_version without 
+ */
+function cce_basic_config_update_7229() {
+  module_load_include('inc', 'features', "features.export");
+  features_set_signature('cce_basic_config', 'variable');
+}

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -1945,8 +1945,8 @@ function cce_basic_config_update_7228() {
 
 /**
  * Set new value for cce_basic_config feature in database.
- * 
- * Variable date_api_version must be removed from cce_basic_config feature and 
+ *
+ * Variable date_api_version must be removed from cce_basic_config feature and
  * this feature must not be reverted.
  * Recreate the value of the feature in database without the variable.
  */

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -1944,7 +1944,11 @@ function cce_basic_config_update_7228() {
 }
 
 /**
- * Set value for cce_basic_config feature in database after removing var date_api_version without 
+ * Set new value for cce_basic_config feature in database.
+ * 
+ * date_api_version must be removed from cce_basic_config feature and this
+ * feature must not be reverted. 
+ * Recreate the value of the feature in database without the variable.
  */
 function cce_basic_config_update_7229() {
   module_load_include('inc', 'features', "features.export");

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.strongarm.inc
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.strongarm.inc
@@ -70,15 +70,6 @@ function cce_basic_config_strongarm() {
 
   $strongarm->disabled = FALSE;
   $strongarm->api_version = 1;
-  $strongarm->name = 'date_api_version';
-  $strongarm->value = '7.2';
-  $export['date_api_version'] = $strongarm;
-
-  $strongarm = new stdClass();
-  /* Edit this to true to make a default strongarm disabled initially */
-
-  $strongarm->disabled = FALSE;
-  $strongarm->api_version = 1;
   $strongarm->name = 'date_default_timezone';
   $strongarm->value = 'Europe/Luxembourg';
   $export['date_default_timezone'] = $strongarm;


### PR DESCRIPTION
## NEPT-762
### Description

This parameter must be removed from cce_basic_config because it is set automotically by the "date_api" module and that must not set like that.


### Change log

- Removed: date_api_version variable from the following files:
  - profiles/common/modules/features/cce_basic_config/cce_basic_config.info
  - profiles/common/modules/features/cce_basic_config/cce_basic_config.strongarm.inc

### Commands

drush fr cce_basic_config

