### PR TITLE
NEPT-2193: Make small changes in build to support poetry mock on c9 by default.

### DIFF
--- a/build.properties.dist
+++ b/build.properties.dist
@@ -47,7 +47,7 @@ drupal.htaccess.path = ${platform.build.dir}/.htaccess
 drupal.htaccess.append.text =
 
 # Configuration to append to the settings.php file of the build.
-drupal.settings.append.text = $conf['multisite_toolbox_cs_whitelist'] = array('*.europa.eu', 'europa.eu');
+drupal.settings.append.text = ${line.separator}$conf['multisite_toolbox_cs_whitelist'] = array('*.europa.eu', 'europa.eu');${line.separator}$conf['poetry_mock_base_url'] = "${mock.poetry.base_url}";${line.separator}
 
 
 # Platform configuration
@@ -166,6 +166,10 @@ behat.poetry.endpoint = /service
 behat.poetry.wsdl = /wsdl
 behat.poetry.username = username
 behat.poetry.password = password
+
+# Poetry mock
+# Example mock.poetry.base_url = http://127.0.0.1:8080/platform-dev/build
+mock.poetry.base_url =
 
 # PHPUnit configuration
 # -------------------

--- a/build.properties.drone
+++ b/build.properties.drone
@@ -7,6 +7,8 @@ behat.base_url = http://web:8080/build
 behat.wd_host.url = http://selenium:8910/wd/hub
 behat.browser.name = phantomjs
 
+mock.poetry.base_url = http://web:8080/build
+
 behat.poetry.host = behat
 behat.poetry.port = 28080
 behat.poetry.endpoint = /service

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.install
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.install
@@ -92,7 +92,6 @@ function tmgmt_poetry_requirements($phase) {
   $requirements = array();
   $t = get_t();
   global $conf;
-
   switch ($phase) {
     case 'install':
       if (!isset($conf['poetry_service']['address'])) {

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.install
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.install
@@ -94,7 +94,7 @@ function tmgmt_poetry_requirements($phase) {
   global $conf;
   switch ($phase) {
     case 'install':
-      if (!isset($conf['poetry_service']['address'])) {
+      if (!isset($conf['poetry_service']['address']) && empty($conf['poetry_mock_base_url'])) {
         $requirements['poetry_service'] = array(
           'title' => 'DGT connector webservice',
           'severity' => REQUIREMENT_ERROR,

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/README.md
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/README.md
@@ -9,8 +9,9 @@ use cases provided by European Commission Poetry translation services
 
 In order to enable the mock module, you need to set up the mock path in your
 settings.php file.
-Check the build.properties.dist file, the variable mock.poetry.base_url is
-added added autromatically to settings.php file when building the platform.
+Check the build.properties.dist file, the variable mock.poetry.base_url should
+be set in your build.properties.local file, which will  automatically add it
+to settings.php file when building the platform.
 
 
 Install as usual, see http://drupal.org/node/70151 or Run the drush command

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/README.md
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/README.md
@@ -7,6 +7,12 @@ use cases provided by European Commission Poetry translation services
 
 # Installation
 
+In order to enable the mock module, you need to set up the mock path in your
+settings.php file.
+Check the build.properties.dist file, the variable mock.poetry.base_url is
+added added autromatically to settings.php file when building the platform.
+
+
 Install as usual, see http://drupal.org/node/70151 or Run the drush command
   ```drush en tmgmt_poetry_mock```
 

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/tmgmt_poetry_mock.module
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry_mock/tmgmt_poetry_mock.module
@@ -130,13 +130,10 @@ function _check_poetry_service_variable() {
  *   Absolute URL of the mocked Poetry WSDL.
  */
 function _tmgmt_poetry_mock_get_poetry_service_wsdl() {
-  return url(
-    'tmgmt_poetry_mock/tmgmt_poetry_mock.wsdl',
-    [
-      'absolute' => TRUE,
-      'language' => (object) ['language' => FALSE],
-    ]
-  );
+  $mock_base = variable_get('poetry_mock_base_url', '');
+  if (!empty($mock_base)) {
+    return $mock_base . '/tmgmt_poetry_mock/tmgmt_poetry_mock.wsdl';
+  }
 }
 
 /**
@@ -162,6 +159,10 @@ function _tmgmt_poetry_mock_get_poetry_service_endpoint() {
  *   Absolute URL of the tmgmt_poetry WSDL.
  */
 function _tmgmt_poetry_mock_get_drupal_service_wsdl() {
+  $mock_base = variable_get('poetry_mock_base_url', '');
+  if (!empty($mock_base)) {
+    return $mock_base . "/" . drupal_get_path("module", "tmgmt_poetry") . "/wsdl/PoetryIntegration.wsdl";
+  }
   return url(
     drupal_get_path("module", "tmgmt_poetry") . "/wsdl/PoetryIntegration.wsdl",
     [


### PR DESCRIPTION
## NEPT-2193
### Description

Make small changes in build to support poetry mock on c9 by default.

### Change log

- Added: mock.poetry.base_url in build.properties.dist



