### PR TITLE
NEPT-510: multisite_drupal_standard is useless.

### DIFF
--- a/profiles/common/modules/features/multisite_settings/multisite_settings_standard/multisite_settings_standard.info
+++ b/profiles/common/modules/features/multisite_settings/multisite_settings_standard/multisite_settings_standard.info
@@ -3,5 +3,4 @@ description = Multisite standard settings
 core = 7.x
 package = Multisite Standard Features
 features[features_api][] = api:2
-dependencies[] = multisite_settings_core
 mtime = 1418979432

--- a/profiles/multisite_drupal_standard/multisite_drupal_standard.info
+++ b/profiles/multisite_drupal_standard/multisite_drupal_standard.info
@@ -101,7 +101,6 @@ dependencies[] = nexteuropa_feature_set
 ; Features.
 dependencies[] = cce_basic_config
 dependencies[] = multisite_settings_core
-dependencies[] = multisite_settings_standard
 dependencies[] = multisite_autosave
 dependencies[] = multisite_custom_error
 dependencies[] = ecas_env


### PR DESCRIPTION
## NEPT-510

### Description

The feature multisite_drupal_standard is empty and has to be removed from the platform. 
- Remove dependency to multisite_settings_core to avoid issues at uninstall (release-2.5.137)
- Uninstall it from all subsites in the fpfis-scheduler script for 2.6
- Remove the code in the next major release (release-2.6)

### Change log

- Removed: dependencies of the module to avoid issues while uninstalling.

