### PR TITLE
NEPT-2256: Link module - update list of allowed TLDs

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -440,6 +440,10 @@ projects[libraries][version] = "2.3"
 
 projects[link][subdir] = "contrib"
 projects[link][version] = "1.4"
+; Allow any TLD on url links.
+; https://www.drupal.org/project/link/issues/2299657 
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2256
+projects[link][patch][] = https://www.drupal.org/files/issues/link-2299657-for-7.x-1.4.patch
 
 projects[linkchecker][subdir] = "contrib"
 projects[linkchecker][version] = "1.3"


### PR DESCRIPTION
## NEPT-2256

### Description

Allow the use of any TLD on the urls of the field from the link module.

### Change log

- Added: patch https://www.drupal.org/files/issues/link-2299657-for-7.x-1.4.patch  from issue https://www.drupal.org/project/link/issues/2299657



