### PR TITLE
NEPT-2652: Entity Translation patch replacement

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -201,8 +201,8 @@ projects[entity_translation][version] = "1.0"
 projects[entity_translation][patch][] = https://www.drupal.org/files/issues/2018-07-25/workbench_moderation-1707156-83.patch
 ; https://www.drupal.org/node/2856927
 projects[entity_translation][patch][] = https://www.drupal.org/files/issues/entity_translation-2856927-8-dual_setter_logic.patch
-; https://www.drupal.org/node/2741407
-projects[entity_translation][patch][] = https://www.drupal.org/files/issues/entity_translation-respect_pathauto_state-2741407-6_0.patch
+; https://www.drupal.org/project/entity_translation/issues/3010146
+projects[entity_translation][patch][] = https://www.drupal.org/files/issues/2018-10-30/entity_translation-pathauto_exposed_configuration-3010146-2.patch
 
 projects[entitycache][subdir] = "contrib"
 projects[entitycache][version] = 1.5


### PR DESCRIPTION
## NEPT-2652
### Description

This patch that we are using 
https://www.drupal.org/node/2741407

Will be replaced by this config feature
https://www.drupal.org/project/entity_translation/issues/3010146

This task is to replace the first patch with the second patch

### Change log

- Changed: replaced patch for entity_translation in multisite_drupal_standard.make


