### PR TITLE
NEPT-2503: Update ApacheSolr

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -48,7 +48,7 @@ projects[apachesolr][patch][] = patches/apachesolr-changing_drupal_http_request_
 ; Delay removing entities from the index.
 ; https://www.drupal.org/node/2764637
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-11582
-projects[apachesolr][patch][] = patches/apachesolr-delay-entity-removal.patch
+projects[apachesolr][patch][] = patches/apachesolr-delay-entity-removal-2764637.patch
 
 projects[apachesolr_attachments][subdir] = "contrib"
 projects[apachesolr_attachments][version] = "1.4"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -24,7 +24,7 @@ projects[advanced_help][subdir] = "contrib"
 projects[advanced_help][version] = "1.4"
 
 projects[apachesolr][subdir] = "contrib"
-projects[apachesolr][version] = "1.8"
+projects[apachesolr][version] = "1.11"
 ; Issue #2178283 : Apache Solr doesn't invalidate its caches when inserting a new node type.
 ; https://drupal.org/node/2178283
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-2890
@@ -48,7 +48,7 @@ projects[apachesolr][patch][] = patches/apachesolr-changing_drupal_http_request_
 ; Delay removing entities from the index.
 ; https://www.drupal.org/node/2764637
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-11582
-projects[apachesolr][patch][] = https://www.drupal.org/files/issues/apachesolr-delay-entity-removal-2764637-1.patch
+projects[apachesolr][patch][] = patches/apachesolr-delay-entity-removal.patch
 
 projects[apachesolr_attachments][subdir] = "contrib"
 projects[apachesolr_attachments][version] = "1.4"

--- a/resources/patches/apachesolr-delay-entity-removal-2764637.patch
+++ b/resources/patches/apachesolr-delay-entity-removal-2764637.patch
@@ -1,8 +1,8 @@
 diff --git a/apachesolr.index.inc b/apachesolr.index.inc
-index 94588ef..7d53eb4 100644
+index 58b535b..15768f9 100644
 --- a/apachesolr.index.inc
 +++ b/apachesolr.index.inc
-@@ -618,7 +618,6 @@ function _apachesolr_index_get_next_set_query($env_id, $entity_type) {
+@@ -627,7 +627,6 @@ function _apachesolr_index_get_next_set_query($env_id, $entity_type) {
    $query = db_select($table, 'aie')
      ->fields('aie')
      ->condition('aie.bundle', $bundles)
@@ -11,30 +11,28 @@ index 94588ef..7d53eb4 100644
        ->condition('aie.changed', $last_changed, '>')
        // Tie breaker for entities that were changed at exactly
 diff --git a/apachesolr.module b/apachesolr.module
-index 6a948cc..0502bba 100644
+index e88e103..3cdeb0f 100644
 --- a/apachesolr.module
 +++ b/apachesolr.module
-@@ -2071,13 +2071,29 @@ function apachesolr_get_indexer_table($type) {
+@@ -2070,13 +2070,28 @@ function apachesolr_get_indexer_table($type) {
   * Delete the entity's entry from a fictional table of all entities.
   */
  function apachesolr_entity_delete($entity, $entity_type) {
 +  if (!apachesolr_entity_should_index($entity, $entity_type)) {
 +    return;
 +  }
-+
    list($entity_id) = entity_extract_ids($entity_type, $entity);
  
    if (apachesolr_entity_should_index($entity, $entity_type)) {
--    // Get all environments and delete it from their table and index
-+
+     // Get all environments and delete it from their table and index
      $environments = apachesolr_load_all_environments();
 -    foreach ($environments as $environment) {
 -      apachesolr_remove_entity($environment['env_id'], $entity_type, $entity_id);
-+
++    
 +    if (empty($environments)) {
 +      return;
 +    }
-+
++  
 +    if (variable_get('apachesolr_delay_removals', false)) {
 +      // Mark for later removal from the Solr index.
 +      apachesolr_mark_entity_for_removal($entity_type, $entity_id);
@@ -47,8 +45,7 @@ index 6a948cc..0502bba 100644
      }
    }
  }
- 
-@@ -2085,15 +2101,30 @@ function apachesolr_remove_entity($env_id, $entity_type, $entity_id) {
+@@ -2100,14 +2115,29 @@ function apachesolr_remove_entity($env_id, $entity_type, $entity_id) {
        ->execute();
    }
    else {
@@ -62,7 +59,7 @@ index 6a948cc..0502bba 100644
    }
  }
  
- /**
++/**
 + * Marks a specific entity for later removal.
 + *
 + * @param string $entity_type
@@ -80,7 +77,6 @@ index 6a948cc..0502bba 100644
 +    ->execute();
 +}
 +
-+/**
+ /**
   * Returns array containing information about node fields that should be indexed
   */
- function apachesolr_entity_fields($entity_type = 'node') {

--- a/resources/patches/apachesolr-delay-entity-removal.patch
+++ b/resources/patches/apachesolr-delay-entity-removal.patch
@@ -1,0 +1,86 @@
+diff --git a/apachesolr.index.inc b/apachesolr.index.inc
+index 94588ef..7d53eb4 100644
+--- a/apachesolr.index.inc
++++ b/apachesolr.index.inc
+@@ -618,7 +618,6 @@ function _apachesolr_index_get_next_set_query($env_id, $entity_type) {
+   $query = db_select($table, 'aie')
+     ->fields('aie')
+     ->condition('aie.bundle', $bundles)
+-    ->condition('aie.status', 1)
+     ->condition(db_or()
+       ->condition('aie.changed', $last_changed, '>')
+       // Tie breaker for entities that were changed at exactly
+diff --git a/apachesolr.module b/apachesolr.module
+index 6a948cc..0502bba 100644
+--- a/apachesolr.module
++++ b/apachesolr.module
+@@ -2071,13 +2071,29 @@ function apachesolr_get_indexer_table($type) {
+  * Delete the entity's entry from a fictional table of all entities.
+  */
+ function apachesolr_entity_delete($entity, $entity_type) {
++  if (!apachesolr_entity_should_index($entity, $entity_type)) {
++    return;
++  }
++
+   list($entity_id) = entity_extract_ids($entity_type, $entity);
+ 
+   if (apachesolr_entity_should_index($entity, $entity_type)) {
+-    // Get all environments and delete it from their table and index
++
+     $environments = apachesolr_load_all_environments();
+-    foreach ($environments as $environment) {
+-      apachesolr_remove_entity($environment['env_id'], $entity_type, $entity_id);
++
++    if (empty($environments)) {
++      return;
++    }
++
++    if (variable_get('apachesolr_delay_removals', false)) {
++      // Mark for later removal from the Solr index.
++      apachesolr_mark_entity_for_removal($entity_type, $entity_id);
++    }
++    else {
++      // Immediately remove from the Solr index.
++      foreach ($environments as $environment) {
++        apachesolr_remove_entity($environment['env_id'], $entity_type, $entity_id);
++      }
+     }
+   }
+ }
+ 
+@@ -2085,15 +2101,30 @@ function apachesolr_remove_entity($env_id, $entity_type, $entity_id) {
+       ->execute();
+   }
+   else {
+-    // Set status 0 so we try to delete from the index again in the future.
+-    db_update($indexer_table)
+-      ->condition('entity_id', $entity_id)
+-      ->fields(array('changed' => REQUEST_TIME, 'status' => 0))
+-      ->execute();
++    // Try to delete from the index again in the future.
++    apachesolr_mark_entity_for_removal($entity_type, $entity_id);
+   }
+ }
+ 
+ /**
++ * Marks a specific entity for later removal.
++ *
++ * @param string $entity_type
++ * @param string $entity_id
++ */
++function apachesolr_mark_entity_for_removal($entity_type, $entity_id) {
++  module_load_include('inc', 'apachesolr', 'apachesolr.index');
++
++  $indexer_table = apachesolr_get_indexer_table($entity_type);
++
++  db_update($indexer_table)
++    ->condition('entity_type', $entity_type)
++    ->condition('entity_id', $entity_id)
++    ->fields(array('changed' => REQUEST_TIME, 'status' => 0))
++    ->execute();
++}
++
++/**
+  * Returns array containing information about node fields that should be indexed
+  */
+ function apachesolr_entity_fields($entity_type = 'node') {


### PR DESCRIPTION
## NEPT-2503

### Description

- Update Apache Solr Search to version 7.x-1.11
- Modified patch to apply correctly


### Change log

- Added: new local patch, modified from the drupal.org version
- Changed: updated .make file to use the new module version and point to the local patch

### Commands

drush cc all

