### PR TITLE
NEPT-1530: Implement varnish path flushing on file delete.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -288,9 +288,8 @@ function nexteuropa_varnish_file_delete($file) {
   if ($scheme !== FALSE && file_stream_wrapper_valid_scheme($scheme) === TRUE) {
     // Get path on filesystem.
     $wrapper = file_stream_wrapper_get_instance_by_scheme($scheme);
-    $dir = $wrapper->getDirectoryPath($file);
     _nexteuropa_varnish_purge_paths(array(
-      'escaped_alias' => preg_quote($dir . '/' . $file->filename, '/'),
+      'escaped_alias' => preg_quote($wrapper->getDirectoryPath($file) . '/' . $file->filename, '/'),
     ));
   }
 }
@@ -312,7 +311,7 @@ function nexteuropa_varnish_path_delete($path) {
   }
 
   // No rule defined for the node: Ignore the rest of the process.
-  if ($node !== NULL && !nexteuropa_varnish_node_has_rules($node)) {
+  if ($node !== NULL && nexteuropa_varnish_node_has_rules($node) === FALSE) {
     return;
   }
 

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -284,12 +284,13 @@ function nexteuropa_varnish_node_delete($node) {
  */
 function nexteuropa_varnish_file_delete($file) {
   $scheme = file_uri_scheme($file->uri);
-  if ($scheme && file_stream_wrapper_valid_scheme($scheme)) {
+  if ($scheme !== FALSE && file_stream_wrapper_valid_scheme($scheme) === TRUE) {
     // Get path on filesystem.
     $wrapper = file_stream_wrapper_get_instance_by_scheme($scheme);
     $dir = $wrapper->getDirectoryPath($file);
-    $paths = array('escaped_alias' => preg_quote($dir . '/' . $file->filename, '/'));
-    _nexteuropa_varnish_purge_paths($paths);
+    _nexteuropa_varnish_purge_paths(array(
+      'escaped_alias' => preg_quote($dir . '/' . $file->filename, '/')
+    ));
   }
 }
 
@@ -305,12 +306,12 @@ function nexteuropa_varnish_path_delete($path) {
   $is_file = strpos($path['source'], 'file/');
 
   // Has to be a node or file path.
-  if (empty($node) && $is_file === FALSE) {
+  if ($node === NULL && $is_file === FALSE) {
     return;
   }
 
   // No rule defined for the node: Ignore the rest of the process.
-  if ($node && !nexteuropa_varnish_node_has_rules($node)) {
+  if ($node !== NULL && !nexteuropa_varnish_node_has_rules($node)) {
     return;
   }
 

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -280,6 +280,22 @@ function nexteuropa_varnish_node_delete($node) {
 }
 
 /**
+ * Implements hook_file_delete().
+ */
+function nexteuropa_varnish_file_delete($file) {
+  $scheme = file_uri_scheme($file->uri);
+  if ($scheme && file_stream_wrapper_valid_scheme($scheme)) {
+    // Get path on filesystem.
+    $wrapper = file_stream_wrapper_get_instance_by_scheme($scheme);
+    $dir = $wrapper->getDirectoryPath($file);
+    // Get path alias.
+    
+    $paths = array('escaped_alias' => preg_quote($dir . '/' . $file->filename, '/'));
+    _nexteuropa_varnish_purge_paths($paths);
+  }
+}
+
+/**
  * Implements hook_path_delete().
  */
 function nexteuropa_varnish_path_delete($path) {
@@ -288,14 +304,15 @@ function nexteuropa_varnish_path_delete($path) {
   }
 
   $node = menu_get_object('node', 1, $path['source']);
+  $is_file = strpos($path['source'], 'file/');
 
-  // Its a node path.
-  if (empty($node)) {
+  // Has to be a node or file path.
+  if (empty($node) && $is_file === FALSE) {
     return;
   }
 
   // No rule defined for the node: Ignore the rest of the process.
-  if (!nexteuropa_varnish_node_has_rules($node)) {
+  if ($node && !nexteuropa_varnish_node_has_rules($node)) {
     return;
   }
 

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -284,6 +284,7 @@ function nexteuropa_varnish_node_delete($node) {
  */
 function nexteuropa_varnish_file_delete($file) {
   $scheme = file_uri_scheme($file->uri);
+
   if ($scheme !== FALSE && file_stream_wrapper_valid_scheme($scheme) === TRUE) {
     // Get path on filesystem.
     $wrapper = file_stream_wrapper_get_instance_by_scheme($scheme);

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -289,7 +289,7 @@ function nexteuropa_varnish_file_delete($file) {
     $wrapper = file_stream_wrapper_get_instance_by_scheme($scheme);
     $dir = $wrapper->getDirectoryPath($file);
     _nexteuropa_varnish_purge_paths(array(
-      'escaped_alias' => preg_quote($dir . '/' . $file->filename, '/')
+      'escaped_alias' => preg_quote($dir . '/' . $file->filename, '/'),
     ));
   }
 }

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -288,8 +288,6 @@ function nexteuropa_varnish_file_delete($file) {
     // Get path on filesystem.
     $wrapper = file_stream_wrapper_get_instance_by_scheme($scheme);
     $dir = $wrapper->getDirectoryPath($file);
-    // Get path alias.
-    
     $paths = array('escaped_alias' => preg_quote($dir . '/' . $file->filename, '/'));
     _nexteuropa_varnish_purge_paths($paths);
   }

--- a/tests/features/frontend_cache_purge.feature
+++ b/tests/features/frontend_cache_purge.feature
@@ -100,6 +100,25 @@ Feature:
       | node\/[node:last-deleted-node-id]_[a-z]{2}                  | 1       |
 
   @moderated-content
+  Scenario: Flush cache when file was deleted.
+    Given I go to "file/add"
+    And I attach the file "/tests/files/logo.png" to "edit-upload-upload"
+    And I press "Next"
+    And I select the radio button "Public local files served by the webserver."
+    And I press "Next"
+    And I press "Save" button
+    Then I should see "Image logo.png was uploaded."
+    When I am on "admin/content/file"
+    And I click "Delete" on the "logo.png" row
+    Then I should see "Are you sure you want to delete the file test.png?"
+    And I press "Delete" button
+    Then the web front end cache was instructed to purge the multiple paths for the application tag "my-website":
+      | Path                              | Request |
+      | file\/logopng_[a-z]{2}            | 0       |
+      | file\/logopng                     | 0       |
+      | sites\/default\/files\/logo\.png  | 1       |
+
+  @moderated-content
   Scenario: Create a draft.
     Given the default purge rule is disabled
     And the following cache purge rules:

--- a/tests/features/frontend_cache_purge.feature
+++ b/tests/features/frontend_cache_purge.feature
@@ -99,19 +99,19 @@ Feature:
       | node\/[node:last-deleted-node-id]                           | 1       |
       | node\/[node:last-deleted-node-id]_[a-z]{2}                  | 1       |
 
-  @moderated-content
+  @moderated-content @andras
   Scenario: Flush cache when file was deleted.
     Given I go to "file/add"
     And I attach the file "/tests/files/logo.png" to "edit-upload-upload"
     And I press "Next"
     And I select the radio button "Public local files served by the webserver."
     And I press "Next"
-    And I press "Save" button
+    And I press "Save"
     Then I should see "Image logo.png was uploaded."
     When I am on "admin/content/file"
     And I click "Delete" on the "logo.png" row
     Then I should see "Are you sure you want to delete the file test.png?"
-    And I press "Delete" button
+    And I press "Delete"
     Then the web front end cache was instructed to purge the multiple paths for the application tag "my-website":
       | Path                              | Request |
       | file\/logopng_[a-z]{2}            | 0       |

--- a/tests/features/frontend_cache_purge.feature
+++ b/tests/features/frontend_cache_purge.feature
@@ -110,7 +110,7 @@ Feature:
     Then I should see "Image logo.png was uploaded."
     When I am on "admin/content/file"
     And I click "Delete" on the "logo.png" row
-    Then I should see "Are you sure you want to delete the file test.png?"
+    Then I should see "Are you sure you want to delete the file logo.png?"
     And I press "Delete"
     Then the web front end cache was instructed to purge the multiple paths for the application tag "my-website":
       | Path                              | Request |

--- a/tests/features/frontend_cache_purge.feature
+++ b/tests/features/frontend_cache_purge.feature
@@ -99,7 +99,7 @@ Feature:
       | node\/[node:last-deleted-node-id]                           | 1       |
       | node\/[node:last-deleted-node-id]_[a-z]{2}                  | 1       |
 
-  @moderated-content @andras
+  @moderated-content
   Scenario: Flush cache when file was deleted.
     Given I go to "file/add"
     And I attach the file "/tests/files/logo.png" to "edit-upload-upload"

--- a/tests/src/Context/FrontendCacheContext.php
+++ b/tests/src/Context/FrontendCacheContext.php
@@ -283,14 +283,16 @@ class FrontendCacheContext implements Context {
     $link = $row->findLink($arg1);
     $link->click();
   }
-  
+
   /**
+   * Clicks a link in a specific table row given a element in that row.
+   * 
    * @When I click :arg1 on the :arg2 row
    */
   public function iClickOnTheRow($arg1, $arg2)
   {
     $page = $this->getSession()->getPage();
-    
+
     if ($row = $this->getTableRow($page, $arg2)) {
       $row->findLink($arg1)->click();
     }

--- a/tests/src/Context/FrontendCacheContext.php
+++ b/tests/src/Context/FrontendCacheContext.php
@@ -292,8 +292,7 @@ class FrontendCacheContext implements Context {
     $page = $this->getSession()->getPage();
     
     if ($row = $this->getTableRow($page, $arg2)) {
-      $link = $row->findLink($arg1);
-      $link->click();  
+      $row->findLink($arg1)->click();
     }
     else {
       throw new \Exception(sprintf("No row with '%s", $arg2));

--- a/tests/src/Context/FrontendCacheContext.php
+++ b/tests/src/Context/FrontendCacheContext.php
@@ -283,6 +283,22 @@ class FrontendCacheContext implements Context {
     $link = $row->findLink($arg1);
     $link->click();
   }
+  
+  /**
+   * @When I click :arg1 on the :arg2 row
+   */
+  public function iClickOnTheRow($arg1, $arg2)
+  {
+    $page = $this->getSession()->getPage();
+    
+    if ($row = $this->getTableRow($page, $arg2)) {
+      $link = $row->findLink($arg1);
+      $link->click();  
+    }
+    else {
+      throw new \Exception(sprintf("No row with '%s", $arg2));
+    }
+  }
 
   /**
    * Asserts that the web front end cache received certain purge requests.

--- a/tests/src/Context/FrontendCacheContext.php
+++ b/tests/src/Context/FrontendCacheContext.php
@@ -286,11 +286,10 @@ class FrontendCacheContext implements Context {
 
   /**
    * Clicks a link in a specific table row given a element in that row.
-   * 
+   *
    * @When I click :arg1 on the :arg2 row
    */
-  public function iClickOnTheRow($arg1, $arg2)
-  {
+  public function iClickOnTheRow($arg1, $arg2) {
     $page = $this->getSession()->getPage();
 
     if ($row = $this->getTableRow($page, $arg2)) {

--- a/tests/src/Context/FrontendCacheContext.php
+++ b/tests/src/Context/FrontendCacheContext.php
@@ -290,7 +290,7 @@ class FrontendCacheContext implements Context {
    * @When I click :arg1 on the :arg2 row
    */
   public function iClickOnTheRow($arg1, $arg2) {
-    $page = $this->getSession()->getPage();
+    $page = $this->mink->getSession()->getPage();
 
     if ($row = $this->getTableRow($page, $arg2)) {
       $row->findLink($arg1)->click();

--- a/tests/src/Context/FrontendCacheContext.php
+++ b/tests/src/Context/FrontendCacheContext.php
@@ -292,7 +292,7 @@ class FrontendCacheContext implements Context {
   public function iClickOnTheRow($arg1, $arg2) {
     $page = $this->mink->getSession()->getPage();
 
-    if ($row = $this->getTableRow($page, $arg2)) {
+    if ($row = $this->mink->getTableRow($page, $arg2)) {
       $row->findLink($arg1)->click();
     }
     else {


### PR DESCRIPTION
## NEPT-1530

### Description

Implement varnish path flushing on file delete.

### Change log

- Added: hook nexteuropa_varnish_file_delete().
- Changed: nexteuropa_varnish_path_delete() to handle file aliases.

### Commands

drush cc all

