### PR TITLE
NEPT-571: Remove current_search from profile dependencies

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.info
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.info
@@ -6,7 +6,6 @@ dependencies[] = better_formats
 dependencies[] = comment
 dependencies[] = context
 dependencies[] = ctools
-dependencies[] = current_search
 dependencies[] = date
 dependencies[] = date_popup
 dependencies[] = easy_breadcrumb

--- a/profiles/common/modules/features/solr_config/solr_config.info
+++ b/profiles/common/modules/features/solr_config/solr_config.info
@@ -4,6 +4,7 @@ core = 7.x
 package = Multisite Core Features
 dependencies[] = apachesolr_search
 dependencies[] = ctools
+dependencies[] = current_search
 dependencies[] = facetapi
 dependencies[] = features
 dependencies[] = menu

--- a/profiles/multisite_drupal_communities/multisite_drupal_communities.info
+++ b/profiles/multisite_drupal_communities/multisite_drupal_communities.info
@@ -16,7 +16,6 @@ dependencies[] = context_layouts
 dependencies[] = context_ui
 dependencies[] = contextual
 dependencies[] = ctools
-dependencies[] = current_search
 dependencies[] = dashboard
 dependencies[] = date
 dependencies[] = diff

--- a/profiles/multisite_drupal_standard/multisite_drupal_standard.info
+++ b/profiles/multisite_drupal_standard/multisite_drupal_standard.info
@@ -26,7 +26,6 @@ dependencies[] = ctools
 dependencies[] = token
 dependencies[] = facetapi
 dependencies[] = fast_404
-dependencies[] = current_search
 dependencies[] = context
 dependencies[] = context_ui
 dependencies[] = context_layouts


### PR DESCRIPTION
## NEPT-571

### Description

Remove current_search from profile dependencies

### Change log

- Removed: current_search has been removed from profile dependencies


