### PR TITLE
NEPT-2261: Fix introduced issues with AJAX for exposed filters

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -825,10 +825,11 @@ projects[views][patch][] = https://www.drupal.org/files/issues/views-contextual_
 ; Thousands of results after update to 3.18 - Put extras in parentheses, otherwise OR conditions in extras not correctly enclosed
 ; https://www.drupal.org/node/2908538
 projects[views][patch][] = https://www.drupal.org/files/issues/views-and_missing_parenthesis-2908538-2-D7.patch
-; Issue #3012609: Ajax Exposed filters not working with multiple same views
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2149
+; Issue #3012609: Issues with AJAX for exposed filters
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2261
 ; https://www.drupal.org/project/views/issues/3012609
-projects[views][patch][] = https://www.drupal.org/files/issues/2018-11-14/views_fix_ajax_exposed_filter_with_same_mutliple_views-3012609-7.patch
+; https://www.drupal.org/project/views/issues/1809958
+projects[views][patch][] = https://www.drupal.org/files/issues/2019-03-04/issues-ajax-exposed-filters-blocks-1809958-68.patch
 
 projects[views_ajax_history][subdir] = "contrib"
 projects[views_ajax_history][version] = "1.0"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -829,7 +829,7 @@ projects[views][patch][] = https://www.drupal.org/files/issues/views-and_missing
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2261
 ; https://www.drupal.org/project/views/issues/3012609
 ; https://www.drupal.org/project/views/issues/1809958
-projects[views][patch][] = https://www.drupal.org/files/issues/2019-03-04/issues-ajax-exposed-filters-blocks-1809958-68.patch
+projects[views][patch][] = patches/issues-ajax-exposed-filters-blocks.patch
 
 projects[views_ajax_history][subdir] = "contrib"
 projects[views_ajax_history][version] = "1.0"

--- a/resources/patches/issues-ajax-exposed-filters-blocks.patch
+++ b/resources/patches/issues-ajax-exposed-filters-blocks.patch
@@ -1,0 +1,25 @@
+diff --git a/js/ajax_view.js b/js/ajax_view.js
+index aa10a00..a6d2293 100644
+--- a/js/ajax_view.js
++++ b/js/ajax_view.js
+@@ -57,7 +57,7 @@ Drupal.views.ajaxView = function(settings) {
+   this.settings = settings;
+ 
+   // Add the ajax to exposed forms.
+-  this.$exposed_form = $('#views-exposed-form-'+ settings.view_name.replace(/_/g, '-') + '-' + settings.view_display_id.replace(/_/g, '-'));
++  this.$exposed_form = $('.exp-dom-id-' + settings.view_dom_id + '#views-exposed-form-'+ settings.view_name.replace(/_/g, '-') + '-' + settings.view_display_id.replace(/_/g, '-'));
+   this.$exposed_form.once(jQuery.proxy(this.attachExposedFormAjax, this));
+ 
+   // Store Drupal.ajax objects here for all pager links.
+diff --git a/views.module b/views.module
+index 2093aa7..caf1175 100644
+--- a/views.module
++++ b/views.module
+@@ -2071,6 +2071,7 @@ function views_exposed_form($form, &$form_state) {
+   $form['#theme'] = views_theme_functions('views_exposed_form', $view, $display);
+   $form['#id'] = drupal_clean_css_identifier('views_exposed_form-' . check_plain($view->name) . '-' . check_plain($display->id));
+ //  $form['#attributes']['class'] = array('views-exposed-form');
++  $form['#attributes']['class'][] = 'exp-dom-id-' . $view->dom_id;
+ 
+   // If using AJAX, we need the form plugin.
+   if ($view->use_ajax) {


### PR DESCRIPTION
## NEPT-2261

### Description

Fixed platform 2.5.124 introduced issues with AJAX for exposed filters blocks.

### Change log
- Fixed: ajax filtering by adding dom_id to exposed form and change selector for ajax to match


