### PR TITLE
NEPT-2186: WYSIWYG - Remove unauthorised target option JAVASCRIPT under popup window "LINK"

### DIFF
--- a/profiles/common/modules/features/multisite_wysiwyg/ckeditor/link_alter.js
+++ b/profiles/common/modules/features/multisite_wysiwyg/ckeditor/link_alter.js
@@ -1,0 +1,34 @@
+/**
+ * @file
+ * CKEditor Link target alter.
+ */
+
+// Alter the options of the link dialog plugin.
+(function () {
+    CKEDITOR.on('dialogDefinition', function (ev) {
+        // Take the dialog name and its definition from the event data.
+        var dialogName = ev.data.name;
+        var dialogDefinition = ev.data.definition;
+        // Check the it is the link definition.
+        if (dialogName == 'link') {
+          var targetTab = dialogDefinition.getContents("target");
+          /*
+            Remove options from the default list defined on the link plugin.
+            var removeOptions = ["frame", "popup", "notSet", "_blank", "_top", "_self", "_parent"];
+            */
+          var removeOptions = ["frame", "popup"];
+          var i;
+          var optionsToKeep = [];
+          for (i = targetTab.elements[0].children[0].items.length - 1; i >= 0; i--) {
+              // Remove options from the target select.
+              if (removeOptions.indexOf(targetTab.elements[0].children[0].items[i][1]) !== -1) {
+                delete targetTab.elements[0].children[0].items[i];
+              }
+              else {
+                optionsToKeep.unshift(targetTab.elements[0].children[0].items[i]);
+              }
+          }
+          targetTab.elements[0].children[0].items = optionsToKeep;
+        }
+    });
+})();

--- a/profiles/common/modules/features/multisite_wysiwyg/ckeditor/link_alter.js
+++ b/profiles/common/modules/features/multisite_wysiwyg/ckeditor/link_alter.js
@@ -16,7 +16,7 @@
             Remove options from the default list defined on the link plugin.
             var removeOptions = ["frame", "popup", "notSet", "_blank", "_top", "_self", "_parent"];
             */
-          var removeOptions = ["frame", "popup"];
+          var removeOptions = ["popup"];
           var i;
           var optionsToKeep = [];
           for (i = targetTab.elements[0].children[0].items.length - 1; i >= 0; i--) {

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
@@ -32,6 +32,10 @@ function multisite_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
     // This namespace must be applied even if the node edit forms are displayed
     // with the admin theme.
     $settings['bodyClass'] = 'ecl-editor';
+    // Add js to alter the target options of the link plugin.
+    if (in_array('Link', $settings['toolbar'][0])) {
+      drupal_add_js(drupal_get_path('module', 'multisite_wysiwyg') . '/ckeditor/link_alter.js');
+    }
   }
 }
 


### PR DESCRIPTION
## NEPT-2186

### Description

Remove popup and iframe options from the target options of the Link Ckeditor plugin.
Update: the iframe option should not be removed, only the popup.

### Change log

- Added: File link_alter.js to remove options from the target select.


