### PR TITLE
NEPT-2214: Upgrade core to 7.63

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = "core"
-projects[drupal][version] = "7.60"
+projects[drupal][version] = "7.63"
 
 ; AJAX callbacks not properly working with the language url suffix.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-4268


### PR DESCRIPTION
## NEPT-2241
### Description

Upgrade core to 7.63

### Change log

- Changed: Drupal core version
