### PR TITLE
NEPT-2427: Restrict media to display wysiwyg.

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -545,6 +545,17 @@ function cce_basic_config_enable() {
 
   // My Account.
   variable_set('user_logout_data_image', 'log-out');
+
+  // Do not allow the modes to be used from the wysiwyg.
+  $types = array('image', 'document');
+  $displays = array('default', 'teaser', 'preview');
+  foreach ($types as $type) {
+    foreach ($displays as $display) {
+      db_delete('media_restrict_wysiwyg')->condition('type', $type)->condition('display', $display)->execute();
+      $record = array('type' => $type, 'display' => $display);
+      drupal_write_record('media_restrict_wysiwyg', $record);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## NEPT-2427

### Description

Only enable wysiwyg display mode in wysiwyg, this prevents media tags to be rendered as block.

### Change log

- Removed: Default, teaser and preview displays from media popup options.


