### PR TITLE
NEPT-2280: Upgrade composer lock for ex-tidy only.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1886,7 +1886,7 @@
         "ext-json": "*",
         "ext-phar": "*",
         "ext-xml": "*",
-        "ext-tidy": "^2.0"
+        "ext-tidy": "*"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
## NEPT-2280

Update lock file for ex-tidy

### Change log

- Changed: composer.lock

