### PR TITLE
NEPT-1017: Remove ec_resp from default values

### DIFF
--- a/profiles/common/modules/features/multisite_custom_error/multisite_custom_error.install
+++ b/profiles/common/modules/features/multisite_custom_error/multisite_custom_error.install
@@ -35,7 +35,6 @@ function multisite_custom_error_disable() {
   foreach (_customerror_enum_errors() as $code => $desc) {
     if (variable_get('site_' . $code, '') == 'customerror/' . $code) {
       variable_del('site_' . $code);
-      variable_del('customerror_' . $code . '_theme');
       drupal_set_message(t('Default %v error page has been restored.', array('%v' => $code)));
     }
   }

--- a/profiles/common/modules/features/multisite_custom_error/multisite_custom_error.install
+++ b/profiles/common/modules/features/multisite_custom_error/multisite_custom_error.install
@@ -16,7 +16,6 @@ function multisite_custom_error_enable() {
   module_load_include('module', 'customerror');
   foreach (_customerror_enum_errors() as $code => $desc) {
     variable_set('site_' . $code, 'customerror/' . $code);
-    variable_set('customerror_' . $code . '_theme', 'ec_resp');
     drupal_set_message(t('Default error page has been set.'));
   }
   $link = l(t('Site information'), 'admin/config/system/site-information', array('attributes' => array('target' => '_blank')));


### PR DESCRIPTION
## NEPT-1017

### Description

Remove ec_resp from default values. 
There still is a reference to ec-resp without taking into account of ec_europa: 
https://github.com/ec-europa/platform-dev/blob/223bd1dddd5bc4d29dd3ce5b7a7f25d7e6d2e14a/profiles/common/modules/features/multisite_custom_error/multisite_custom_error.install#L19
The other references are for treating a case specific for ec_resp.

### Change log

- Removed: unuseful variable from multisite_custom_error feature, which was set to 'ec_resp' by default.

