### PR TITLE
NEPT-2325: Upgrade video to latest release

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -773,7 +773,7 @@ projects[variable][subdir] = "contrib"
 projects[variable][version] = "2.5"
 
 projects[video][subdir] = "contrib"
-projects[video][version] = "2.11"
+projects[video][version] = "2.14"
 projects[video][patch][] = patches/video-revert_issue-1891012-0.patch
 projects[video][patch][] = patches/video-security-883.patch
 


### PR DESCRIPTION
## NEPT-2325

### Description

Upgrade video module from 2.11 to 2.14. The upgrade contains a security patch.

### Change log

- Changed: resources/multisite_drupal_standard.make
