### PR TITLE
NEPT-1454: Add granularity to watchdog message logging.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.admin.inc
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.admin.inc
@@ -39,6 +39,19 @@ function nexteuropa_varnish_admin_settings_form($form, $form_state) {
     '#disabled' => $disabled,
   );
 
+  $form['watchdog_settings'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Watchdog settings'),
+    '#description' => t('Set varnish watchdog logging granularity.'),
+  );
+
+  $form['watchdog_settings']['nexteuropa_varnish-granularity'] = array(
+    '#type' => 'radios',
+    '#title' => t('Granularity'),
+    '#default_value' => variable_get('nexteuropa_varnish-granularity', 2),
+    '#options' => array(0 => t('None'), 1 => t('Only errors'), 2 => t('All')),
+  );
+
   $form['settings'] = array(
     '#type' => 'fieldset',
     '#title' => t('Settings'),

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -450,14 +450,18 @@ function _nexteuropa_varnish_purge_paths($paths) {
     },
     $paths
   );
-  watchdog(
-    'nexteuropa_varnish',
-    'Clearing paths: @paths',
-    array(
-      '@paths' => implode(', ', $escaped_paths),
-    ),
-    WATCHDOG_INFO
-  );
+
+  if (variable_get('nexteuropa_varnish-granularity', 2) === 2) {
+    watchdog(
+      'nexteuropa_varnish',
+      'Clearing paths: @paths',
+      array(
+        '@paths' => implode(', ', $escaped_paths),
+      ),
+      WATCHDOG_INFO
+    );
+  }
+
   _nexteuropa_varnish_varnish_requests_send($escaped_paths);
 }
 
@@ -491,7 +495,7 @@ function _nexteuropa_varnish_varnish_requests_send($path_regexp_rules = array())
         $request_options
       );
 
-      if (isset($response->error)) {
+      if (isset($response->error) && variable_get('nexteuropa_varnish-granularity', 2) > 0) {
         watchdog(
           'nexteuropa_varnish',
           'Clear operation failed for target %target: %code %error',
@@ -509,14 +513,17 @@ function _nexteuropa_varnish_varnish_requests_send($path_regexp_rules = array())
     return $requests_ok;
   }
   catch (InvalidArgumentException $iae) {
-    $log_link = l(t('status report page'), 'admin/reports/status_en');
-    watchdog(
-      'nexteuropa_varnish',
-      'No path has been sent for clearing because all module settings are not set.',
-      array(),
-      WATCHDOG_CRITICAL,
-      $log_link
-    );
+    if (variable_get('nexteuropa_varnish-granularity', 2) > 0) {
+      $log_link = l(t('status report page'), 'admin/reports/status_en');
+      watchdog(
+        'nexteuropa_varnish',
+        'No path has been sent for clearing because all module settings are not set.',
+        array(),
+        WATCHDOG_CRITICAL,
+        $log_link
+      );
+    }
+
     return FALSE;
   }
 }

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -451,7 +451,7 @@ function _nexteuropa_varnish_purge_paths($paths) {
     $paths
   );
 
-  if (variable_get('nexteuropa_varnish-granularity', 2) === 2) {
+  if ((int) variable_get('nexteuropa_varnish-granularity', 2) === 2) {
     watchdog(
       'nexteuropa_varnish',
       'Clearing paths: @paths',
@@ -495,7 +495,7 @@ function _nexteuropa_varnish_varnish_requests_send($path_regexp_rules = array())
         $request_options
       );
 
-      if (isset($response->error) && variable_get('nexteuropa_varnish-granularity', 2) > 0) {
+      if (isset($response->error) && (int) variable_get('nexteuropa_varnish-granularity', 2) > 0) {
         watchdog(
           'nexteuropa_varnish',
           'Clear operation failed for target %target: %code %error',
@@ -513,7 +513,7 @@ function _nexteuropa_varnish_varnish_requests_send($path_regexp_rules = array())
     return $requests_ok;
   }
   catch (InvalidArgumentException $iae) {
-    if (variable_get('nexteuropa_varnish-granularity', 2) > 0) {
+    if ((int) variable_get('nexteuropa_varnish-granularity', 2) > 0) {
       $log_link = l(t('status report page'), 'admin/reports/status_en');
       watchdog(
         'nexteuropa_varnish',


### PR DESCRIPTION
## NEPT-1454

### Description

There is a need to introduce more granular and configurable logging mechanism to avoid flooding of the watchdog log.

### Change log

- Added: Form options in admin/config/system/nexteuropa-varnish to configure watchdog granularity, default it works like before.


