### PR TITLE
NEPT-2254: Update atomium to version 2.12

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1153,7 +1153,7 @@ projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
 projects[ec_resp][download][tag] = 2.3.9
 
 projects[atomium][type] = theme
-projects[atomium][version] = 2.11
+projects[atomium][version] = 2.12
 
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git


### PR DESCRIPTION
## NEPT-2254

### Description

Infinite loop in Atomium subtheme when discovering new templates.
With this issue is not possible build the site

### Change log

- Added:
- Changed: new atomium release 2.12
- Deprecated:
- Removed:
- Fixed:
- Security:


