### PR TITLE
NEPT-2300: Revert eu_cookie_compliance due to update hooks.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -241,11 +241,10 @@ projects[entityreference_prepopulate][version] = "1.7"
 projects[entityreference_prepopulate][patch][] = https://www.drupal.org/files/issues/entityreference_prepopulate-1809776-5-test-only.patch
 
 projects[eu_cookie_compliance][subdir] = "contrib"
-projects[eu_cookie_compliance][version] = "1.28"
-; Popup doesn't close after clicking Decline button.
-; https://www.drupal.org/project/eu_cookie_compliance/issues/2985509
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2026
-projects[eu_cookie_compliance][patch][] = https://www.drupal.org/files/issues/2018-07-13/eu_cookie_compliance-close_popup-2985509-1.patch
+projects[eu_cookie_compliance][version] = "1.14"
+; Security patch adds filter_xss_admin to popup_agreed.
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2299
+projects[eu_cookie_compliance][patch][] = patches/eu_cookie_compliance_nept-2299.patch
 
 projects[extlink][subdir] = "contrib"
 projects[extlink][version] = "1.18"

--- a/resources/patches/eu_cookie_compliance_nept-2299.patch
+++ b/resources/patches/eu_cookie_compliance_nept-2299.patch
@@ -1,0 +1,19 @@
+--- eu_cookie_compliance.module	2014-05-20 13:18:53.000000000 +0000
++++ eu_cookie_compliance.module	2019-03-07 19:14:17.827831627 +0000
+@@ -95,12 +95,12 @@
+         $data['css'] = '#sliding-popup.sliding-popup-' . $position . ' {background:#'. check_plain($popup_settings["popup_bg_hex"]) . ';}'
+              . '#sliding-popup .popup-content #popup-text h2, #sliding-popup .popup-content #popup-text p {color:#' . check_plain($popup_settings['popup_text_hex']) . ' !important;}';
+       }
+-      $popup_text_info = str_replace(array("\r", "\n"), '', $popup_settings['popup_info']['value']);
+-      $popup_text_agreed = str_replace(array("\r", "\n"), '', $popup_settings['popup_agreed']['value']);
++      $popup_text_info = str_replace(array("\r", "\n"), '', filter_xss_admin($popup_settings['popup_info']['value']));
++      $popup_text_agreed = str_replace(array("\r", "\n"), '', filter_xss_admin($popup_settings['popup_agreed']['value']));
+       $html_info = theme('eu_cookie_compliance_popup_info', array('message' => check_markup($popup_text_info, $popup_settings['popup_info']['format'], FALSE), 'agree_button'=> $popup_settings['popup_agree_button_message'], 'disagree_button' => $popup_settings['popup_disagree_button_message']));
+       $html_agreed = theme('eu_cookie_compliance_popup_agreed', array('message' => check_markup($popup_text_agreed, $popup_settings['popup_agreed']['format'], FALSE),'hide_button'=>$popup_settings['popup_hide_button_message'],'find_more_button'=>$popup_settings['popup_find_more_button_message']));
+-      $popup_text_info = str_replace(array("\r", "\n"), '', $popup_settings['popup_info']['value']);
+-      $popup_text_agreed = str_replace(array("\r", "\n"), '', $popup_settings['popup_agreed']['value']);
++      $popup_text_info = str_replace(array("\r", "\n"), '', filter_xss_admin($popup_settings['popup_info']['value']));
++      $popup_text_agreed = str_replace(array("\r", "\n"), '', filter_xss_admin($popup_settings['popup_agreed']['value']));
+       $clicking_confirmation = (isset($popup_settings['popup_clicking_confirmation']))? $popup_settings['popup_clicking_confirmation'] : TRUE ;
+       $data['variables'] = array(
+         'popup_enabled' => $popup_settings['popup_enabled'],


### PR DESCRIPTION
## NEPT-2300

### Description

Revert eu_cookie_compliance due to update hooks

### Change log

- Added: 
- Changed: eu_cookie_compliance version back from 1.28 to 1.14
- Security: patch eu_cookie_compliance_nept-2299.patch.


