### PR TITLE
NEPT-2221: HTML tags in Webtools JSON Object field

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_json_field/nexteuropa_json_field.module
+++ b/profiles/common/modules/custom/nexteuropa_json_field/nexteuropa_json_field.module
@@ -124,8 +124,9 @@ function nexteuropa_json_field_field_formatter_view($entity_type, $entity, $fiel
       // Build element.
       foreach ($items as $delta => $item) {
         $element[$delta] = array();
-        // Use filter_xss function to avoid javascript injection.
+        // HTML tags to be allowed.
         $allowed_tags = array('b', 'strong', 'i', 'em', 'br', 'span');
+        // Use filter_xss function to avoid javascript injection.
         $element[$delta]['#markup'] = filter_xss($item['value'], $allowed_tags);
         $element[$delta]['#prefix'] = "<script type=\"application/json\">";
         $element[$delta]['#suffix'] = "</script>";

--- a/profiles/common/modules/custom/nexteuropa_json_field/nexteuropa_json_field.module
+++ b/profiles/common/modules/custom/nexteuropa_json_field/nexteuropa_json_field.module
@@ -124,7 +124,7 @@ function nexteuropa_json_field_field_formatter_view($entity_type, $entity, $fiel
       // Build element.
       foreach ($items as $delta => $item) {
         $element[$delta] = array();
-        // Strip_tags to avoid javascript injection.
+        // Use filter_xss function to avoid javascript injection.
         $allowed_tags = array('b', 'strong', 'i', 'em', 'br', 'span');
         $element[$delta]['#markup'] = filter_xss($item['value'], $allowed_tags);
         $element[$delta]['#prefix'] = "<script type=\"application/json\">";

--- a/profiles/common/modules/custom/nexteuropa_json_field/nexteuropa_json_field.module
+++ b/profiles/common/modules/custom/nexteuropa_json_field/nexteuropa_json_field.module
@@ -125,7 +125,8 @@ function nexteuropa_json_field_field_formatter_view($entity_type, $entity, $fiel
       foreach ($items as $delta => $item) {
         $element[$delta] = array();
         // Strip_tags to avoid javascript injection.
-        $element[$delta]['#markup'] = strip_tags($item['value']);
+        $allowed_tags = array('b', 'strong', 'i', 'em', 'br', 'span');
+        $element[$delta]['#markup'] = filter_xss($item['value'], $allowed_tags);
         $element[$delta]['#prefix'] = "<script type=\"application/json\">";
         $element[$delta]['#suffix'] = "</script>";
       }


### PR DESCRIPTION
## NEPT-2221

### Description
Allow tags `<b>, <strong>, <i>, <em>, <br/>, <span>` on the json filter

### Change log

- Changed: filter function of webtools render

