### PR TITLE
NEPT-2162: CLONE - EMA - Internal Link popup too wide (CKEDITOR)

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/nexteuropa_token_ckeditor.module
+++ b/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/nexteuropa_token_ckeditor.module
@@ -286,11 +286,11 @@ function nexteuropa_token_ckeditor_views_pre_render(&$view) {
       drupal_add_js(drupal_get_path('module', 'nexteuropa_token_ckeditor') . '/js/delete_history.js', array('weight' => 1));
     }
   }
-  foreach ($view->result as $key=>$result) {
-    if (strlen($result->node_title) >= 100) {
-      // Shorten the title if it is too long. Show in the table just the first 95 characters and then the last 10 chars of the title.
-      $result->node_title = substr($result->node_title, 0, 95) . " [...] " . substr($result->node_title, -10);
-      $view->result[$key]= $result;
+  foreach ($view->result as $key => $result) {
+    if (drupal_strlen($result->node_title) >= 100) {
+      // Shorten the title if it is too long. Only show first and last chars.
+      $result->node_title = drupal_substr($result->node_title, 0, 95) . " [...] " . drupal_substr($result->node_title, -10);
+      $view->result[$key] = $result;
     }
   }
 }

--- a/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/nexteuropa_token_ckeditor.module
+++ b/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/nexteuropa_token_ckeditor.module
@@ -288,8 +288,13 @@ function nexteuropa_token_ckeditor_views_pre_render(&$view) {
   }
   foreach ($view->result as $key => $result) {
     if (drupal_strlen($result->node_title) >= 100) {
-      // Shorten the title if it is too long. Only show first and last chars.
+      // Shorten the node title if it is too long. Only show first & last chars.
       $result->node_title = drupal_substr($result->node_title, 0, 95) . " [...] " . drupal_substr($result->node_title, -10);
+      $view->result[$key] = $result;
+    }
+    if (drupal_strlen($result->bean_title) >= 100) {
+      // Shorten the bean title if it is too long. Only show first & last chars.
+      $result->bean_title = drupal_substr($result->bean_title, 0, 95) . " [...] " . drupal_substr($result->bean_title, -10);
       $view->result[$key] = $result;
     }
   }

--- a/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/nexteuropa_token_ckeditor.module
+++ b/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/nexteuropa_token_ckeditor.module
@@ -278,11 +278,19 @@ function nexteuropa_token_ckeditor_custom_theme() {
  *
  * See NEPT-191: Delete the History object to avoid errors in the views
  * provided by this module only.
+ * See NEPT-2162: Internal Link popup too wide (CKEDITOR)
  */
 function nexteuropa_token_ckeditor_views_pre_render(&$view) {
   if (isset($view->export_module) && 'nexteuropa_token_ckeditor' == $view->export_module) {
     if ($view->use_ajax && !$view->editing) {
       drupal_add_js(drupal_get_path('module', 'nexteuropa_token_ckeditor') . '/js/delete_history.js', array('weight' => 1));
+    }
+  }
+  foreach ($view->result as $key=>$result) {
+    if (strlen($result->node_title) >= 100) {
+      // Shorten the title if it is too long. Show in the table just the first 95 characters and then the last 10 chars of the title.
+      $result->node_title = substr($result->node_title, 0, 95) . " [...] " . substr($result->node_title, -10);
+      $view->result[$key]= $result;
     }
   }
 }


### PR DESCRIPTION
## NEPT-2162

### Description

There is a CKEditor issue when trying to add a link and one of the titles has too many characters the popup is to wide and it cannot be used.

### Change log

- Changed:  nexteuropa_token_ckeditor_views_pre_render in profiles/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/nexteuropa_token_ckeditor.module file

### Commands

No commands 
