### PR TITLE
NEPT-2160: ECAS Login fails with active EU Login session

### DIFF
--- a/profiles/common/modules/custom/ecas/libraries/phpcas/CAS/Client.php
+++ b/profiles/common/modules/custom/ecas/libraries/phpcas/CAS/Client.php
@@ -1610,7 +1610,7 @@ class CAS_Client
      *
      * @return void
      */
-    public function redirectToCas($gateway=false,$renew=false)
+    public function redirectToCas($gateway=false,$renew=true)
     {
         phpCAS::traceBegin();
         $cas_url = $this->getServerLoginURL($gateway, $renew);


### PR DESCRIPTION
## NEPT-2160

### Description

When a user tries to log using ecas, always renew the session to force login on ecas, if the session on the site is closed.

### Change log

- Changed: CAS_Client::redirectToCas($gateway=false,$renew=false) to CAS_Client::redirectToCas($gateway=false,$renew=true)  


