### PR TITLE
NEPT-1114: Remove last reference to continuousphp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://status.continuousphp.com/git-hub/ec-europa/platform-dev?token=4df2e996-5362-486e-b409-84527de6a65b&branch=develop)](https://continuousphp.com/git-hub/ec-europa/platform-dev)
-
 # NextEuropa
 
 ## Requirements


### PR DESCRIPTION
## NEPT-1114

### Description

Follow-up: remove continuousphp mentions from platform.

### Change log

- Removed: Reference to continuousphp from README.md


