### PR TITLE
Nept 2242: Workbench permissions for Contributor and Editor roles

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -924,6 +924,9 @@ projects[workbench_og][download][branch] = 7.x-2.x
 ; Issue https://www.drupal.org/project/workbench_og/issues/2006134
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1866
 projects[workbench_og][patch][] = https://www.drupal.org/files/issues/2018-06-29/workbench_og-my_drafts_missing-2006134-6.patch
+; Check access for unpublished content not included on a group.
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2242
+projects[workbench_og][patch][] = patches/workbench_og_grants.patch
 
 ; Fix version on a commit, see issue NEPT-2247
 projects[wysiwyg][subdir] = "contrib"

--- a/resources/patches/workbench_og_grants.patch
+++ b/resources/patches/workbench_og_grants.patch
@@ -1,5 +1,5 @@
 diff --git a/workbench_og.module b/workbench_og.module
-index dc2f6ca..bde0ebf 100755
+index dc2f6ca..bfe6aa3 100755
 --- a/workbench_og.module
 +++ b/workbench_og.module
 @@ -117,6 +117,22 @@ function workbench_og_node_access_records($node) {
@@ -9,7 +9,7 @@ index dc2f6ca..bde0ebf 100755
 +  else {
 +    // Assign grants to unpublished nodes that belong to no group.
 +    $roles = _workbench_og_view_authorized_roles();
-+    foreach($roles as $key => $value) {
++    foreach ($roles as $key => $value) {
 +      $grants[] = array(
 +        // Realm to view unpublished content.
 +        'realm' => 'workbench_moderation_og_view_all_unpublished',
@@ -25,7 +25,7 @@ index dc2f6ca..bde0ebf 100755
    return $grants;
  }
  
-@@ -149,6 +165,14 @@ function workbench_og_node_grants($account, $op) {
+@@ -149,7 +165,16 @@ function workbench_og_node_grants($account, $op) {
    if (user_access('view all unpublished content')) {
      // Assign grant to access content withe the user uid as gid.
      $grants['workbench_moderation_og_view_own_unpublished'][] = $account->uid;
@@ -38,23 +38,26 @@ index dc2f6ca..bde0ebf 100755
 +      }
 +    }
    }
++
    return $grants;
  }
-@@ -170,3 +194,22 @@ function workbench_og_help($path, $arg) {
+ 
+@@ -170,3 +195,23 @@ function workbench_og_help($path, $arg) {
        }
    }
  }
++
 +/**
 + * Get roles authorized to see unpublished content.
 + *
-+ *  @return array
-+ *    Array with roles ['rid' => 'role name']
++ * @return array
++ *   Array with roles ['rid' => 'role name']
 + */
 +function _workbench_og_view_authorized_roles() {
 +  $defined_roles = user_roles();
 +  $authorized_roles = array();
 +
-+  foreach($defined_roles as  $key => $value) {
++  foreach ($defined_roles as $key => $value) {
 +    $roles = user_role_permissions(array($key => $value));
 +    if (isset($roles[$key]['view all unpublished content']) && $roles[$key]['view all unpublished content'] == 1) {
 +      $authorized_roles[$key] = $value;

--- a/resources/patches/workbench_og_grants.patch
+++ b/resources/patches/workbench_og_grants.patch
@@ -1,0 +1,61 @@
+diff --git a/workbench_og.module b/workbench_og.module
+index dc2f6ca..4b1f56a 100755
+--- a/workbench_og.module
++++ b/workbench_og.module
+@@ -117,6 +117,22 @@ function workbench_og_node_access_records($node) {
+       );
+     }
+   }
++  else {
++    // Assign grants to unpublished nodes that belong to no group.
++    $roles = _workbench_og_view_unpublished_roles();
++    foreach($roles as $key => $value) {
++      $grants[] = array(
++        // Realm to view unpublished content.
++        'realm' => 'workbench_moderation_og_view_all_unpublished',
++        // Assign role gid.
++        'gid' => $key,
++        'grant_view' => 1,
++        'grant_update' => 0,
++        'grant_delete' => 0,
++        'priority' => 2,
++      ); 
++    }
++  }
+   return $grants;
+ }
+ 
+@@ -149,6 +165,14 @@ function workbench_og_node_grants($account, $op) {
+   if (user_access('view all unpublished content')) {
+     // Assign grant to access content withe the user uid as gid.
+     $grants['workbench_moderation_og_view_own_unpublished'][] = $account->uid;
++    // Assign grant to access unpublished content.
++    $roles = _workbench_og_view_unpublished_roles();
++    $enabled_roles = array_intersect($roles, $account->roles);
++    if (count($enabled_roles) > 0) {
++      foreach ($enabled_roles as $key => $value) {
++        $grants['workbench_moderation_og_view_all_unpublished'][] = $key;
++      }
++    }
+   }
+   return $grants;
+ }
+@@ -170,3 +194,18 @@ function workbench_og_help($path, $arg) {
+       }
+   }
+ }
++/**
++ * Get roles authorized to see unpublished content.
++ * 
++ *  @return array
++ *    Array with roles ['rid' => 'role name']
++ */ 
++function _workbench_og_view_unpublished_roles() {
++  $defined_roles = user_roles();
++  $authorized_roles = array();
++  foreach($defined_roles as  $key => $value) {
++    $roles = user_role_permissions(array($key => $value));
++    isset($roles[$key]['view all unpublished content']) && $roles[$key]['view all unpublished content'] == 1 ? $authorized_roles[$key] = $value : FALSE;
++  }
++  return $authorized_roles;
++}

--- a/resources/patches/workbench_og_grants.patch
+++ b/resources/patches/workbench_og_grants.patch
@@ -1,8 +1,8 @@
 diff --git a/workbench_og.module b/workbench_og.module
-index dc2f6ca..bfe6aa3 100755
+index dc2f6ca..d82a5f8 100755
 --- a/workbench_og.module
 +++ b/workbench_og.module
-@@ -117,6 +117,22 @@ function workbench_og_node_access_records($node) {
+@@ -117,6 +117,23 @@ function workbench_og_node_access_records($node) {
        );
      }
    }
@@ -22,10 +22,11 @@ index dc2f6ca..bfe6aa3 100755
 +      );
 +    }
 +  }
++
    return $grants;
  }
  
-@@ -149,7 +165,16 @@ function workbench_og_node_grants($account, $op) {
+@@ -149,7 +166,16 @@ function workbench_og_node_grants($account, $op) {
    if (user_access('view all unpublished content')) {
      // Assign grant to access content withe the user uid as gid.
      $grants['workbench_moderation_og_view_own_unpublished'][] = $account->uid;
@@ -42,7 +43,7 @@ index dc2f6ca..bfe6aa3 100755
    return $grants;
  }
  
-@@ -170,3 +195,23 @@ function workbench_og_help($path, $arg) {
+@@ -170,3 +196,23 @@ function workbench_og_help($path, $arg) {
        }
    }
  }

--- a/resources/patches/workbench_og_grants.patch
+++ b/resources/patches/workbench_og_grants.patch
@@ -1,5 +1,5 @@
 diff --git a/workbench_og.module b/workbench_og.module
-index dc2f6ca..4b1f56a 100755
+index dc2f6ca..bde0ebf 100755
 --- a/workbench_og.module
 +++ b/workbench_og.module
 @@ -117,6 +117,22 @@ function workbench_og_node_access_records($node) {
@@ -8,7 +8,7 @@ index dc2f6ca..4b1f56a 100755
    }
 +  else {
 +    // Assign grants to unpublished nodes that belong to no group.
-+    $roles = _workbench_og_view_unpublished_roles();
++    $roles = _workbench_og_view_authorized_roles();
 +    foreach($roles as $key => $value) {
 +      $grants[] = array(
 +        // Realm to view unpublished content.
@@ -19,7 +19,7 @@ index dc2f6ca..4b1f56a 100755
 +        'grant_update' => 0,
 +        'grant_delete' => 0,
 +        'priority' => 2,
-+      ); 
++      );
 +    }
 +  }
    return $grants;
@@ -30,7 +30,7 @@ index dc2f6ca..4b1f56a 100755
      // Assign grant to access content withe the user uid as gid.
      $grants['workbench_moderation_og_view_own_unpublished'][] = $account->uid;
 +    // Assign grant to access unpublished content.
-+    $roles = _workbench_og_view_unpublished_roles();
++    $roles = _workbench_og_view_authorized_roles();
 +    $enabled_roles = array_intersect($roles, $account->roles);
 +    if (count($enabled_roles) > 0) {
 +      foreach ($enabled_roles as $key => $value) {
@@ -40,22 +40,26 @@ index dc2f6ca..4b1f56a 100755
    }
    return $grants;
  }
-@@ -170,3 +194,18 @@ function workbench_og_help($path, $arg) {
+@@ -170,3 +194,22 @@ function workbench_og_help($path, $arg) {
        }
    }
  }
 +/**
 + * Get roles authorized to see unpublished content.
-+ * 
++ *
 + *  @return array
 + *    Array with roles ['rid' => 'role name']
-+ */ 
-+function _workbench_og_view_unpublished_roles() {
++ */
++function _workbench_og_view_authorized_roles() {
 +  $defined_roles = user_roles();
 +  $authorized_roles = array();
++
 +  foreach($defined_roles as  $key => $value) {
 +    $roles = user_role_permissions(array($key => $value));
-+    isset($roles[$key]['view all unpublished content']) && $roles[$key]['view all unpublished content'] == 1 ? $authorized_roles[$key] = $value : FALSE;
++    if (isset($roles[$key]['view all unpublished content']) && $roles[$key]['view all unpublished content'] == 1) {
++      $authorized_roles[$key] = $value;
++    }
 +  }
++
 +  return $authorized_roles;
 +}


### PR DESCRIPTION
## NEPT-2242
### Description

Workbench permissions for Contributor and Editor roles

### Change log

- Added: Patch to change views in workbench

### Commands

`drush php-eval 'node_access_rebuild();'`
Or manually on url: "admin/reports/status/rebuild"

