### PR TITLE
NEPT-2374: Update Atomium to latest stable version.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -197,11 +197,7 @@ projects[ds][subdir] = "contrib"
 projects[ds][version] = "2.15"
 
 projects[easy_breadcrumb][subdir] = "contrib"
-projects[easy_breadcrumb][version] = "2.12"
-; Issue #2290941 : Breadcrumb shows escaped HTML tags on core admin pages
-; https://www.drupal.org/node/2290941
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-6753
-projects[easy_breadcrumb][patch][] = https://www.drupal.org/files/issues/check-plain-vs-filter-xss_0_1.patch
+projects[easy_breadcrumb][version] = "2.16"
 
 projects[email][subdir] = "contrib"
 projects[email][version] = "1.3"
@@ -1167,12 +1163,12 @@ projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
 projects[ec_resp][download][tag] = 2.3.9
 
 projects[atomium][type] = theme
-projects[atomium][version] = 2.12
+projects[atomium][version] = 2.19
 
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
-projects[ec_europa][download][tag] = 0.0.14
+projects[ec_europa][download][tag] = 0.1.3
 
 ; ==============
 ; Custom modules

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1163,12 +1163,12 @@ projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
 projects[ec_resp][download][tag] = 2.3.9
 
 projects[atomium][type] = theme
-projects[atomium][version] = 2.19
+projects[atomium][version] = 2.22
 
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
-projects[ec_europa][download][tag] = 0.1.3
+projects[ec_europa][download][tag] = 0.1.5
 
 ; ==============
 ; Custom modules


### PR DESCRIPTION
## NEPT-3274

### Description

Update Atomium, Europa theme and Easy Breadcrumb to latest stable version.

### Change log

- Changed: Atomium, Europa theme and Easy Breadcrumb version.
- Removed: patch https://www.drupal.org/files/issues/check-plain-vs-filter-xss_0_1.patch.

