### PR TITLE
NEPT-2318: Upgrade views to 3.21 for release-2.5. 

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -824,22 +824,25 @@ projects[video][patch][] = patches/video-revert_issue-1891012-0.patch
 projects[video][patch][] = patches/video-security-883.patch
 
 projects[views][subdir] = "contrib"
-projects[views][version] = 3.18
-
+projects[views][version] = 3.21
 ; Error when configuring exposed group filter: "The value is required if title for this item is defined."
 ; https://www.drupal.org/node/1818176
 projects[views][patch][] = https://www.drupal.org/files/issues/views-erroneous_empty_not_empty_filter_error-1818176-37.patch
 ; Default argument not skipped in breadcrumbs
 ; https://www.drupal.org/node/1201160
 projects[views][patch][] = https://www.drupal.org/files/issues/views-contextual_filter_exception_breadcrumbs-1201160-17.patch
-; Thousands of results after update to 3.18 - Put extras in parentheses, otherwise OR conditions in extras not correctly enclosed
-; https://www.drupal.org/node/2908538
-projects[views][patch][] = https://www.drupal.org/files/issues/views-and_missing_parenthesis-2908538-2-D7.patch
-; Issue #3012609: Issues with AJAX for exposed filters
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2261
+; Reset of Exposed Published Status filter with "Remember last selection" results in:
+; Undefined index: status in views_handler_filter->store_exposed_input()
+; https://www.drupal.org/project/views/issues/2961962
+; The patch of this issue fixes the PHP error: https://www.drupal.org/project/views/issues/2900405
+projects[views][patch][] = https://www.drupal.org/files/issues/views-check-exposed-identifier.patch
+; Issue #3012609: Ajax Exposed filters not working with multiple same views
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2149
 ; https://www.drupal.org/project/views/issues/3012609
-; https://www.drupal.org/project/views/issues/1809958
-projects[views][patch][] = patches/issues-ajax-exposed-filters-blocks.patch
+projects[views][patch][] = https://www.drupal.org/files/issues/2018-12-20/ajax-exposed-filters-not-working-with-multiple-same-views-3012609-17.patch
+; Issue #3039953: PHP 5.3.x fix for syntax changes Views 3.21
+; https://www.drupal.org/project/views/issues/3039953
+projects[views][patch][] = https://www.drupal.org/files/issues/2019-03-13/3039953-25.patch
 
 projects[views_ajax_history][subdir] = "contrib"
 projects[views_ajax_history][version] = "1.0"


### PR DESCRIPTION
## NEPT-2318

### Description

Upgrade views to the last version. It includes 3 security patches so the upgrade (or a security patch) must be included also in 2.4 and 2.5.

### Change log

- Changed: resources/multisite_drupal_standard.make