### PR TITLE
NEPT-2529: Show EU Login logout menu if usernames are different

### DIFF
--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -688,9 +688,7 @@ function ecas_menu_logout_check() {
 
   // We provide access to this menu entry only if we are logged via ECAS.
   if (isset($_SESSION['phpCAS']) && isset($user->name)) {
-    if ($_SESSION['phpCAS']['user'] === $user->name) {
-      return TRUE;
-    }
+    return TRUE;
   }
 
   return FALSE;

--- a/profiles/common/modules/features/ecas_env/ecas_env.module
+++ b/profiles/common/modules/features/ecas_env/ecas_env.module
@@ -79,9 +79,7 @@ function normal_menu_logout_check() {
 
   // We provide access to this menu entry only if we are not logged via ECAS.
   if (isset($_SESSION['phpCAS']) && isset($user->name)) {
-    if ($_SESSION['phpCAS']['user'] === $user->name) {
-      return FALSE;
-    }
+    return FALSE;
   }
 
   return TRUE;


### PR DESCRIPTION
## NEPT-2529

### Description

Show the EU Login logout link when logged in with EU Login, even if the EU Login username does not match the Drupal one.

### Change log

- Changed: Modified normal_menu_logout_check() and ecas_menu_logout_check() to not require that the ecas and drupal usernames match


### Commands

drush cc all

