### PR TITLE
NEPT-2643: Fix func_get_args() no longer report the original value.

### DIFF
--- a/phpcs-compat.xml
+++ b/phpcs-compat.xml
@@ -31,6 +31,8 @@
     <exclude-pattern>/vendor/phing/</exclude-pattern>
     <exclude-pattern>/vendor/composer/</exclude-pattern>
 
+    <exclude-pattern>/profiles/*/modules/contrib/xml_field/modules/xml_field_test/</exclude-pattern>
+
     <arg name="extensions" value="php,inc,module,install,profile,theme"/>
     <arg name="report" value="csv"/>
     <arg name="report-file" value="php-compatibility-report.csv"/>

--- a/phpcs-compat.xml
+++ b/phpcs-compat.xml
@@ -42,5 +42,5 @@
     <!-- only print errors for now -->
     <arg name="warning-severity" value="0"/>
 
-    <config name="testVersion" value="5.6-7.0"/>
+    <config name="testVersion" value="5.6-7.2"/>
 </ruleset>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -28,7 +28,6 @@
     <exclude-pattern>profiles/common/libraries/</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_*/libraries/</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_*/modules/contrib/</exclude-pattern>
-    <exclude-pattern>profiles/*/modules/contrib/xml_field/modules/xml_field_test/</exclude-pattern>
 
     <exclude-pattern>profiles/common/modules/custom/ecas/libraries/</exclude-pattern>
     <exclude-pattern>profiles/common/modules/custom/tmgmt_poetry/tests/</exclude-pattern>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -28,6 +28,7 @@
     <exclude-pattern>profiles/common/libraries/</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_*/libraries/</exclude-pattern>
     <exclude-pattern>profiles/multisite_drupal_*/modules/contrib/</exclude-pattern>
+    <exclude-pattern>profiles/*/modules/contrib/xml_field/modules/xml_field_test/</exclude-pattern>
 
     <exclude-pattern>profiles/common/modules/custom/ecas/libraries/</exclude-pattern>
     <exclude-pattern>profiles/common/modules/custom/tmgmt_poetry/tests/</exclude-pattern>

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -908,10 +908,6 @@ projects[wysiwyg][patch][2410565] = https://www.drupal.org/files/issues/wysiwyg-
 
 projects[xml_field][subdir] = "contrib"
 projects[xml_field][version] = "2.3"
-; Issue 3077075: func_get_args(), no longer report the original value as passed to a parameter
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2643
-; https://www.drupal.org/project/xml_field/issues/3077075
-projects[xml_field][patch][] = https://www.drupal.org/files/issues/2019-08-25/xml_field-3077075-2.patch
 
 projects[xmlsitemap][subdir] = "contrib"
 projects[xmlsitemap][version] = "2.6"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -907,7 +907,11 @@ projects[wysiwyg][download][revision] = "18832abda6a2a6df93b72a6edb8b980d1e94860
 projects[wysiwyg][patch][2410565] = https://www.drupal.org/files/issues/wysiwyg-heights.2410565.5.patch
 
 projects[xml_field][subdir] = "contrib"
-projects[xml_field][version] = "2.2"
+projects[xml_field][version] = "2.3"
+; Issue 3077075: func_get_args(), no longer report the original value as passed to a parameter
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2643
+; https://www.drupal.org/project/xml_field/issues/3077075
+projects[xml_field][patch][] = https://www.drupal.org/files/issues/2019-08-25/xml_field-3077075-2.patch
 
 projects[xmlsitemap][subdir] = "contrib"
 projects[xmlsitemap][version] = "2.6"


### PR DESCRIPTION
## NEPT-2643

### Description

Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter

### Change log

- Added: Exclude rule in phpcs-compact.xml
- Changed: xml_field version to 2.3


