### PR TITLE
NEPT-1343: Fix bug, theme & add the multisite_og_button block to the relevant region

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install.inc
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install.inc
@@ -52,10 +52,6 @@ function cce_basic_config_profile_theme_default_form_submit($form, &$form_state)
   theme_enable($theme_list);
   variable_set('theme_default', $theme_default);
   $theme_name = $form['container']['theme_default']['#options'][$theme_default];
-  if ($theme_default == 'ec_europa') {
-    module_enable(array('nexteuropa_ecl_migrate'));
-    _nexteuropa_ecl_migrate_blocks();
-  }
   drupal_set_message(st("'@name' has been set as default theme.", array('@name' => $theme_name)));
 }
 

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.module
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.module
@@ -487,5 +487,6 @@ function cce_basic_config_themes_enabled($theme_list) {
       module_enable(array('nexteuropa_ecl_migrate'));
     }
     _nexteuropa_ecl_migrate_blocks();
+    cache_clear_all();
   }
 }

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.module
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.module
@@ -477,3 +477,12 @@ function cce_basic_config_field_widget_entityreference_autocomplete_form_alter(&
 function cce_basic_config_field_widget_entityreference_autocomplete_tags_form_alter(&$element, &$form_state, $context) {
   _cce_basic_config_field_widget_form_alter($element, $form_state, $context);
 }
+
+function cce_basic_config_themes_enabled($theme_list) {
+  if (in_array('ec_europa', $theme_list)) {
+    if (!module_exists('nexteuropa_ecl_migrate')) {
+      module_enable(array('nexteuropa_ecl_migrate'));
+    }
+    _nexteuropa_ecl_migrate_blocks();
+  }
+}

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.module
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.module
@@ -478,6 +478,9 @@ function cce_basic_config_field_widget_entityreference_autocomplete_tags_form_al
   _cce_basic_config_field_widget_form_alter($element, $form_state, $context);
 }
 
+/**
+ * Implements hook_themes_enabled().
+ */
 function cce_basic_config_themes_enabled($theme_list) {
   if (in_array('ec_europa', $theme_list)) {
     if (!module_exists('nexteuropa_ecl_migrate')) {


### PR DESCRIPTION
## NEPT-1343

### Description

Missing content selector on communities on eu_europa when the install theme is ec_resp

### Change log

- Added: cce_basic_config_themes_enabled() hook to configure blocks for ec_europa
- Removed: remove enabling of ec_europa blocks on install


