### PR TITLE
NEPT-2560: Upgrade ds module from 2.15 to 2.16.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -194,7 +194,7 @@ projects[diff][download][revision] = b1b09189d52380a008c9cb29b879e3aa140ec2e0
 projects[diff][download][type] = git
 
 projects[ds][subdir] = "contrib"
-projects[ds][version] = "2.15"
+projects[ds][version] = "2.16"
 
 projects[easy_breadcrumb][subdir] = "contrib"
 projects[easy_breadcrumb][version] = "2.12"


### PR DESCRIPTION
## NEPT-2560

### Description

Upgrade ds module from 2.15 to 2.16.

### Change log

- Changed: version of module ds in multisite_drupal_standard.make

