### PR TITLE
 NEPT-2181: Module to show message when publishing a node after the configured date.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
@@ -15,7 +15,7 @@ It is possible to override these values by configuring the values on the setting
     $conf['nexteuropa_scheduler_message_text'] = 'Replace text %date';  
 * To change the date to check:
      // Use the format shown here, also take into account that this date will always use CET as timezone.
-    $conf['nexteuropa_scheduler_message_time'] = '2019-03-30 01:00:00'; 
+        $conf['nexteuropa_scheduler_message_time'] = '2019-03-30 01:00:00'; 
 
 You can check the value of both parameters, if you have "administer scheduler" permissions. I will show the default values or the values from settings.php, if they
 are configured:

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
@@ -1,5 +1,5 @@
-This module checks when a node or revision is saved and is scheduled for publication.
-When this happens it checks the publication date and, if it is after the limit date
+This module checks when a node or revision is scheduled for publication when editing it.
+When this happens it checks the publication date configured and, if it is after the limit date
 configured on the module, shows a message.
 
 By default, if nothing is configured, the module has these values:

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
@@ -20,3 +20,11 @@ It is possible to override these values by configuring the values on the setting
 
 You can check the value of both parameters, if you have "administer scheduler" permissions. I will show the default values or the values from settings.php, if they are configured:
 * admin/config/content/scheduler/scheduler_message
+
+Translation
+    It is possible to translate the default text or the test configured on the settings.php page.
+    To allow translation take this steps:
+    .- Ensure you have more than one language enabled.
+    .- Load the page admin/config/content/scheduler/scheduler_message with a language different to english, for example:
+            admin/config/content/scheduler/scheduler_message_fr
+    .- Load the page admin/config/regional/translate/translate_en and search for the string translate.

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
@@ -1,0 +1,22 @@
+This module checks when a node or revision is saved and is scheduled for publication.
+When this happens it checks the publication date and, if it is after the limit date
+configured on the module, shows a message.
+
+By default, if nothing is configured, the module has this values:
+* Message to show (nexteuropa_scheduler_message_text): 
+    This node has been scheduled to be published at or after %date. Please ensure your changes will not lead to the premature publication of sensitive information.
+* Date to check (nexteuropa_scheduler_message_time):
+    2019-03-30 00:00:00
+
+It is possible to override these values by configuring the values on the settings.php file like this:
+* To change the message to show:
+    // The text %date will be replaced by the date value from nexteuropa_scheduler_message_text (see below).
+    // If nexteuropa_scheduler_message_text is not configured, it will use the default value (check Date to check (nexteuropa_scheduler_message_time)).
+    $conf['nexteuropa_scheduler_message_text'] = 'Replace text %date';  
+* To change the date to check:
+     // Use the format shown here, also take into account that this date will always use CET as timezone.
+    $conf['nexteuropa_scheduler_message_time'] = '2019-03-30 01:00:00'; 
+
+You can check the value of both parameters, if you have "administer scheduler" permissions. I will show the default values or the values from settings.php, if they
+are configured:
+* admin/config/content/scheduler/scheduler_message

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
@@ -4,13 +4,13 @@ configured on the module, shows a message.
 
 By default, if nothing is configured, the module has this values:
 * Message to show (nexteuropa_scheduler_message_text): 
-    This node has been scheduled to be published at or after %date. Please ensure your changes will not lead to the premature publication of sensitive information.
+    This node scheduled publication date, %date_to_publish, is at or after %date_to_check. Please ensure your changes will not lead to the premature publication of sensitive information.
 * Date to check (nexteuropa_scheduler_message_time):
     2019-03-30 00:00:00
 
 It is possible to override these values by configuring the values on the settings.php file like this:
 * To change the message to show:
-    // The text %date will be replaced by the date value from nexteuropa_scheduler_message_text (see below).
+    // The text %date_to_check will be replaced by the date value from nexteuropa_scheduler_message_text (see below).
     // If nexteuropa_scheduler_message_text is not configured, it will use the default value (check Date to check (nexteuropa_scheduler_message_time)).
     $conf['nexteuropa_scheduler_message_text'] = 'Replace text %date';  
 * To change the date to check:

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
@@ -2,21 +2,21 @@ This module checks when a node or revision is saved and is scheduled for publica
 When this happens it checks the publication date and, if it is after the limit date
 configured on the module, shows a message.
 
-By default, if nothing is configured, the module has this values:
+By default, if nothing is configured, the module has these values:
 * Message to show (nexteuropa_scheduler_message_text): 
-    This node scheduled publication date, %date_to_publish, is at or after %date_to_check. Please ensure your changes will not lead to the premature publication of sensitive information.
+    This node date for publication is %date_to_publish, this is at or after %date_to_check. Please ensure your changes will not lead to the premature publication of sensitive information.
 * Date to check (nexteuropa_scheduler_message_time):
     2019-03-30 00:00:00
 
 It is possible to override these values by configuring the values on the settings.php file like this:
 * To change the message to show:
     // The text %date_to_check will be replaced by the date value from nexteuropa_scheduler_message_text (see below).
+    // The text %date_to_publish will be replaced by the publication date of the node or the revision.
     // If nexteuropa_scheduler_message_text is not configured, it will use the default value (check Date to check (nexteuropa_scheduler_message_time)).
-    $conf['nexteuropa_scheduler_message_text'] = 'Replace text %date';  
+    $conf['nexteuropa_scheduler_message_text'] = 'Replace text %date_to_publish %date_to_check';  
 * To change the date to check:
-     // Use the format shown here, also take into account that this date will always use CET as timezone.
-        $conf['nexteuropa_scheduler_message_time'] = '2019-03-30 01:00:00'; 
+    // Use the format shown here, also take into account that this date will always use CET as timezone.
+    $conf['nexteuropa_scheduler_message_time'] = '2019-03-30 01:00:00'; 
 
-You can check the value of both parameters, if you have "administer scheduler" permissions. I will show the default values or the values from settings.php, if they
-are configured:
+You can check the value of both parameters, if you have "administer scheduler" permissions. I will show the default values or the values from settings.php, if they are configured:
 * admin/config/content/scheduler/scheduler_message

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_admin.inc
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_admin.inc
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Show module configuration info.
+ */
+
+/**
+ * Build the admin settings form.
+ */
+function nexteuropa_scheduler_message_settings() {
+  $form = array();
+  $form['nexteuropa_scheduler_message_text'] = array(
+    '#type' => 'item',
+    "#disabled" => TRUE,
+    '#title' => t('Message text'),
+    '#markup' => _nexteuropa_scheduler_message_replace(),
+    '#description' => t('This is the message to show when scheduling the publication of a node or revision. The element %date will be replaced with the date from the field below.'),
+  );
+  $form['nexteuropa_scheduler_message_time'] = array(
+    '#type' => 'item',
+    "#disabled" => TRUE,
+    '#title' => t('Limit date'),
+    '#markup' => _nexteuropa_scheduler_message_get_time()->format('r'),
+    '#description' => t('This is the limit date to check. Any node or revision set to be published after this date, will show the previous message.'),
+  );
+  return $form;
+}

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_admin.inc
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_admin.inc
@@ -15,7 +15,7 @@ function nexteuropa_scheduler_message_settings() {
     "#disabled" => TRUE,
     '#title' => t('Message text'),
     '#markup' => _nexteuropa_scheduler_message_replace(),
-    '#description' => t('This is the message to show when scheduling the publication of a node or revision. The element %date will be replaced with the date from the field below.'),
+    '#description' => t('This is the message to show when scheduling the publication of a node or revision. The text %date_to_check will be replaced by the date value from the field below and the text %date_to_publish will be replaced by the publication date of the node or the revision.'),
   );
   $form['nexteuropa_scheduler_message_time'] = array(
     '#type' => 'item',

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.info
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.info
@@ -1,0 +1,7 @@
+name = NextEuropa Scheduler Message
+description = Allows to show a meesage when scheduling the publication of a node or revision.
+package = NextEuropa
+core = 7.x
+
+dependencies[] = scheduler
+dependencies[] = scheduler_workbench

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
@@ -26,9 +26,13 @@ function nexteuropa_scheduler_message_menu() {
 }
 
 /**
- * Implements hook_node_presave().
+ * Implements hook_form_node_form_alter().
  */
-function nexteuropa_scheduler_message_node_presave($node) {
+function nexteuropa_scheduler_message_form_node_form_alter(&$form, &$form_state, $form_id) {
+  if (!isset($form_state['node']) || !isset($form_state['node']->nid)) {
+    return;
+  }
+  $node = $form_state['node'];
   $time_to_check = _nexteuropa_scheduler_message_get_time();
   // Handle date when there are scheduling dates for revisions.
   // This is only needed for platform version 2.5.

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
@@ -30,7 +30,7 @@ function nexteuropa_scheduler_message_menu() {
  */
 function nexteuropa_scheduler_message_node_presave($node) {
   $time_to_check = _nexteuropa_scheduler_message_get_time();
-  if (is_numeric($node->publish_on) && (int)$node->publish_on == $node->publish_on) {
+  if (is_numeric($node->publish_on) && (int) $node->publish_on == $node->publish_on) {
     $time_to_publish = DateTime::createFromFormat("U", $node->publish_on);
   }
   else {
@@ -39,7 +39,7 @@ function nexteuropa_scheduler_message_node_presave($node) {
   // Always convert the date to the Brussels time for the comparation.
   $time_to_publish->setTimezone(new DateTimeZone('Europe/Brussels'));
   if (isset($node->publish_on) && !empty($node->publish_on) && $time_to_publish->format('r') >= $time_to_check->format('r')) {
-    drupal_set_message(_nexteuropa_scheduler_message_replace($time_to_publish)) ;
+    drupal_set_message(_nexteuropa_scheduler_message_replace($time_to_publish));
   }
 }
 

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @file
+ * Drupal Module: NextEuropa Scheduler Message.
+ *
+ * Add a message to show when scheduling the publication of a node or review.
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function nexteuropa_scheduler_message_menu() {
+  $items = array();
+  $items['admin/config/content/scheduler/scheduler_message'] = array(
+    'title' => 'Scheduling Message',
+    'description' => 'Configure a message when scheduling the publication of a node or revision',
+    'page callback' => 'drupal_get_form',
+    'access arguments' => array('administer scheduler'),
+    'page arguments' => array('nexteuropa_scheduler_message_settings'),
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 35,
+    'file' => 'nexteuropa_scheduler_admin.inc',
+  );
+  return $items;
+}
+
+/**
+ * Implements hook_node_presave().
+ */
+function nexteuropa_scheduler_message_node_presave($node) {
+  $time_to_check = _nexteuropa_scheduler_message_get_time();
+  $time_to_publish = new DateTime($node->publish_on);
+  if (isset($node->publish_on) && !empty($node->publish_on) && $time_to_publish >= $time_to_check) {
+    drupal_set_message(_nexteuropa_scheduler_message_replace());
+  }
+}
+
+/**
+ * Get the message and replace the date.
+ */
+function _nexteuropa_scheduler_message_replace() {
+  $time_to_check = _nexteuropa_scheduler_message_get_time();
+  $message = variable_get('nexteuropa_scheduler_message_text', "This node has been scheduled to be published at or after %date. Please ensure your changes will not lead to the premature publication of sensitive information.");
+  $date = $time_to_check->format('r');
+  $message = str_replace('%date', $date, $message);
+  return $message;
+}
+
+/**
+ * Returns the limit date to check.
+ */
+function _nexteuropa_scheduler_message_get_time() {
+  return new DateTime(variable_get('nexteuropa_scheduler_message_time', '2019-03-30 00:00:00'));
+}

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
@@ -59,7 +59,7 @@ function nexteuropa_scheduler_message_form_node_form_alter(&$form, &$form_state,
   $time_to_publish->setTimezone(new DateTimeZone('Europe/Brussels'));
   if ((isset($node->publish_on) && !empty($node->publish_on) || isset($node->revision_publish_on) &&
    !empty($node->revision_publish_on)) && $time_to_publish->format('U') >= $time_to_check->format('U')) {
-    drupal_set_message(_nexteuropa_scheduler_message_replace($time_to_publish));
+    drupal_set_message(_nexteuropa_scheduler_message_replace($time_to_publish), 'warning');
   }
 }
 

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
@@ -31,13 +31,18 @@ function nexteuropa_scheduler_message_menu() {
 function nexteuropa_scheduler_message_node_presave($node) {
   $time_to_check = _nexteuropa_scheduler_message_get_time();
   $time_to_publish = new DateTime($node->publish_on);
-  if (isset($node->publish_on) && !empty($node->publish_on) && $time_to_publish >= $time_to_check) {
+  // Always convert the date to the Brussels time for the comparation.
+  $time_to_publish->setTimezone(new DateTimeZone('Europe/Brussels'));
+  if (isset($node->publish_on) && !empty($node->publish_on) && $time_to_publish->format('r') >= $time_to_check->format('r')) {
     drupal_set_message(_nexteuropa_scheduler_message_replace());
   }
 }
 
 /**
  * Get the message and replace the date.
+ *
+ * @return text
+ *   Message to show.
  */
 function _nexteuropa_scheduler_message_replace() {
   $time_to_check = _nexteuropa_scheduler_message_get_time();
@@ -49,7 +54,11 @@ function _nexteuropa_scheduler_message_replace() {
 
 /**
  * Returns the limit date to check.
+ *
+ * @return object
+ *   Datetime object
  */
 function _nexteuropa_scheduler_message_get_time() {
+  // This date will assume Brussels time (CET).
   return new DateTime(variable_get('nexteuropa_scheduler_message_time', '2019-03-30 00:00:00'));
 }

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
@@ -30,11 +30,16 @@ function nexteuropa_scheduler_message_menu() {
  */
 function nexteuropa_scheduler_message_node_presave($node) {
   $time_to_check = _nexteuropa_scheduler_message_get_time();
-  $time_to_publish = new DateTime($node->publish_on);
+  if (is_numeric($node->publish_on) && (int)$node->publish_on == $node->publish_on) {
+    $time_to_publish = DateTime::createFromFormat("U", $node->publish_on);
+  }
+  else {
+    $time_to_publish = new DateTime($node->publish_on);
+  }
   // Always convert the date to the Brussels time for the comparation.
   $time_to_publish->setTimezone(new DateTimeZone('Europe/Brussels'));
   if (isset($node->publish_on) && !empty($node->publish_on) && $time_to_publish->format('r') >= $time_to_check->format('r')) {
-    drupal_set_message(_nexteuropa_scheduler_message_replace());
+    drupal_set_message(_nexteuropa_scheduler_message_replace($time_to_publish)) ;
   }
 }
 
@@ -44,11 +49,12 @@ function nexteuropa_scheduler_message_node_presave($node) {
  * @return text
  *   Message to show.
  */
-function _nexteuropa_scheduler_message_replace() {
+function _nexteuropa_scheduler_message_replace($time_to_publish) {
   $time_to_check = _nexteuropa_scheduler_message_get_time();
-  $message = variable_get('nexteuropa_scheduler_message_text', "This node has been scheduled to be published at or after %date. Please ensure your changes will not lead to the premature publication of sensitive information.");
+  $message = variable_get('nexteuropa_scheduler_message_text', "This node is scheduled for publication on %date_to_publish, this is at or after %date_to_check. Please ensure your changes will not lead to the premature publication of sensitive information.");
   $date = $time_to_check->format('r');
-  $message = str_replace('%date', $date, $message);
+  $message = str_replace('%date_to_publish', $time_to_publish->format('r'), $message);
+  $message = str_replace('%date_to_check', $date, $message);
   return $message;
 }
 

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
@@ -30,15 +30,31 @@ function nexteuropa_scheduler_message_menu() {
  */
 function nexteuropa_scheduler_message_node_presave($node) {
   $time_to_check = _nexteuropa_scheduler_message_get_time();
-  if (is_numeric($node->publish_on) && (int) $node->publish_on == $node->publish_on) {
-    $time_to_publish = DateTime::createFromFormat("U", $node->publish_on);
+  // Handle date when there are scheduling dates for revisions.
+  // This is only needed for platform version 2.5.
+  if (isset($node->revision_publish_on)) {
+    // Transform to unix time.
+    if (!is_numeric($node->revision_publish_on) || (int) $node->revision_publish_on != $node->revision_publish_on) {
+      $time_to_publish = date_create($node->revision_publish_on, timezone_open(drupal_get_user_timezone()));
+    }
+    else {
+      $time_to_publish = DateTime::createFromFormat("U", $node->revision_publish_on);
+    }
   }
   else {
-    $time_to_publish = new DateTime($node->publish_on);
+    // Create date from date format. Needed for node updates.
+    if (!is_numeric($node->publish_on) || (int) $node->publish_on != $node->publish_on) {
+      $time_to_publish = date_create($node->publish_on, timezone_open(drupal_get_user_timezone()));
+    }
+    // Create date from unix time. Needed for node creation.
+    else {
+      $time_to_publish = DateTime::createFromFormat("U", $node->publish_on);
+    }
   }
   // Always convert the date to the Brussels time for the comparation.
   $time_to_publish->setTimezone(new DateTimeZone('Europe/Brussels'));
-  if (isset($node->publish_on) && !empty($node->publish_on) && $time_to_publish->format('r') >= $time_to_check->format('r')) {
+  if ((isset($node->publish_on) && !empty($node->publish_on) || isset($node->revision_publish_on) &&
+   !empty($node->revision_publish_on)) && $time_to_publish->format('r') >= $time_to_check->format('r')) {
     drupal_set_message(_nexteuropa_scheduler_message_replace($time_to_publish));
   }
 }
@@ -49,11 +65,13 @@ function nexteuropa_scheduler_message_node_presave($node) {
  * @return text
  *   Message to show.
  */
-function _nexteuropa_scheduler_message_replace($time_to_publish) {
+function _nexteuropa_scheduler_message_replace(Datetime $time_to_publish = NULL) {
   $time_to_check = _nexteuropa_scheduler_message_get_time();
-  $message = variable_get('nexteuropa_scheduler_message_text', "This node is scheduled for publication on %date_to_publish, this is at or after %date_to_check. Please ensure your changes will not lead to the premature publication of sensitive information.");
+  $message = variable_get('nexteuropa_scheduler_message_text', "This node date for publication is %date_to_publish, this is at or after %date_to_check. Please ensure your changes will not lead to the premature publication of sensitive information.");
   $date = $time_to_check->format('r');
-  $message = str_replace('%date_to_publish', $time_to_publish->format('r'), $message);
+  if ($time_to_publish) {
+    $message = str_replace('%date_to_publish', $time_to_publish->format('r'), $message);
+  }
   $message = str_replace('%date_to_check', $date, $message);
   return $message;
 }

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
@@ -54,7 +54,7 @@ function nexteuropa_scheduler_message_node_presave($node) {
   // Always convert the date to the Brussels time for the comparation.
   $time_to_publish->setTimezone(new DateTimeZone('Europe/Brussels'));
   if ((isset($node->publish_on) && !empty($node->publish_on) || isset($node->revision_publish_on) &&
-   !empty($node->revision_publish_on)) && $time_to_publish->format('r') >= $time_to_check->format('r')) {
+   !empty($node->revision_publish_on)) && $time_to_publish->format('U') >= $time_to_check->format('U')) {
     drupal_set_message(_nexteuropa_scheduler_message_replace($time_to_publish));
   }
 }
@@ -67,7 +67,8 @@ function nexteuropa_scheduler_message_node_presave($node) {
  */
 function _nexteuropa_scheduler_message_replace(Datetime $time_to_publish = NULL) {
   $time_to_check = _nexteuropa_scheduler_message_get_time();
-  $message = variable_get('nexteuropa_scheduler_message_text', "This node date for publication is %date_to_publish, this is at or after %date_to_check. Please ensure your changes will not lead to the premature publication of sensitive information.");
+  $message_text = t("This node date for publication is %date_to_publish, this is at or after %date_to_check. Please ensure your changes will not lead to the premature publication of sensitive information.");
+  $message = variable_get('nexteuropa_scheduler_message_text', $message_text);
   $date = $time_to_check->format('r');
   if ($time_to_publish) {
     $message = str_replace('%date_to_publish', $time_to_publish->format('r'), $message);

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
@@ -67,8 +67,8 @@ function nexteuropa_scheduler_message_node_presave($node) {
  */
 function _nexteuropa_scheduler_message_replace(Datetime $time_to_publish = NULL) {
   $time_to_check = _nexteuropa_scheduler_message_get_time();
-  $message_text = t("This node date for publication is %date_to_publish, this is at or after %date_to_check. Please ensure your changes will not lead to the premature publication of sensitive information.");
-  $message = variable_get('nexteuropa_scheduler_message_text', $message_text);
+  $message_text = "This node date for publication is %date_to_publish, this is at or after %date_to_check. Please ensure your changes will not lead to the premature publication of sensitive information.";
+  $message = t(variable_get('nexteuropa_scheduler_message_text', $message_text));
   $date = $time_to_check->format('r');
   if ($time_to_publish) {
     $message = str_replace('%date_to_publish', $time_to_publish->format('r'), $message);

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
@@ -66,14 +66,30 @@ function nexteuropa_scheduler_message_node_presave($node) {
  *   Message to show.
  */
 function _nexteuropa_scheduler_message_replace(Datetime $time_to_publish = NULL) {
+  // The platform forces the language of the admin pages, like node/%/edit,
+  // to be able to translage, we need to pass the language from the url
+  // to the t() function.
+  global $language_url;
+  // If we configure the message on the settings.php file, we need to
+  // pass it to the t() function to translate it.
+  global $conf;
+  $options = array('langcode' => $language_url->language);
   $time_to_check = _nexteuropa_scheduler_message_get_time();
-  $message_text = "This node date for publication is %date_to_publish, this is at or after %date_to_check. Please ensure your changes will not lead to the premature publication of sensitive information.";
-  $message = t(variable_get('nexteuropa_scheduler_message_text', $message_text));
-  $date = $time_to_check->format('r');
+  $args = array('%date_to_check' => $time_to_check->format('r'));
   if ($time_to_publish) {
-    $message = str_replace('%date_to_publish', $time_to_publish->format('r'), $message);
+    $args['%date_to_publish'] = $time_to_publish->format('r');
   }
-  $message = str_replace('%date_to_check', $date, $message);
+  if (!isset($conf['nexteuropa_scheduler_message_text'])) {
+    $message_text = t("This node date for publication is %date_to_publish, this is at or after %date_to_check. Please ensure your changes will not lead to the premature publication of sensitive information.", $args, $options);
+    $message = variable_get('nexteuropa_scheduler_message_text', $message_text);
+  }
+  else {
+    // We can trust this value, as it should be configured on the settings.php
+    // file.
+    // @codingStandardsIgnoreStart
+    $message = t($conf['nexteuropa_scheduler_message_text'], $args, $options);
+    // @codingStandardsIgnoreEnd
+  }
   return $message;
 }
 

--- a/profiles/multisite_drupal_communities/modules/custom/nexteuropa_scheduler_message
+++ b/profiles/multisite_drupal_communities/modules/custom/nexteuropa_scheduler_message
@@ -1,0 +1,1 @@
+../../../common/modules/custom/nexteuropa_scheduler_message/

--- a/profiles/multisite_drupal_standard/modules/custom/nexteuropa_scheduler_message
+++ b/profiles/multisite_drupal_standard/modules/custom/nexteuropa_scheduler_message
@@ -1,0 +1,1 @@
+../../../common/modules/custom/nexteuropa_scheduler_message


### PR DESCRIPTION
## NEPT-NEPT-2181

### Description

A module to show a message when scheduling the publication of a node after a set date.
The text to show and the date to check can be configured on the settings.php file, check the README.md file for detailed instructions.

### Change log

- Added: Module nexteuropa_scheduler_message

### Commands

drush en nexteuropa_scheduler_message

