### PR TITLE
NEPT-2243: Error in CKEditor with Rules

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -465,6 +465,11 @@ projects[media][version] = 2.20
 ; Media markup navigation causes duplicated links
 projects[media][patch][] = https://www.drupal.org/files/issues/media-delete-embedded-document-2028231-11.patch
 
+; Ensure the media_wysiwyg.filter.js is loaded.
+; https://www.drupal.org/project/media/issues/3039731
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1545
+projects[media][patch][] = https://www.drupal.org/files/issues/2019-03-13/add-js-library-3039731-1.patch
+
 projects[media_avportal][subdir] = "contrib"
 projects[media_avportal][version] = "1.3"
 

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -467,7 +467,7 @@ projects[media][patch][] = https://www.drupal.org/files/issues/media-delete-embe
 
 ; Ensure the media_wysiwyg.filter.js is loaded.
 ; https://www.drupal.org/project/media/issues/3039731
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1545
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2243
 projects[media][patch][] = https://www.drupal.org/files/issues/2019-03-13/add-js-library-3039731-1.patch
 
 projects[media_avportal][subdir] = "contrib"


### PR DESCRIPTION
## NEPT-2243

### Description

Ensure the library media_wysiwyg.filter.js  is loaded

### Change log

- Added: patch https://www.drupal.org/files/issues/2019-03-13/add-js-library-3039731-1.patch


