### PR TITLE
NEPT-2178: Translation workflow may not ensure that text removed from original is also removed from translations.

### DIFF
--- a/profiles/common/modules/custom/tmgmt_workbench/includes/tmgmt_workbench.plugin.inc
+++ b/profiles/common/modules/custom/tmgmt_workbench/includes/tmgmt_workbench.plugin.inc
@@ -52,9 +52,9 @@ class TMGMTWorkbenchSourcePluginController extends TMGMTEntitySourcePluginContro
     $handler = entity_translation_get_handler($job_item->item_type, $current_revision);
     $handler->setActiveLanguage($job_item->getJob()->target_language);
 
-    $current_revision_metadata_value = $this->manageEmptyFieldUpdate($current_revision, $job_item->getData(), $job->source_language, $job->target_language);
-    if ($current_revision_metadata_value) {
-      $current_revision = $current_revision_metadata_value;
+    $current_revision_update = $this->manageEmptyFieldUpdate($current_revision, $job_item->getData(), $job->source_language, $job->target_language);
+    if ($current_revision_update) {
+      $current_revision = $current_revision_update;
     }
     // Save current node revision.
     node_save($current_revision);

--- a/profiles/common/modules/custom/tmgmt_workbench/includes/tmgmt_workbench.plugin.inc
+++ b/profiles/common/modules/custom/tmgmt_workbench/includes/tmgmt_workbench.plugin.inc
@@ -52,6 +52,10 @@ class TMGMTWorkbenchSourcePluginController extends TMGMTEntitySourcePluginContro
     $handler = entity_translation_get_handler($job_item->item_type, $current_revision);
     $handler->setActiveLanguage($job_item->getJob()->target_language);
 
+    $current_revision_metadata_value = $this->manageEmptyFieldUpdate($current_revision, $job_item->getData(), $job->source_language, $job->target_language);
+    if ($current_revision_metadata_value) {
+      $current_revision = $current_revision_metadata_value;
+    }
     // Save current node revision.
     node_save($current_revision);
 

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -765,6 +765,7 @@ projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2018-09-17/check_
 ; https://www.drupal.org/node/2955245
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1878
 projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2018-04-17/2955245-5.patch
+projects[tmgmt][patch][] = patches/translation_not_taking_in_account_the_source_data_update.patch
 
 projects[token][subdir] = "contrib"
 projects[token][version] = "1.7"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -765,7 +765,10 @@ projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2018-09-17/check_
 ; https://www.drupal.org/node/2955245
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1878
 projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2018-04-17/2955245-5.patch
-projects[tmgmt][patch][] = patches/translation_not_taking_in_account_the_source_data_update.patch
+; #3021843: Translation not taking into account the source data update on empty fields
+; https://www.drupal.org/node/3021843
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2178
+projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2018-12-20/translation_not_taking_into_account_the_source_data_update-3021843.patch
 
 projects[token][subdir] = "contrib"
 projects[token][version] = "1.7"

--- a/resources/patches/translation_not_taking_in_account_the_source_data_update.patch
+++ b/resources/patches/translation_not_taking_in_account_the_source_data_update.patch
@@ -1,0 +1,62 @@
+diff --git a/sources/entity/tmgmt_entity.plugin.inc b/sources/entity/tmgmt_entity.plugin.inc
+index 90cf76e..66a0b89 100644
+--- a/sources/entity/tmgmt_entity.plugin.inc
++++ b/sources/entity/tmgmt_entity.plugin.inc
+@@ -49,6 +49,12 @@ class TMGMTEntitySourcePluginController extends TMGMTDefaultSourcePluginControll
+     $handler = entity_translation_get_handler($job_item->item_type, $entity);
+     $handler->setFormLanguage($job_item->getJob()->target_language);
+ 
++    // Copy over because if entity is not update, $entity_wrapper->save() won't work.
++    $entity_metadata_value = $this->manageEmptyFieldUpdate($entity, $job_item->getData(), $job->source_language, $job->target_language);
++    if ($entity_metadata_value) {
++      $entity = $entity_metadata_value;
++    }
++
+     entity_save($job_item->item_type, $entity);
+ 
+     $translation = array(
+@@ -107,4 +113,44 @@ class TMGMTEntitySourcePluginController extends TMGMTDefaultSourcePluginControll
+ 
+     return array();
+   }
++
++  /**
++   * A controller method to check when the original entity has been updated.
++   *
++   * In this case, if the field has been empty, the translation process does not take the update field,
++   * however, while saving the translated entity the updated field should be taken into account.
++   *
++   * @param $entity
++   *   The entity.
++   * @param $data_to_translate
++   *   A structured data array.
++   * @param string $source_language
++   *   The original language code.
++   * @param string $target_language
++   *   The language code to be translated to.
++   *
++   * @return The value of the wrapped data. If the data property is not altered, NULL
++   *    is returned.
++   */
++  public function manageEmptyFieldUpdate($entity, array $data_to_translate, $source_language, $target_language) {
++    // Filter the fields that are translated, and loop to the rest.
++    $cache = _field_info_field_cache();
++    $info = $cache->getBundleInstances($entity->entity_type, $entity->type);
++    $fields = array_diff_key($info, $data_to_translate);
++    $entity_wrapper = entity_metadata_wrapper($entity->entity_type, $entity->nid);
++
++    $has_empty_field = FALSE;
++    foreach ($fields as $field_name => $data) {
++      // Not all the fields has language index, such as "field groups"
++      if (is_array($entity->$field_name) && array_key_exists($target_language, $entity->$field_name) &&
++        (!array_key_exists($source_language, $entity->$field_name) || empty($entity->$field_name[$source_language]))
++      ) {
++        $entity_wrapper->language($target_language)->$field_name->value->set(NULL);
++        $has_empty_field = TRUE;
++      }
++    }
++
++    return $has_empty_field ? $entity_wrapper->value() : NULL;
++  }
++
+ }

--- a/resources/patches/translation_not_taking_into_account_the_source_data_update.patch
+++ b/resources/patches/translation_not_taking_into_account_the_source_data_update.patch
@@ -1,42 +1,41 @@
 diff --git a/sources/entity/tmgmt_entity.plugin.inc b/sources/entity/tmgmt_entity.plugin.inc
-index 90cf76e..66a0b89 100644
+index 90cf76e..9c9f1ac 100644
 --- a/sources/entity/tmgmt_entity.plugin.inc
 +++ b/sources/entity/tmgmt_entity.plugin.inc
-@@ -49,6 +49,12 @@ class TMGMTEntitySourcePluginController extends TMGMTDefaultSourcePluginControll
+@@ -49,6 +49,11 @@ class TMGMTEntitySourcePluginController extends TMGMTDefaultSourcePluginControll
      $handler = entity_translation_get_handler($job_item->item_type, $entity);
      $handler->setFormLanguage($job_item->getJob()->target_language);
  
-+    // Copy over because if entity is not update, $entity_wrapper->save() won't work.
-+    $entity_metadata_value = $this->manageEmptyFieldUpdate($entity, $job_item->getData(), $job->source_language, $job->target_language);
-+    if ($entity_metadata_value) {
-+      $entity = $entity_metadata_value;
++    $entity_updated = $this->manageEmptyFieldUpdate($entity, $job_item->getData(), $job->source_language, $job->target_language);
++    if ($entity_updated) {
++      $entity = $entity_updated;
 +    }
 +
      entity_save($job_item->item_type, $entity);
  
      $translation = array(
-@@ -107,4 +113,44 @@ class TMGMTEntitySourcePluginController extends TMGMTDefaultSourcePluginControll
+@@ -107,4 +112,43 @@ class TMGMTEntitySourcePluginController extends TMGMTDefaultSourcePluginControll
  
      return array();
    }
 +
 +  /**
-+   * A controller method to check when the original entity has been updated.
++   * Manage empty entity fields which are excluded from translation.
 +   *
-+   * In this case, if the field has been empty, the translation process does not take the update field,
++   * In such case, if the field has been empty, the translation process does not take the update field,
 +   * however, while saving the translated entity the updated field should be taken into account.
 +   *
-+   * @param $entity
++   * @param object $entity
 +   *   The entity.
-+   * @param $data_to_translate
++   * @param array $data_to_translate
 +   *   A structured data array.
 +   * @param string $source_language
 +   *   The original language code.
 +   * @param string $target_language
 +   *   The language code to be translated to.
 +   *
-+   * @return The value of the wrapped data. If the data property is not altered, NULL
-+   *    is returned.
++   * @return object|null
++   *   The entity wrapped data. If the entity wrapper is not altered, NULL is returned.
 +   */
 +  public function manageEmptyFieldUpdate($entity, array $data_to_translate, $source_language, $target_language) {
 +    // Filter the fields that are translated, and loop to the rest.
@@ -47,7 +46,6 @@ index 90cf76e..66a0b89 100644
 +
 +    $has_empty_field = FALSE;
 +    foreach ($fields as $field_name => $data) {
-+      // Not all the fields has language index, such as "field groups"
 +      if (is_array($entity->$field_name) && array_key_exists($target_language, $entity->$field_name) &&
 +        (!array_key_exists($source_language, $entity->$field_name) || empty($entity->$field_name[$source_language]))
 +      ) {


### PR DESCRIPTION
## NEPT-2178

### Description

Translation not taking in account the update on fields when the field updated has been empty after been populated.

### Change log

- Added:
   - A patch has been created.
   - An issue open on dorg will follow the patch. (tbd)
   - The solution target the translation using File and auto_accept and also the small jobs.

### Commands

n/a
