### PR TITLE
NEPT-2263: Upgrade context module to version 3.10

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -147,7 +147,7 @@ projects[colors][subdir] = "contrib"
 projects[colors][version] = "1.0-rc1"
 
 projects[context][subdir] = "contrib"
-projects[context][version] = "3.7"
+projects[context][version] = "3.10"
 projects[context][patch][] = https://www.drupal.org/files/issues/massively-increase-pe-reroll-873936-67.patch
 
 projects[context_entity_field][subdir] = "contrib"


### PR DESCRIPTION
## NEPT-2263

### Description

Upgrade of Context module from 3.7 to 3.10.

### Change log

- Changed: context version to 7.x-3.10

