### PR TITLE
NEPT-2399: Not removing slash if redirect target is external.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -647,6 +647,9 @@ projects[redirect][subdir] = "contrib"
 ; In order to be able to #1396446 patch the module we need to point to the latest dev commit.
 projects[redirect][download][branch] = 7.x-1.x
 projects[redirect][download][revision] = add3c695f613fbeec23b7259e59936f60a6b6da6
+; Target URL modified when implementing redirection using Redirect module
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2399
+projects[redirect][patch][] = patches/target-modified-implementing-redirection.patch
 ; Increase size of source field to hold long URLs
 ; https://www.drupal.org/project/redirect/issues/2057615
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1943

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -646,14 +646,10 @@ projects[realname][version] = "1.3"
 projects[redirect][subdir] = "contrib"
 ; In order to be able to #1396446 patch the module we need to point to the latest dev commit.
 projects[redirect][download][branch] = 7.x-1.x
-projects[redirect][download][revision] = add3c695f613fbeec23b7259e59936f60a6b6da6
+projects[redirect][download][revision] = d5c95c2112f05d1a31c2f10bc921c633110c8a91
 ; Target URL modified when implementing redirection using Redirect module
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2399
 projects[redirect][patch][] = patches/target-modified-implementing-redirection.patch
-; Increase size of source field to hold long URLs
-; https://www.drupal.org/project/redirect/issues/2057615
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1943
-projects[redirect][patch][] = https://www.drupal.org/files/issues/2018-06-24/redirect-increase-size-fields-to-900-2057615-35.patch
 ; Prevent new redirects from being deleted on cron runs.
 ; https://www.drupal.org/node/1396446
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1945

--- a/resources/patches/target-modified-implementing-redirection.patch
+++ b/resources/patches/target-modified-implementing-redirection.patch
@@ -1,0 +1,27 @@
+diff --git a/redirect.module b/redirect.module
+index 5d92399..311e7a7 100644
+--- a/redirect.module
++++ b/redirect.module
+@@ -1430,6 +1430,8 @@ function redirect_variables() {
+ 
+ function redirect_parse_url($url) {
+   $original_url = $url;
++  $is_external = url_is_external($url);
++  
+   $url = trim($url, " \t\n\r\0\x0B\/");
+   $parsed = parse_url($url);
+ 
+@@ -1456,7 +1458,12 @@ function redirect_parse_url($url) {
+     }
+   }
+ 
+-  $url = trim($url, '/');
++  // At this point, a URL with a query or fragment may still have a trailing
++  // slash. Trim the trailing slash from "internal" Drupal paths (and other
++  // local paths).
++  if (!$is_external) {
++    $url = trim($url, '/');
++  }
+ 
+   // Convert to frontpage paths.
+   if ($url == '<front>') {


### PR DESCRIPTION
## NEPT-2399

### Description

Target URL was modified when implementing redirection using Redirect module, so we are not removing slash if redirected target is external.

### Change log

- Added: Patch target-modified-implementing-redirection.patch.
- Removed: https://www.drupal.org/files/issues/2018-06-24/redirect-increase-size-fields-to-900-2057615-35.patch.
- Changed: Redirect module version to commit d5c9521.
