### PR TITLE
NEPT-2207: Update version constraints of ex-tidy for php 7 compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "pfrenssen/phpcs-pre-push": "1.0",
     "phing/phing": "~2",
     "wimg/php-compatibility": "~7.0.7",
-    "ext-tidy": "^2.0"
+    "ext-tidy": "*"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master"


### PR DESCRIPTION
## NEPT-2207

### Description

ex-tidy versioning nr has changed in php 7
The following should be appropriate
"ext-tidy": "^2.0|^5.6|^7"

### Change log

- Added:
- Changed:
composer.json
- Deprecated:
- Removed:
- Fixed:
- Security:


