### PR TITLE
NEPT-2149: CLONE - NextEuropa_token_CKEditor - Ajax Exposed filters not working with multiple same views.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_piwik/README.md
+++ b/profiles/common/modules/custom/nexteuropa_piwik/README.md
@@ -54,15 +54,11 @@ There are two types of PIWIK rules:
 - **Direct path** rules are based on the direct full path of a page
 - **Regexp path** rules are based on a regular expression
   
-#### Overlapping rules <a name="overlapping-rules"></a>
-If more than one rule applies for a given page, a log entry will be
-created with the information about the overlapping rule IDs.
-
 The "Direct path" rules have a priority over the "Regexp path".
 It means that if two or more rules are applicable for the given page and
 one of them is a "Direct path" rule, that rule will be applied.
 The same rule applies to the language selection. If there is more
-than a one rule, the rule with the specific language will be selected
+than one rule, the rule with the specific language will be selected
 instead of the one with an 'all' languages option.
 
 The function that filters the rules does so by returning the first result from

--- a/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.module
+++ b/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.module
@@ -496,18 +496,6 @@ function _nexteuropa_piwik_get_regexp_path_rule($path, $lang_code) {
  *   FALSE if there is no rule for the currently processed path.
  */
 function _nexteuropa_piwik_filter_results($results, $path, $lang_code) {
-  // Log the overlapping rules case.
-  if (count($results) > 1) {
-    watchdog(
-      'nexteuropa_piwik',
-      'Overlapping PIWIK rules for the following path detected: @path. Overlapping rules IDs: @rules_ids',
-      array(
-        '@path' => $path,
-        '@rules_ids' => implode(', ', array_keys($results)),
-      ),
-      WATCHDOG_WARNING
-    );
-  }
   // Return PIWIK rule.
   $lang_code_rules = array();
   $lang_all_rules = array();

--- a/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/nexteuropa_token_ckeditor.module
+++ b/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/nexteuropa_token_ckeditor.module
@@ -278,11 +278,24 @@ function nexteuropa_token_ckeditor_custom_theme() {
  *
  * See NEPT-191: Delete the History object to avoid errors in the views
  * provided by this module only.
+ * See NEPT-2162: Internal Link popup too wide (CKEDITOR)
  */
 function nexteuropa_token_ckeditor_views_pre_render(&$view) {
   if (isset($view->export_module) && 'nexteuropa_token_ckeditor' == $view->export_module) {
     if ($view->use_ajax && !$view->editing) {
       drupal_add_js(drupal_get_path('module', 'nexteuropa_token_ckeditor') . '/js/delete_history.js', array('weight' => 1));
+    }
+  }
+  foreach ($view->result as $key => $result) {
+    if (drupal_strlen($result->node_title) >= 100) {
+      // Shorten the node title if it is too long. Only show first & last chars.
+      $result->node_title = drupal_substr($result->node_title, 0, 95) . " [...] " . drupal_substr($result->node_title, -10);
+      $view->result[$key] = $result;
+    }
+    if (drupal_strlen($result->bean_title) >= 100) {
+      // Shorten the bean title if it is too long. Only show first & last chars.
+      $result->bean_title = drupal_substr($result->bean_title, 0, 95) . " [...] " . drupal_substr($result->bean_title, -10);
+      $view->result[$key] = $result;
     }
   }
 }

--- a/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/nexteuropa_token_ckeditor.module
+++ b/profiles/common/modules/custom/nexteuropa_token/modules/nexteuropa_token_ckeditor/nexteuropa_token_ckeditor.module
@@ -287,12 +287,12 @@ function nexteuropa_token_ckeditor_views_pre_render(&$view) {
     }
   }
   foreach ($view->result as $key => $result) {
-    if (drupal_strlen($result->node_title) >= 100) {
+    if (isset($result->node_title) && drupal_strlen($result->node_title) >= 100) {
       // Shorten the node title if it is too long. Only show first & last chars.
       $result->node_title = drupal_substr($result->node_title, 0, 95) . " [...] " . drupal_substr($result->node_title, -10);
       $view->result[$key] = $result;
     }
-    if (drupal_strlen($result->bean_title) >= 100) {
+    if (isset($result->bean_title) && drupal_strlen($result->bean_title) >= 100) {
       // Shorten the bean title if it is too long. Only show first & last chars.
       $result->bean_title = drupal_substr($result->bean_title, 0, 95) . " [...] " . drupal_substr($result->bean_title, -10);
       $view->result[$key] = $result;

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.admin.inc
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.admin.inc
@@ -17,16 +17,24 @@ function nexteuropa_varnish_admin_settings_form($form, $form_state) {
   $form['purge_cache'] = array(
     '#type' => 'fieldset',
     '#title' => t('Purge caches'),
-    '#description' => t('Flush all caches (Drupal & Varnish)'),
+    '#description' => t('The operation will clear Varnish cache.
+    Click the checkbox to also clear Drupal cache.'),
   );
 
   // If the purge mechanism is prevented to work, then the button must be
   // disabled and a warning message must be displayed.
   $disabled = _nexteuropa_varnish_temporary_message();
 
+  $form['purge_cache']['purge_drupal'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Clear drupal cache as well'),
+    '#return_value' => 1,
+    '#default_value' => 0,
+  );
+
   $form['purge_cache']['purge'] = array(
     '#type' => 'submit',
-    '#value' => t('Purge all caches'),
+    '#value' => t('Purge caches'),
     '#submit' => array('nexteuropa_varnish_purge_all_confirm'),
     '#disabled' => $disabled,
   );
@@ -46,7 +54,6 @@ function nexteuropa_varnish_admin_settings_form($form, $form_state) {
   );
 
   $form['#submit'][] = 'nexteuropa_varnish_admin_settings_cache_clear_submit';
-
   return system_settings_form($form);
 }
 
@@ -63,15 +70,21 @@ function nexteuropa_varnish_admin_settings_cache_clear_submit($form, &$form_stat
  * Redirect the user from "General" page to the "purge all" confirmation form.
  */
 function nexteuropa_varnish_purge_all_confirm($form, &$form_state) {
-  $form_state['redirect'] = 'admin/config/system/nexteuropa-varnish/purge_all';
+  if ($form_state['values']['purge_drupal']) {
+    $form_state['redirect'] = 'admin/config/system/nexteuropa-varnish/purge/all';
+  }
+  else {
+    $form_state['redirect'] = 'admin/config/system/nexteuropa-varnish/purge/varnish';
+  }
 }
 
 /**
  * Generates the form allowing triggering the full cache purge.
  */
-function nexteuropa_varnish_purge_all_form($form, &$form_state) {
+function nexteuropa_varnish_purge_all_form($form, &$form_state, $arg) {
   $description = t("The action you are about to perform has a deep impact on the site's performance!");
-  $confirm_message = t("Are you sure you want to purge all site's caches (Varnish included)?");
+  $arg == 'all' ? $type = "Varnish and Drupal" : $type = "Varnish";
+  $confirm_message = t("Are you sure you want to purge !type cache ?", array('!type' => $type));
   return confirm_form($form,
     $confirm_message,
     'admin/config/system/nexteuropa-varnish/general',
@@ -82,17 +95,21 @@ function nexteuropa_varnish_purge_all_form($form, &$form_state) {
 }
 
 /**
- * Processes the full flush cache triggered by the "Purge all caches" button.
+ * Processes the flush cache triggered by the "Purge caches" button.
  *
  * @see nexteuropa_varnish_admin_settings_form()
  */
 function nexteuropa_varnish_purge_all_form_submit($form, &$form_state) {
-  $confirm_message = t('The Drupal and Varnish caches have been fully flushed.');
+  $arg = $form_state['build_info']['args'][0];
+  $arg == 'all' ? $type = "Drupal and Varnish" : $type = "Varnish";
+  $confirm_message = t('The !type caches have been fully flushed.', array('!type' => $type));
   $message_level = 'status';
   // First clear the actual backend cache (usually DrupalDatabaseCache).
   // Otherwise the web frontend cache will receive again outdated cached
   // versions of pages.
-  drupal_flush_all_caches();
+  if ($arg == 'all') {
+    drupal_flush_all_caches();
+  }
 
   // Treating Varnish flushing (inspired by "flexibe_purge" contrib module).
   $send_success = _nexteuropa_varnish_varnish_requests_send();

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -24,11 +24,11 @@ function nexteuropa_varnish_menu() {
     'file' => 'nexteuropa_varnish.admin.inc',
   );
 
-  $items['admin/config/system/nexteuropa-varnish/purge_all'] = array(
+  $items['admin/config/system/nexteuropa-varnish/purge/%'] = array(
     'title' => 'Next Europa Varnish - Purge confirmation',
-    'description' => 'Confirmation form for the varnish purge flush.',
+    'description' => 'Confirmation form for Drupal and Varnish purge.',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('nexteuropa_varnish_purge_all_form'),
+    'page arguments' => array('nexteuropa_varnish_purge_all_form', 5),
     'access callback' => '_nexteuropa_varnish_purge_all_access',
     'file' => 'nexteuropa_varnish.admin.inc',
     'type' => MENU_CALLBACK,

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/controller/tmgmt_poetry.controller.job.inc
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/controller/tmgmt_poetry.controller.job.inc
@@ -13,6 +13,29 @@
 class TMGMTPoetryJobController extends TMGMTJobController {
 
   /**
+   * When using #cart, delete all jobs and sub jobs (job items).
+   *
+   * @param array|int $ids
+   *   The job id/s.
+   * @param DatabaseTransaction|null $transaction
+   *   The transaction.
+   */
+  public function delete($ids, $transaction = NULL) {
+
+    $ids = (array) $ids;
+
+    $ids_iterate = $ids;
+    foreach ($ids_iterate as $id_iterate) {
+      $related_jobs = tmgmt_poetry_obtain_related_translation_jobs(array(), 'SUB_' . $id_iterate, TRUE)->fetchAll();
+      foreach ($related_jobs as $related_job) {
+        $ids[] = $related_job->tjid;
+      }
+    }
+
+    parent::delete($ids, $transaction);
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function save($origin_job, DatabaseTransaction $transaction = NULL) {

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.module
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.module
@@ -31,7 +31,7 @@ function tmgmt_poetry_entity_info_alter(&$entity_info) {
  */
 function _tmgmt_poetry_translator_access($op, $translator, $account) {
   if (!empty($translator) && $translator->plugin == 'poetry') {
-    if ($op == 'delete') {
+    if ($op == 'delete'  && $translator->name != 'tmgmt_poetry_test_translator') {
       return FALSE;
     }
     else {

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -828,6 +828,10 @@ projects[views][patch][] = https://www.drupal.org/files/issues/views-contextual_
 ; https://www.drupal.org/project/views/issues/2961962
 ; The patch of this issue fixes the PHP error: https://www.drupal.org/project/views/issues/2900405
 projects[views][patch][] = https://www.drupal.org/files/issues/views-check-exposed-identifier.patch
+; Issue #3012609: Ajax Exposed filters not working with multiple same views
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2149
+; https://www.drupal.org/project/views/issues/3012609
+projects[views][patch][] = https://www.drupal.org/files/issues/2018-11-14/views_fix_ajax_exposed_filter_with_same_mutliple_views-3012609-7.patch
 
 projects[views_ajax_history][subdir] = "contrib"
 projects[views_ajax_history][version] = "1.0"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -821,6 +821,10 @@ projects[views][patch][] = https://www.drupal.org/files/issues/views-contextual_
 ; Thousands of results after update to 3.18 - Put extras in parentheses, otherwise OR conditions in extras not correctly enclosed
 ; https://www.drupal.org/node/2908538
 projects[views][patch][] = https://www.drupal.org/files/issues/views-and_missing_parenthesis-2908538-2-D7.patch
+; Issue #3012609: Ajax Exposed filters not working with multiple same views
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2149
+; https://www.drupal.org/project/views/issues/3012609
+projects[views][patch][] = https://www.drupal.org/files/issues/2018-11-14/views_fix_ajax_exposed_filter_with_same_mutliple_views-3012609-7.patch
 
 projects[views_ajax_history][subdir] = "contrib"
 projects[views_ajax_history][version] = "1.0"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -831,7 +831,7 @@ projects[views][patch][] = https://www.drupal.org/files/issues/views-check-expos
 ; Issue #3012609: Ajax Exposed filters not working with multiple same views
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2149
 ; https://www.drupal.org/project/views/issues/3012609
-projects[views][patch][] = https://www.drupal.org/files/issues/2018-11-14/views_fix_ajax_exposed_filter_with_same_mutliple_views-3012609-7.patch
+projects[views][patch][] = https://www.drupal.org/files/issues/2018-12-20/ajax-exposed-filters-not-working-with-multiple-same-views-3012609-17.patch
 
 projects[views_ajax_history][subdir] = "contrib"
 projects[views_ajax_history][version] = "1.0"

--- a/tests/features/frontend_cache_purge.feature
+++ b/tests/features/frontend_cache_purge.feature
@@ -659,7 +659,7 @@ Feature:
 
   @non-moderated-content @unilingual-content @purge-rule-type-node
   Scenario: Set the 'nexteuropa_varnish_prevent_purge' variable in the setting file prevents any purge requests to be sent
-    and the "Purge all caches" button is disabled
+    and the "Purge caches" button is disabled
     Given I request to change the variable nexteuropa_varnish_prevent_purge to "TRUE"
     When I go to "node/add/editorial-team"
     And I fill in "Name" with "frontend-cache-purge-editorial-team-publish-draft"
@@ -672,7 +672,7 @@ Feature:
     And I press "Save"
     Then the web front end cache was not instructed to purge any paths
     When I go to "admin/config/system/nexteuropa-varnish/general"
-    Then the "Purge all caches" button is disabled
+    Then the "Purge caches" button is disabled
     And I should see the warning message "The purge mechanism is temporary disabled. Purge rules are still manageable but they will not be executed until it is enabled again."
     When I go to "/admin/config/system/nexteuropa-varnish/purge_rules"
     Then I should see the warning message "The purge mechanism is temporary disabled. Purge rules are still manageable but they will not be executed until it is enabled again."
@@ -690,13 +690,26 @@ Feature:
       | Basic page   | /, /all-basic-pages, /yet-another-page |
     And I should see the warning message "The purge mechanism is temporary disabled. Purge rules are still manageable but they will not be executed until it is enabled again."
 
-  # Scenario testing the "Full all caches" feature
+  # Scenario testing the "Full Varnish caches" feature
 
-  Scenario: As administrator, I want to flush all Drupal caches and Varnish through the purge admin interface
+  Scenario: As administrator, I want to flush Varnish through the purge admin interface
     When I go to "admin/config/system/nexteuropa-varnish/general"
-    And I press "Purge all caches"
-    Then I should see "Are you sure you want to purge all site's caches (Varnish included)?"
+    And I press "Purge caches"
+    Then I should see "Are you sure you want to purge Varnish cache ?"
+    And I should see "The action you are about to perform has a deep impact on the site's performance!"
+    When I press "Continue"
+    Then the web front end cache was instructed to purge completely its index for the application tag "my-website"
+    And I should see the success message "The Varnish caches have been fully flushed."
+
+  # Scenario testing the "Full all Drupal and Varnish caches" feature
+
+  Scenario: As administrator, I want to flush Drupal and Varnish through the purge admin interface
+    When I go to "admin/config/system/nexteuropa-varnish/general"
+    And I check "Clear drupal cache as well"
+    And I press "Purge caches"
+    Then I should see "Are you sure you want to purge Varnish and Drupal cache ?"
     And I should see "The action you are about to perform has a deep impact on the site's performance!"
     When I press "Continue"
     Then the web front end cache was instructed to purge completely its index for the application tag "my-website"
     And I should see the success message "The Drupal and Varnish caches have been fully flushed."
+

--- a/tests/features/multisite_create_button.feature
+++ b/tests/features/multisite_create_button.feature
@@ -1,0 +1,42 @@
+@api @javascript
+Feature: Create content button
+  In order to create content
+  As an editor
+  I can use the "Create content" element to create content
+
+  Background:
+    Given I am logged in as a user with the 'editor' role
+
+  @ec_resp_theme
+  Scenario Outline: An editor can create an article from the Create content element
+    When I go to "node"
+    Then I should see the text "Create content"
+    And I click "Create content"
+    Then I should see the text "<node_type>"
+    And I click "<node_type>"
+    Then I should see "Create <node_type>"
+    And I fill in "Title" with "<title>"
+    And I press "Save"
+    Then I should see "<title> has been created"
+
+  Examples:
+  | node_type      | title      |
+  | Article        | Node title |
+  | Basic page     | Node title |
+
+  @ec_europa_theme
+  Scenario Outline: An editor can create an article from the Create content element
+    When I go to "node"
+    Then I should see the text "Create content"
+    And I click on element "#block-multisite-create-button-create-content-button .ecl-select"
+    Then I should see the text "<node_type>"
+    And I should see "<node_type>"
+    And I click on option "<node_type>" from element "#block-multisite-create-button-create-content-button .ecl-select"
+    Then I fill in "Title" with "<title>"
+    And I press "Save"
+    Then I should see "<title> has been created"
+
+  Examples:
+  | node_type      | title      |
+  | Article        | Node title |
+  | Basic page     | Node title |

--- a/tests/features/piwik.feature
+++ b/tests/features/piwik.feature
@@ -99,10 +99,25 @@ Feature: Check Piwik
   Scenario: Assert that the regular expression based PIWIK rule is triggered and embedded correctly.
     Given the nexteuropa_piwik module is configured to use advanced PIWIK rules
     And the following PIWIK rules:
-      | Rule language | Rule path       | Rule path type | Rule section         |
-      | all           | ^content/*      | regexp         | Regexp based section |
+      | Rule language | Rule path                                     | Rule path type | Rule section         |
+      | all           | ^content/.*                                    | regexp         | Regexp based section |
+      | all           | ^content/priorities.*                          | regexp         | priorities           |
+      | all           | ^content/prioritiesstate-union-speeches.*      | regexp         | prioritiessou        |
+      | all           | ^content/prioritiesstate-union-speeches-2018.* | regexp         | prioritiessou2018    |
     And "page" content:
-      | title              | field_ne_body     | status |
-      | Testing Title no 1 | Body content no 1 | 1      |
+      | title                                    | field_ne_body          | status |
+      | Testing Title no 1                       | Body content no 1      | 1      |
+      | Priorities                               | Body content no 2      | 1      |
+      | Prioritiesstate union speeches           | Body content no 3      | 1      | 
+      | Prioritiesstate union speeches 2018      | Body content no 4      | 1      |
+      | Prioritiesstate union speeches 2018 test | Body content no 5      | 1      |
     When I go to "content/testing-title-no-1_en"
     Then the response should contain "\"siteSection\":\"Regexp based section\""
+    When I go to "content/priorities_en"
+    Then the response should contain "\"siteSection\":\"priorities\""
+    When I go to "content/prioritiesstate-union-speeches_en"
+    Then the response should contain "\"siteSection\":\"prioritiessou\""
+    When I go to "content/prioritiesstate-union-speeches-2018_en"
+    Then the response should contain "\"siteSection\":\"prioritiessou2018\""
+    When I go to "content/prioritiesstate-union-speeches-2018-test_en"
+    Then the response should contain "\"siteSection\":\"prioritiessou2018\""

--- a/tests/features/tmgmt/tmgmt_dgt_connector_cancel.feature
+++ b/tests/features/tmgmt/tmgmt_dgt_connector_cancel.feature
@@ -1,0 +1,72 @@
+@api @poetry_mock @i18n @poetry
+Feature: TMGMT Poetry features
+  In order to manage Carts translations with Poetry service
+  As an Administrator
+  I want to be able to cancel translation requests
+
+  Background:
+    Given the module is enabled
+      | modules                  |
+      | tmgmt_dgt_connector_cart |
+    And I am logged in as a user with the 'administrator' role
+    And the following languages are available:
+      | languages |
+      | en        |
+      | es        |
+      | fr        |
+    And I change the variable "nexteuropa_poetry_notification_username" to "foo"
+    And I change the variable "nexteuropa_poetry_notification_password" to "bar"
+    And I change the variable "nexteuropa_poetry_service_username" to "bar"
+    And I change the variable "nexteuropa_poetry_service_password" to "foo"
+    And I change the variable "nexteuropa_poetry_service_wsdl" to "http://localhost:28080/wsdl"
+    And Poetry service uses the following settings:
+    """
+      username: foo
+      password: bar
+    """
+    And the following Poetry settings:
+    """
+        address: http://localhost:28080/wsdl
+        method: requestService
+    """
+    And Poetry will return the following "response.status" message response:
+    """
+    identifier:
+      code: WEB
+      year: 2017
+      number: 1234
+      version: 0
+      part: 0
+      product: TRA
+    status:
+      -
+        type: request
+        code: '0'
+        date: 06/10/2017
+        time: 02:41:53
+        message: OK
+    """
+
+  Scenario: I can add contents to cart.
+    Given I go to "admin/tmgmt/dgt_cart"
+    When I am viewing a multilingual "page" content:
+      | language | title     | field_ne_body | status |
+      | en       | My page 1 | Short body    | 1      |
+    And I click "Translate" in the "primary_tabs" region
+    And I check the box on the "French" row
+    And I check the box on the "Spanish" row
+    And I press "Send to cart"
+    Then I should see the success message "1 content source was added into the cart."
+
+    When I click "cart" in the "front_messages" region
+    Then I should see "Target languages: FR, ES"
+
+    When I click "Send" in the "Target languages: FR, ES" row
+    And I press "Delete"
+    And I press "Confirm"
+    Then I should see "Deleted the translation job"
+
+    When I visit the "page" content with title "My page 1"
+    And I click "Translate" in the "primary_tabs" region
+    Then I should not see the link "In progress"
+    And I should see "Not translated" in the "Spanish" row

--- a/tests/src/Context/DrupalContext.php
+++ b/tests/src/Context/DrupalContext.php
@@ -356,6 +356,46 @@ class DrupalContext extends DrupalExtensionDrupalContext {
   }
 
   /**
+   * Click on a selector element.
+   *
+   * @param string $arg1
+   *   Selector css.
+   *
+   * @Then I click on element :arg1
+   */
+  public function iClickOnElement($arg1) {
+    $session = $this->getSession();
+    $element = $session->getPage()->find("css", $arg1);
+    if (NULL === $element) {
+      throw new \Exception(sprintf('Could not find: "%s"', $arg1));
+    }
+    $element->click();
+  }
+
+  /**
+   * Click on a selector element option.
+   *
+   * @param string $arg1
+   *   Selector css.
+   * @param string $arg2
+   *   Option text.
+   *
+   * @Then I click on option :arg1 from element :arg2
+   */
+  public function iClickOnOptionFromElement($arg1, $arg2) {
+    $session = $this->getSession();
+    $element = $session->getPage()->find("css", $arg2);
+    if (NULL === $element) {
+      throw new \Exception(sprintf('Could not find selector: "%s"', $arg2));
+    }
+    $element = $element->find("xpath", 'option[text()="' . $arg1 . '"]');
+    if (NULL === $element) {
+      throw new \Exception(sprintf('Could not find text: "%s"', $arg1));
+    }
+    $element->click();
+  }
+
+  /**
    * Creates content of the given type and a moderation state.
    *
    * @param string $type


### PR DESCRIPTION
## NEPT-2149
### Description

The problem comes from the fact that we have several CKEditor on the page.
Clicking the icon to add a link, opens the popup each time with the same view (duplicated).
The view of the nexteuropa_token_ckeditor module uses AJAX with better exposed filter.
The JS behaviors of the view module are based on the name of the view to initialize the ajax actions.
Since there are several times this same view on the page, the javascript selector is always the same and this creates a bug with the AJAX exposed filter between all the views.

### Change log

- Added: patch for views added in resources/multisite_drupal_standard.make
