### PR TITLE
NEPT-2314: Patch disappearing background

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -245,9 +245,9 @@ projects[eu_cookie_compliance][subdir] = "contrib"
 projects[eu_cookie_compliance][version] = "1.14"
 projects[eu_cookie_compliance][patch][] = patches/eu_cookie_compliance_nept-2299.patch
 ; Fix disappearing background in popup
-; https://www.drupal.org/node/1705230
+; https://www.drupal.org/node/2498251
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2314
-projects[eu_cookie_compliance][patch][] = https://www.drupal.org/files/issues/eu_cookie_compliance-fix_background-1705230-12-d7.patch
+projects[eu_cookie_compliance][patch][] = https://www.drupal.org/files/issues/eu_cookie_compliance-popup_overflow-2498251-2.patch
 
 projects[extlink][subdir] = "contrib"
 projects[extlink][version] = "1.18"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -244,6 +244,10 @@ projects[entityreference_prepopulate][patch][] = https://www.drupal.org/files/is
 projects[eu_cookie_compliance][subdir] = "contrib"
 projects[eu_cookie_compliance][version] = "1.14"
 projects[eu_cookie_compliance][patch][] = patches/eu_cookie_compliance_nept-2299.patch
+; Fix disappearing background in popup
+; https://www.drupal.org/node/1705230
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2314
+projects[eu_cookie_compliance][patch][] = https://www.drupal.org/files/issues/eu_cookie_compliance-fix_background-1705230-12-d7.patch
 
 projects[extlink][subdir] = "contrib"
 projects[extlink][version] = "1.18"


### PR DESCRIPTION
## NEPT-2314

### Patch for popup background issue

Popup background disappeared because of collapsing container, causing the message to be invisible (white text on white background) on the default theme

### Change log

- Changed: multisite_drupal_standard.make
