### PR TITLE
NEPT-2359: Update drupal core version to 7.65.

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = "core"
-projects[drupal][version] = "7.64"
+projects[drupal][version] = "7.65"
 
 ; AJAX callbacks not properly working with the language url suffix.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-4268


### PR DESCRIPTION
## NEPT-2359

### Description

Update drupal core version to 7.65 to fix cross-site scripting (XSS) vulnerability SA-CORE-2019-004.

### Change log

- Changed: Drupal core version in drupal-core.make
- Security: Fix cross-site scripting (XSS) vulnerability SA-CORE-2019-004


