### PR TITLE
NEPT-2638: Fix Feeds is not compatible with php 7.2.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -260,6 +260,11 @@ projects[feature_set][patch][] = https://www.drupal.org/files/issues/feature_set
 
 projects[feeds][subdir] = "contrib"
 projects[feeds][version] = "2.0-beta4"
+; Feeds is not compatible with php 7.2.
+; https://www.drupal.org/project/feeds/issues/1139676
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2638
+projects[feeds][patch][] = https://www.drupal.org/files/issues/2019-05-17/1139676_removing_the_PHP_7.2_warning.patch
+projects[feeds][patch][] = patches/feeds-php7-nept-2638.patch
 
 ; "Feeds: Entity Translation" is a dependency for nexteuropa_newsroom module.
 ; So far, the module does not have any official release.

--- a/resources/patches/feeds-php7-nept-2638.patch
+++ b/resources/patches/feeds-php7-nept-2638.patch
@@ -1,0 +1,16 @@
+diff --git a/libraries/http_request.inc b/libraries/http_request.inc
+index ef7a15ad..200cff96 100644
+--- a/libraries/http_request.inc
++++ b/libraries/http_request.inc
+@@ -427,11 +427,6 @@ function http_request_use_curl() {
+     return FALSE;
+   }
+ 
+-  // cURL below PHP 5.6.0 must not have open_basedir or safe_mode enabled.
+-  if (version_compare(PHP_VERSION, '5.6.0', '<')) {
+-    return !ini_get('safe_mode') && !ini_get('open_basedir');
+-  }
+-
+   // cURL in PHP 5.6.0 and above re-enables CURLOPT_FOLLOWLOCATION with
+   // open_basedir so there is no need to check for this.
+   return TRUE;


### PR DESCRIPTION
## NEPT-2638

### Description

Fix Feeds is not compatible with php 7.2.

### Change log

- Added:
  - Patch 1139676_removing_the_PHP_7.2_warning.patch
  - Patch patches/feeds-php7-nept-2638.patch


