### PR TITLE
NEPT-2204: Apply patches only related to php 7 compatibility from date-7.x-2.11-beta1 release. For 2.5 release.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -180,6 +180,18 @@ projects[date][patch][] = https://www.drupal.org/files/issues/2305049-12.patch
 ; https://www.drupal.org/node/2889759
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1672
 projects[date][patch][] = https://www.drupal.org/files/issues/date-php7Offset-2889759-2.patch
+; PHP 7.1 no longer converts string to arrays the first time a value is assigned with square bracket notation.
+; https://www.drupal.org/node/2995679
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2204
+projects[date][patch][] = https://www.drupal.org/files/issues/2018-08-28/date-array_conversion-2995679-2-D7.patch
+; Fix PHP 7 tests.
+; https://www.drupal.org/node/2889636
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2204
+projects[date][patch][] = https://www.drupal.org/files/issues/date-2889636-7.patch
+; String Offset errors on edit page using PHP 7.1.0.
+; https://www.drupal.org/node/2843367
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2204
+projects[date][patch][] = https://www.drupal.org/files/issues/2843367-php71-string-offset-26.patch
 
 projects[date_ical][subdir] = "contrib"
 projects[date_ical][version] = "3.9"


### PR DESCRIPTION
## NEPT-2204

### Description

This version implement PHP7 compatibility
However we noticed some hook update, so for 2.5 we need to add only the php 7 patches.
The real module upgrade will take place in 2.6

http://cgit.drupalcode.org/date/diff/?id2=7.x-2.10&id=7.x-2.11-beta1
### Change log

- Added:
Patches:
1. https://www.drupal.org/node/2995679
2. https://www.drupal.org/node/2889636
3. https://www.drupal.org/node/2843367
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

