### PR TITLE
NEPT-2253: Enable mpdf change location of ttfont directories.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -618,7 +618,7 @@ projects[print][version] = "2.2"
 ; Allow alternate location of ttfont directories
 ; https://www.drupal.org/project/print/issues/3036143
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2253
-projects[redirect][patch][] = https://www.drupal.org/files/issues/2019-02-27/location_ttfont_directories-3036143-1.patch
+projects[print][patch][] = https://www.drupal.org/files/issues/2019-02-27/location_ttfont_directories-3036143-1.patch
 
 projects[quicktabs][subdir] = "contrib"
 projects[quicktabs][version] = "3.8"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -615,6 +615,10 @@ projects[plupload][patch][] = https://www.drupal.org/files/issues/2018-05-22/fil
 
 projects[print][subdir] = "contrib"
 projects[print][version] = "2.2"
+; Allow alternate location of ttfont directories
+; https://www.drupal.org/project/print/issues/3036143
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2253
+projects[redirect][patch][] = https://www.drupal.org/files/issues/2019-02-27/location_ttfont_directories-3036143-1.patch
 
 projects[quicktabs][subdir] = "contrib"
 projects[quicktabs][version] = "3.8"


### PR DESCRIPTION
## NEPT-2253

### Description

Folder profiles/multisite_drupal_standard/libraries/mpdf/ttfontdata is used to save mpdf font datas. Downloaded files must not be present on profile folder, and it generate big diff during deployment.

### Change log

- Removed: Unused code that was loading the lib before usage.
- Fixed: Generated files in ttfontdata are now saved in files folder.


