### PR TITLE
NEPT-2315: Add patch for php7.2 warning

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -188,6 +188,8 @@ projects[easy_breadcrumb][version] = "2.15"
 ; Issue #2973420 : 	Undefined index: html in template_preprocess_easy_breadcrumb()
 ; https://www.drupal.org/node/2973420
 projects[easy_breadcrumb][patch][] = https://www.drupal.org/files/issues/2018-05-16/easy_breadcrumb-undefined_index_html-2973420-2.patch
+; Issue #3043400 : Warning: count() on empty breadcrumb
+; https://www.drupal.org/node/3043400
 projects[easy_breadcrumb][patch][] = https://www.drupal.org/files/issues/2019-03-26/easy-breadcrumb-php72-count-warning-3043400-5.patch
 
 projects[email][subdir] = "contrib"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -190,6 +190,7 @@ projects[easy_breadcrumb][version] = "2.15"
 projects[easy_breadcrumb][patch][] = https://www.drupal.org/files/issues/2018-05-16/easy_breadcrumb-undefined_index_html-2973420-2.patch
 ; Issue #3043400 : Warning: count() on empty breadcrumb
 ; https://www.drupal.org/node/3043400
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2315
 projects[easy_breadcrumb][patch][] = https://www.drupal.org/files/issues/2019-03-26/easy-breadcrumb-php72-count-warning-3043400-5.patch
 
 projects[email][subdir] = "contrib"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -188,6 +188,7 @@ projects[easy_breadcrumb][version] = "2.15"
 ; Issue #2973420 : 	Undefined index: html in template_preprocess_easy_breadcrumb()
 ; https://www.drupal.org/node/2973420
 projects[easy_breadcrumb][patch][] = https://www.drupal.org/files/issues/2018-05-16/easy_breadcrumb-undefined_index_html-2973420-2.patch
+projects[easy_breadcrumb][patch][] = https://www.drupal.org/files/issues/2019-03-26/easy-breadcrumb-php72-count-warning-3043400-5.patch
 
 projects[email][subdir] = "contrib"
 projects[email][version] = "1.3"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -184,14 +184,7 @@ projects[ds][subdir] = "contrib"
 projects[ds][version] = "2.15"
 
 projects[easy_breadcrumb][subdir] = "contrib"
-projects[easy_breadcrumb][version] = "2.15"
-; Issue #2973420 : 	Undefined index: html in template_preprocess_easy_breadcrumb()
-; https://www.drupal.org/node/2973420
-projects[easy_breadcrumb][patch][] = https://www.drupal.org/files/issues/2018-05-16/easy_breadcrumb-undefined_index_html-2973420-2.patch
-; Issue #3043400 : Warning: count() on empty breadcrumb
-; https://www.drupal.org/node/3043400
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2315
-projects[easy_breadcrumb][patch][] = https://www.drupal.org/files/issues/2019-03-26/easy-breadcrumb-php72-count-warning-3043400-5.patch
+projects[easy_breadcrumb][version] = "2.16"
 
 projects[email][subdir] = "contrib"
 projects[email][version] = "1.3"


### PR DESCRIPTION
## NEPT-2315 (UPDATED)

### Patch count() notice on easy breadcrumb module

Applied patch for easy breadcrumb module:
https://www.drupal.org/project/easy_breadcrumb/issues/3043400

**UPDATE: Removed patches in favour of upgrading to the newly-released latest version**

### Change log

- Changed: multisite_drupal_standard.make
