### PR TITLE
NEPT-2257: updated admin_menu version to 3.0-rc6

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -12,7 +12,7 @@ includes[] = "drupal-core.make"
 ; ===================
 
 projects[admin_menu][subdir] = "contrib"
-projects[admin_menu][version] = "3.0-rc5"
+projects[admin_menu][version] = "3.0-rc6"
 
 projects[administration_language_negotiation][subdir] = "contrib"
 projects[administration_language_negotiation][version] = "1.4"


### PR DESCRIPTION
## NEPT-2257

### Description

admin menu generates errors on php7

### Change log

- Changed: admin menu version to 7.x-3.0-rc6

