### PR TITLE
NEPT-2559: Upgrade date module to 2.11 beta 2.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -161,12 +161,12 @@ projects[customerror][subdir] = "contrib"
 projects[customerror][version] = "1.4"
 
 projects[date][subdir] = "contrib"
-projects[date][version] = "2.11-beta1"
+projects[date][version] = "2.11-beta2"
 ; Issue #2305049: Wrong timezone handling in migrate process.
 ; https://www.drupal.org/node/2305049
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-3324
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-4710
-projects[date][patch][] = https://www.drupal.org/files/issues/2305049-12.patch
+projects[date][patch][] = https://www.drupal.org/files/issues/2019-06-27/2305049-12_0.patch
 
 projects[date_ical][subdir] = "contrib"
 projects[date_ical][version] = "3.9"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -166,7 +166,7 @@ projects[date][version] = "2.11-beta2"
 ; https://www.drupal.org/node/2305049
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-3324
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-4710
-projects[date][patch][] = https://www.drupal.org/files/issues/2019-06-27/2305049-12_0.patch
+projects[date][patch][] = https://www.drupal.org/files/issues/2019-06-30/2305049-12_1.patch
 
 projects[date_ical][subdir] = "contrib"
 projects[date_ical][version] = "3.9"

--- a/tests/features/scheduler.feature
+++ b/tests/features/scheduler.feature
@@ -50,7 +50,7 @@ Feature: Scheduler features
     And I should see the text "The 'publish on' date must be in the future"
     And I change the variable "scheduler_publish_past_date_page" to "schedule"
     And I press the "Save" button
-    Then I should see the text "This post is unpublished and will be published 2000-12-31 23:59:00."
+    Then I should see the text "This post is unpublished and will be published 2000-12-31 23:59:59."
     And I should see the text "Revision state: draft"
 
   Scenario: User with permissions can schedule a date to publish a content after configuring allowed status
@@ -72,7 +72,7 @@ Feature: Scheduler features
     And I should see the text "The 'publish on' date must be in the future"
     And I change the variable "scheduler_publish_past_date_page" to "schedule"
     And I press the "Save" button
-    Then I should see the text "This post is unpublished and will be published 2000-12-31 23:59:00."
+    Then I should see the text "This post is unpublished and will be published 2000-12-31 23:59:59."
     And I should see the text "Revision state: Draft"
 
   Scenario: User can schedule a draft to publish a content and wont be published
@@ -198,4 +198,4 @@ Feature: Scheduler features
     Then I am logged in as a user with the 'editor' role
     And I visit the "page" content with title "Next content"
     And I click "Moderate"
-    Then I should see the text "This revision will be published 2050-12-31 23:59:00"
+    Then I should see the text "This revision will be published 2050-12-31 23:59:59"


### PR DESCRIPTION
## NEPT-2559

### Description

Upgrade date module to 2.11 beta 2.

### Change log

- Changed:
   - Date module version to 7.x-2.11-beta2
   - Adapted patch 2305049 to new version

### Commands

drush cc all

