### PR TITLE
NEPT-2204: For 2.6 release of platform update date module version and remove expired patches.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -161,16 +161,12 @@ projects[customerror][subdir] = "contrib"
 projects[customerror][version] = "1.4"
 
 projects[date][subdir] = "contrib"
-projects[date][version] = "2.10"
+projects[date][version] = "2.11-beta1"
 ; Issue #2305049: Wrong timezone handling in migrate process.
 ; https://www.drupal.org/node/2305049
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-3324
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-4710
 projects[date][patch][] = https://www.drupal.org/files/issues/2305049-12.patch
-; Fix PHP 7.1 Error on Exposed Date Filter.
-; https://www.drupal.org/node/2889759
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1672
-projects[date][patch][] = https://www.drupal.org/files/issues/date-php7Offset-2889759-2.patch
 
 projects[date_ical][subdir] = "contrib"
 projects[date_ical][version] = "3.9"


### PR DESCRIPTION
## NEPT-2204

### Description
This version implement PHP7 compatibility
However we noticed some hook update, so for 2.5 we need to add only the php 7 patches.
The real module upgrade will take place in 2.6

http://cgit.drupalcode.org/date/diff/?id2=7.x-2.10&id=7.x-2.11-beta1
### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:
