### PR TITLE
NEPT-2185: Auto Editor Height Adjustment, autoGrow plugin.

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -398,6 +398,9 @@ function cce_basic_config_install() {
     'multisite_wysiwyg_link_hreflang' => array(
       'Link',
     ),
+    'autogrow' => array(
+      'autogrow',
+    ),
   );
   foreach ($plugin_settings as $group => $buttons) {
     multisite_config_service('wysiwyg')->addButtonsToProfile('full_html', $group, $buttons);
@@ -1941,4 +1944,11 @@ function cce_basic_config_update_7228() {
   }
   // Configuration for the settings of honeypot module.
   variable_set('honeypot_protect_all_forms', 1);
+}
+
+/**
+ * NEPT-2185: Activate autoGrow plugin.
+ */
+function cce_basic_config_update_7229() {
+  multisite_config_service('wysiwyg')->addButtonsToProfile('full_html', 'autogrow', array('autogrow'));
 }

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
@@ -32,6 +32,9 @@ function multisite_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
     // This namespace must be applied even if the node edit forms are displayed
     // with the admin theme.
     $settings['bodyClass'] = 'ecl-editor';
+
+    // Automatically disable resize.
+    _multisite_wysiwyg_auto_disable_resize($settings, $context);
   }
 }
 
@@ -119,6 +122,7 @@ function multisite_wysiwyg_wysiwyg_plugin($editor, $version) {
         'load' => TRUE,
         'extensions' => array('Link' => t('CKEditor Link hreflang')),
       ),
+      'autogrow' => _multisite_wysiwyg_enable_auto_grow(),
     );
   }
 }
@@ -185,4 +189,45 @@ function _multisite_wysiwyg_get_ckeditor_css_paths($default_theme = NULL) {
   cache_set($cache_id, $css_file_paths, 'cache', CACHE_TEMPORARY);
 
   return $css_file_paths;
+}
+
+/**
+ * Enable AutoGrow Plugin.
+ *
+ * @return array
+ *   A list of settings to enable the plugin.
+ */
+function _multisite_wysiwyg_enable_auto_grow() {
+  return array(
+    'url' => 'https://sdk.ckeditor.com/samples/autogrow.html',
+    'extensions' => array('autogrow' => t('AutoGrow plugin')),
+    'options' => array(
+      // This sets some default values which can be override in:
+      // hook_wsiwyg_editor_settings_alter and or hook_form_alter.
+      'autoGrow_maxHeight' => variable_get('multisite_autoGrow_maxHeight', 600),
+      'autoGrow_minHeight' => variable_get('multisite_autoGrow_minHeight', 400),
+      'autoGrow_onStartup' => TRUE,
+    ),
+    'load' => TRUE,
+    // The plugin is bundled with CKEditor, no need to set 'path' or 'filename'.
+    'internal' => TRUE,
+  );
+}
+
+/**
+ * Disable resize as recommended.
+ *
+ * @param array $settings
+ *   A settings list which can be alter.
+ * @param array $context
+ *   A context list.
+ */
+function _multisite_wysiwyg_auto_disable_resize(array &$settings, array $context) {
+  if ($context['profile']->editor == 'ckeditor') {
+    // Only disable resize if autogrow is enabled and
+    // removePlugins is empty or does not already contain 'resize'.
+    if (strpos($settings['extraPlugins'], 'autogrow') !== FALSE && (empty($settings['removePlugins']) || strpos($settings['removePlugins'], 'resize') === FALSE)) {
+      $settings['removePlugins'] .= (empty($settings['removePlugins']) ? 'resize' : ',resize');
+    }
+  }
 }

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
@@ -226,7 +226,7 @@ function _multisite_wysiwyg_auto_disable_resize(array &$settings, array $context
   if ($context['profile']->editor == 'ckeditor') {
     // Only disable resize if autogrow is enabled and
     // removePlugins is empty or does not already contain 'resize'.
-    if (strpos($settings['extraPlugins'], 'autogrow') !== FALSE && (empty($settings['removePlugins']) || strpos($settings['removePlugins'], 'resize') === FALSE)) {
+    if (isset($settings['extraPlugins']) && strpos($settings['extraPlugins'], 'autogrow') !== FALSE && isset($settings['removePlugins']) && (empty($settings['removePlugins']) || strpos($settings['removePlugins'], 'resize') === FALSE)) {
       $settings['removePlugins'] .= (empty($settings['removePlugins']) ? 'resize' : ',resize');
     }
   }


### PR DESCRIPTION
## NEPT-2185

### Description

The issue: Textarea with different height (Default height of free text fields)
The Solution: Enable autoGrow, With this plugin, CKEditor will automatically expand and shrink vertically depending on the amount and size of content entered in its editing area.

### Change log

- Added:
    NEPT-2185: Set the same height for all textarea.
    - Add autoGrow plugin to manage the height on textarea fields
    - Use max and min height, with value 600 and 400 by default"
    - The max and min height can be configurable through settings file. 
  
  BUG:
    - There is a delay (javascript) to see autogrow applyed.  


### Commands

Setting config variable for min and max height in pixels;
` $config['multisite_autoGrow_minHeight'] = number_pixel_min
and 
  $config['multisite_autoGrow_maxHeight'] = number_pixel_max`

