### PR TITLE
NEPT-2181: Module to show message when scheduling a node publication.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/README.md
@@ -1,0 +1,22 @@
+This module checks when a node or revision is saved and is scheduled for publication.
+When this happens it checks the publication date and, if it is after the limit date
+configured on the module, shows a message.
+
+By default, if nothing is configured, the module has this values:
+* Message to show (nexteuropa_scheduler_message_text): 
+    This node has been scheduled to be published at or after %date. Please ensure your changes will not lead to the premature publication of sensitive information.
+* Date to check (nexteuropa_scheduler_message_time):
+    2019-03-30 00:00:00
+
+It is possible to override these values by configuring the values on the settings.php file like this:
+* To change the message to show:
+    // The text %date will be replaced by the date value from nexteuropa_scheduler_message_text (see below).
+    // If nexteuropa_scheduler_message_text is not configured, it will use the default value (check Date to check (nexteuropa_scheduler_message_time)).
+    $conf['nexteuropa_scheduler_message_text'] = 'Replace text %date';  
+* To change the date to check:
+     // Use the format shown here, also take into account that this date will always use CET as timezone.
+    $conf['nexteuropa_scheduler_message_time'] = '2019-03-30 01:00:00'; 
+
+You can check the value of both parameters, if you have "administer scheduler" permissions. I will show the default values or the values from settings.php, if they
+are configured:
+* admin/config/content/scheduler/scheduler_message

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_admin.inc
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_admin.inc
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Show module configuration info.
+ */
+
+/**
+ * Build the admin settings form.
+ */
+function nexteuropa_scheduler_message_settings() {
+  $form = array();
+  $form['nexteuropa_scheduler_message_text'] = array(
+    '#type' => 'item',
+    "#disabled" => TRUE,
+    '#title' => t('Message text'),
+    '#markup' => _nexteuropa_scheduler_message_replace(),
+    '#description' => t('This is the message to show when scheduling the publication of a node or revision. The element %date will be replaced with the date from the field below.'),
+  );
+  $form['nexteuropa_scheduler_message_time'] = array(
+    '#type' => 'item',
+    "#disabled" => TRUE,
+    '#title' => t('Limit date'),
+    '#markup' => _nexteuropa_scheduler_message_get_time()->format('r'),
+    '#description' => t('This is the limit date to check. Any node or revision set to be published after this date, will show the previous message.'),
+  );
+  return $form;
+}

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message
@@ -1,0 +1,1 @@
+nexteuropa_scheduler_message

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.info
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.info
@@ -1,0 +1,7 @@
+name = NextEuropa Scheduler Message
+description = Allows to show a meesage when scheduling the publication of a node or revision.
+package = NextEuropa
+core = 7.x
+
+dependencies[] = scheduler
+dependencies[] = scheduler_workbench

--- a/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
+++ b/profiles/common/modules/custom/nexteuropa_scheduler_message/nexteuropa_scheduler_message.module
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @file
+ * Drupal Module: NextEuropa Scheduler Message.
+ *
+ * Add a message to show when scheduling the publication of a node or review.
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function nexteuropa_scheduler_message_menu() {
+  $items = array();
+  $items['admin/config/content/scheduler/scheduler_message'] = array(
+    'title' => 'Scheduling Message',
+    'description' => 'Configure a message when scheduling the publication of a node or revision',
+    'page callback' => 'drupal_get_form',
+    'access arguments' => array('administer scheduler'),
+    'page arguments' => array('nexteuropa_scheduler_message_settings'),
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 35,
+    'file' => 'nexteuropa_scheduler_admin.inc',
+  );
+  return $items;
+}
+
+/**
+ * Implements hook_node_presave().
+ */
+function nexteuropa_scheduler_message_node_presave($node) {
+  $time_to_check = _nexteuropa_scheduler_message_get_time();
+  $time_to_publish = new DateTime($node->publish_on);
+  if (isset($node->publish_on) && !empty($node->publish_on) && $time_to_publish >= $time_to_check) {
+    drupal_set_message(_nexteuropa_scheduler_message_replace());
+  }
+}
+
+/**
+ * Get the message and replace the date.
+ */
+function _nexteuropa_scheduler_message_replace() {
+  $time_to_check = _nexteuropa_scheduler_message_get_time();
+  $message = variable_get('nexteuropa_scheduler_message_text', "This node has been scheduled to be published at or after %date. Please ensure your changes will not lead to the premature publication of sensitive information.");
+  $date = $time_to_check->format('r');
+  $message = str_replace('%date', $date, $message);
+  return $message;
+}
+
+/**
+ * Returns the limit date to check.
+ */
+function _nexteuropa_scheduler_message_get_time() {
+  return new DateTime(variable_get('nexteuropa_scheduler_message_time', '2019-03-30 00:00:00'));
+}

--- a/profiles/multisite_drupal_standard/modules/custom/nexteuropa_scheduler_message
+++ b/profiles/multisite_drupal_standard/modules/custom/nexteuropa_scheduler_message
@@ -1,0 +1,1 @@
+../../../common/modules/custom/nexteuropa_scheduler_message


### PR DESCRIPTION
## NEPT-NEPT-2181

### Description

A module to show a message when scheduling the publication of a node after a set date.
The text to show and the date to check can be configured on the settings.php file, check the README.md file for detailed instructions.

### Change log

- Added: Module nexteuropa_scheduler_message

### Commands

drush en nexteuropa_scheduler_message

