### PR TITLE
NEPT-2149: CLONE - NextEuropa_token_CKEditor - Ajax Exposed filters not working with multiple same views.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -817,6 +817,10 @@ projects[views][patch][] = https://www.drupal.org/files/issues/views-contextual_
 ; Thousands of results after update to 3.18 - Put extras in parentheses, otherwise OR conditions in extras not correctly enclosed
 ; https://www.drupal.org/node/2908538
 projects[views][patch][] = https://www.drupal.org/files/issues/views-and_missing_parenthesis-2908538-2-D7.patch
+; Issue #3012609: Ajax Exposed filters not working with multiple same views
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2149
+; https://www.drupal.org/project/views/issues/3012609
+projects[views][patch][] = https://www.drupal.org/files/issues/2018-11-14/views_fix_ajax_exposed_filter_with_same_mutliple_views-3012609-7.patch
 
 projects[views_ajax_history][subdir] = "contrib"
 projects[views_ajax_history][version] = "1.0"


### PR DESCRIPTION
## NEPT-2149

### Description

The problem comes from the fact that we have several CKEditor on the page.
Clicking the icon to add a link, opens the popup each time with the same view (duplicated).
The view of the nexteuropa_token_ckeditor module uses AJAX with better exposed filter. 
The JS behaviors of the view module are based on the name of the view to initialize the ajax actions. 
Since there are several times this same view on the page, the javascript selector is always the same and this creates a bug with the AJAX exposed filter between all the views.

### Change log

- Added: patch for views added in resources/multisite_drupal_standard.make

