### PR TITLE
NEPT-1905: Add same atomium + ec_europa in current profile as in common.

### DIFF
--- a/build.package.xml
+++ b/build.package.xml
@@ -290,6 +290,14 @@
         <gitcheckout
             repository="${platform.resources.profiles.common.themes.dir}/ec_europa"
             branchname="${platform.theme.europa.repo.branch}"/>
+
+        <!-- Deleting the theme directories from the current profile -->
+        <delete dir="profiles/${platform.profile.name}/themes/atomium" quiet="true"/>
+        <delete dir="profiles/${platform.profile.name}/themes/ec_europa" quiet="true"/>
+
+        <!-- Symlinc the atomium and ec_europa theme from the common profile folder -->
+        <symlink link="profiles/${platform.profile.name}/themes/atomium" target="${platform.resources.profiles.common.themes.dir}/atomium" />
+        <symlink link="profiles/${platform.profile.name}/themes/ec_europa" target="${platform.resources.profiles.common.themes.dir}/ec_europa" />
     </target>
 
     <!-- Generating assets -->

--- a/build.package.xml
+++ b/build.package.xml
@@ -291,13 +291,33 @@
             repository="${platform.resources.profiles.common.themes.dir}/ec_europa"
             branchname="${platform.theme.europa.repo.branch}"/>
 
-        <!-- Delete the theme directories from the current profile -->
-        <delete dir="profiles/${platform.profile.name}/themes/atomium" quiet="true"/>
-        <delete dir="profiles/${platform.profile.name}/themes/ec_europa" quiet="true"/>
-
-        <!-- Symlink the atomium and ec_europa theme from the "common" profile folder -->
-        <symlink link="profiles/${platform.profile.name}/themes/atomium" target="${platform.resources.profiles.common.themes.dir}/atomium" />
-        <symlink link="profiles/${platform.profile.name}/themes/ec_europa" target="${platform.resources.profiles.common.themes.dir}/ec_europa" />
+        <!-- Checking if we should overwrite atomium or ec_europa theme -->
+        <if>
+            <and>
+                <isset property="platform.theme.atomium.dev" />
+                <equals arg1="${platform.theme.atomium.dev}" arg2="true" />
+            </and>
+            <then>
+                <echo msg="Overwriting atomium from make file with branch ${platform.theme.atomium.repo.branch}." />
+                <!-- Deleteing the theme directories from the current profile -->
+                <delete dir="profiles/${platform.profile.name}/themes/atomium" quiet="true"/>
+                <!-- Symlinking the atomium theme from the "common" profile folder -->
+                <symlink link="profiles/${platform.profile.name}/themes/atomium" target="${platform.resources.profiles.common.themes.dir}/atomium" />
+            </then>
+        </if>
+        <if>
+            <and>
+                <isset property="platform.theme.europa.dev" />
+                <equals arg1="${platform.theme.europa.dev}" arg2="true" />
+            </and>
+            <then>
+                <echo msg="Overwriting ec_europa from make file with branch ${platform.theme.europa.repo.branch}." />
+                <!-- Deleteing the theme directories from the current profile -->
+                <delete dir="profiles/${platform.profile.name}/themes/ec_europa" quiet="true"/>
+                <!-- Symlinking the ec_europa theme from the "common" profile folder -->
+                <symlink link="profiles/${platform.profile.name}/themes/ec_europa" target="${platform.resources.profiles.common.themes.dir}/ec_europa" />
+            </then>
+        </if>
     </target>
 
     <!-- Generating assets -->

--- a/build.package.xml
+++ b/build.package.xml
@@ -295,7 +295,7 @@
         <delete dir="profiles/${platform.profile.name}/themes/atomium" quiet="true"/>
         <delete dir="profiles/${platform.profile.name}/themes/ec_europa" quiet="true"/>
 
-        <!-- Symlinc the atomium and ec_europa theme from the common profile folder -->
+        <!-- Symlink the atomium and ec_europa theme from the "common" profile folder -->
         <symlink link="profiles/${platform.profile.name}/themes/atomium" target="${platform.resources.profiles.common.themes.dir}/atomium" />
         <symlink link="profiles/${platform.profile.name}/themes/ec_europa" target="${platform.resources.profiles.common.themes.dir}/ec_europa" />
     </target>

--- a/build.package.xml
+++ b/build.package.xml
@@ -291,7 +291,7 @@
             repository="${platform.resources.profiles.common.themes.dir}/ec_europa"
             branchname="${platform.theme.europa.repo.branch}"/>
 
-        <!-- Deleting the theme directories from the current profile -->
+        <!-- Delete the theme directories from the current profile -->
         <delete dir="profiles/${platform.profile.name}/themes/atomium" quiet="true"/>
         <delete dir="profiles/${platform.profile.name}/themes/ec_europa" quiet="true"/>
 


### PR DESCRIPTION
## NEPT-1905

### Description

Add same atomium and ec_europa theme to the current profile as in common profile when building build-europa-dev.

### Change log

- Added: Symlink from common to current profile for atomium and ec_europa

