### PR TITLE
NEPT-2205: PHP7 compatibility issue with mcrypt_create_iv function.

### DIFF
--- a/resources/composer.json
+++ b/resources/composer.json
@@ -5,7 +5,8 @@
     "php": ">=5.4",
     "drupol/drupal7_psr3_watchdog": "^1.0",
     "ec-europa/oe-poetry-client": "0.3.6",
-    "guzzlehttp/guzzle": "^6.2.1"
+    "guzzlehttp/guzzle": "^6.2.1",
+    "cweagans/composer-patches": "~1.0"
   },
   "require-dev": {
     "behat/behat": "~3.2",
@@ -22,6 +23,14 @@
   "autoload": {
     "psr-4": {
       "Drupal\\nexteuropa\\": "tests/src"
+    }
+  },
+  "extra": {
+    "patches": {
+      "rych/random": {
+        "https://github.com/rchouinard/rych-random/pull/5": "https://patch-diff.githubusercontent.com/raw/rchouinard/rych-random/pull/5.patch",
+        "https://github.com/rchouinard/rych-random/pull/7": "https://patch-diff.githubusercontent.com/raw/rchouinard/rych-random/pull/7.patch"
+      }
     }
   }
 }

--- a/resources/composer.lock
+++ b/resources/composer.lock
@@ -4,8 +4,52 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0d1a3118a1e3a64de9a15c8ba3795db",
+    "content-hash": "86cf78bc7bf436b0c845c25b83e02756",
     "packages": [
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "2ec4f00ff5fb64de584c8c4aea53bf9053ecb0b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/2ec4f00ff5fb64de584c8c4aea53bf9053ecb0b3",
+                "reference": "2ec4f00ff5fb64de584c8c4aea53bf9053ecb0b3",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "time": "2018-05-11T18:00:16+00:00"
+        },
         {
             "name": "drupol/drupal7_psr3_watchdog",
             "version": "1.1.0",


### PR DESCRIPTION
## NEPT-2205

### Description

mcrypt_create_iv (Deprecated 7.1, removed 7.2). Patch and update vendor (rchouinard/rych-random): https://github.com/rchouinard/rych-random/issues/3mcrypt_create_iv

### Change log

- Added:
- Changed:
resources/composer.json
- Deprecated:
- Removed:
- Fixed:
- Security:

