### PR TITLE
NEPT-2206: Fix compatibility issue with PHP 7.

### DIFF
--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/plugins/tmgmt_poetry.plugin.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/plugins/tmgmt_poetry.plugin.inc
@@ -592,9 +592,7 @@ xsi:noNamespaceSchemaLocation=\"http://intragate.ec.europa.eu/DGT/poetry_service
     try {
       $client = new SoapClient($poetry['address'], array('cache_wsdl' => WSDL_CACHE_NONE));
 
-      $response = $client->$poetry['method']($poetry_user, $poetry_password, $msg);
-
-      return $response;
+      return $client->{$poetry['method']}($poetry_user, $poetry_password, $msg);
     }
     catch (Exception $e) {
       watchdog_exception('tmgmt_poetry', $e);


### PR DESCRIPTION
## NEPT-2206

### Description

Error: Function name must be a string in TMGMTPoetryTranslatorPluginController->sendAddNewTargetLanguagesRequest() (line 595 of /test/platform-dev/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/plugins/tmgmt_poetry.plugin.inc).

### Change log

- Added:
- Changed:
/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/plugins/tmgmt_poetry.plugin.inc
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

[Insert commands here]

