### PR TITLE
NEPT-520: Prevent EU Login to create 2 users with the same email.

### DIFF
--- a/profiles/common/modules/custom/ecas/ecas.api.php
+++ b/profiles/common/modules/custom/ecas/ecas.api.php
@@ -6,6 +6,45 @@
  */
 
 /**
+ * Alters the Ecas login process before performing Drupal-Ecas synchronisation.
+  *
+  * It is triggered just after getting the Drupal user based on the Ecas user
+  * name.
+  * It allows modifying the process based on Drupal user properties or fields
+  * of an existing account or the Ecas user name.
+  *
+  * Note also that the phpCAS object is already available and instantiated with
+  * the current Ecas user data.
+  *
+  * @param string $ecas_name
+  *   The user name as defined in Ecas.
+  * @param bool|object $account
+  *   The Drupal user object associated to the Ecas user name or FALSE if the
+  *   user is not registered in Drupal yet.
+  * @param string $destination
+  *   The final destination value as set at Ecas module level.
+  *   This value is also by default the value stored in session,
+  *   $_SESSION['ecas_goto'].
+  *
+  * @see user_load_by_name()
+  * @see hook_ecas_sync_user_info()
+  */
+function hook_ecas_extra_filter_alter(&$ecas_name, &$account, &$destination) {
+   if (!$account) {
+     $ecas_attributes = phpCAS::getAttributes();
+     $first_name = $ecas_attributes['cas:firstName'];
+     $last_name = $ecas_attributes['cas:lastName'];
+
+     $drupal_lastname = field_get_items('user', $account, 'field_lastname');
+     $drupal_firstname = field_get_items('user', $account, 'field_firstname');
+     if (($drupal_lastname[0]['value'] != $last_name) || ($drupal_firstname[0]['value'] != $first_name)) {
+       unset($_REQUEST['destination']);
+       drupal_goto('custom_error_page');
+     }
+   }
+ }
+
+/**
  * Acts on the list of user data value to save of the Ecas user.
  *
  * @param object $user

--- a/profiles/common/modules/custom/ecas/ecas.api.php
+++ b/profiles/common/modules/custom/ecas/ecas.api.php
@@ -7,42 +7,42 @@
 
 /**
  * Alters the Ecas login process before performing Drupal-Ecas synchronisation.
-  *
-  * It is triggered just after getting the Drupal user based on the Ecas user
-  * name.
-  * It allows modifying the process based on Drupal user properties or fields
-  * of an existing account or the Ecas user name.
-  *
-  * Note also that the phpCAS object is already available and instantiated with
-  * the current Ecas user data.
-  *
-  * @param string $ecas_name
-  *   The user name as defined in Ecas.
-  * @param bool|object $account
-  *   The Drupal user object associated to the Ecas user name or FALSE if the
-  *   user is not registered in Drupal yet.
-  * @param string $destination
-  *   The final destination value as set at Ecas module level.
-  *   This value is also by default the value stored in session,
-  *   $_SESSION['ecas_goto'].
-  *
-  * @see user_load_by_name()
-  * @see hook_ecas_sync_user_info()
-  */
+ *
+ * It is triggered just after getting the Drupal user based on the Ecas user
+ * name.
+ * It allows modifying the process based on Drupal user properties or fields
+ * of an existing account or the Ecas user name.
+ *
+ * Note also that the phpCAS object is already available and instantiated with
+ * the current Ecas user data.
+ *
+ * @param string $ecas_name
+ *   The user name as defined in Ecas.
+ * @param bool|object $account
+ *   The Drupal user object associated to the Ecas user name or FALSE if the
+ *   user is not registered in Drupal yet.
+ * @param string $destination
+ *   The final destination value as set at Ecas module level.
+ *   This value is also by default the value stored in session,
+ *   $_SESSION['ecas_goto'].
+ *
+ * @see user_load_by_name()
+ * @see hook_ecas_sync_user_info()
+ */
 function hook_ecas_extra_filter_alter(&$ecas_name, &$account, &$destination) {
-   if (!$account) {
-     $ecas_attributes = phpCAS::getAttributes();
-     $first_name = $ecas_attributes['cas:firstName'];
-     $last_name = $ecas_attributes['cas:lastName'];
+  if (!$account) {
+    $ecas_attributes = phpCAS::getAttributes();
+    $first_name = $ecas_attributes['cas:firstName'];
+    $last_name = $ecas_attributes['cas:lastName'];
 
-     $drupal_lastname = field_get_items('user', $account, 'field_lastname');
-     $drupal_firstname = field_get_items('user', $account, 'field_firstname');
-     if (($drupal_lastname[0]['value'] != $last_name) || ($drupal_firstname[0]['value'] != $first_name)) {
-       unset($_REQUEST['destination']);
-       drupal_goto('custom_error_page');
-     }
-   }
- }
+    $drupal_lastname = field_get_items('user', $account, 'field_lastname');
+    $drupal_firstname = field_get_items('user', $account, 'field_firstname');
+    if (($drupal_lastname[0]['value'] != $last_name) || ($drupal_firstname[0]['value'] != $first_name)) {
+      unset($_REQUEST['destination']);
+      drupal_goto('custom_error_page');
+    }
+  }
+}
 
 /**
  * Acts on the list of user data value to save of the Ecas user.

--- a/profiles/common/modules/custom/ecas/ecas.info
+++ b/profiles/common/modules/custom/ecas/ecas.info
@@ -2,3 +2,5 @@ name = EU Login
 core = 7.x
 package = "ECAS"
 description = "Provides single sign-on EU Login (former ECAS)"
+
+dependencies[] = filter

--- a/profiles/common/modules/custom/ecas/ecas.module
+++ b/profiles/common/modules/custom/ecas/ecas.module
@@ -12,7 +12,7 @@
  *
  * Both will be included from the FPFIS_COMMON_LIBRARIES_PATH.
  */
- 
+
 // Include the constants sued in the different part of the module.
 $constants_ecas_module_include = drupal_get_path('module', 'ecas') . '/includes/ecas.constants.inc';
 include_once $constants_ecas_module_include;

--- a/profiles/common/modules/custom/ecas/ecas.module
+++ b/profiles/common/modules/custom/ecas/ecas.module
@@ -12,10 +12,12 @@
  *
  * Both will be included from the FPFIS_COMMON_LIBRARIES_PATH.
  */
+ 
+// Include the constants sued in the different part of the module.
+$constants_ecas_module_include = drupal_get_path('module', 'ecas') . '/includes/ecas.constants.inc';
+include_once $constants_ecas_module_include;
 
-define('ECAS_MIN_PHPCAS_VERSION', "1.3.3");
-
-// Include the admin part of the module first.
+// Include the admin part of the module.
 $admin_ecas_module_include = drupal_get_path('module', 'ecas') . '/includes/ecas.admin.inc';
 include_once $admin_ecas_module_include;
 

--- a/profiles/common/modules/custom/ecas/ecas.variable.inc
+++ b/profiles/common/modules/custom/ecas/ecas.variable.inc
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @file
+ * Definition of module's variables for Variable API module.
+ */
+
+/**
+ * Implements hook_variable_info().
+ */
+function ecas_variable_info($options) {
+  $variables = array();
+  $variables[ECAS_WARNING_MESSAGE_NO_EMAIL] = array(
+    'type' => 'text_format',
+    'title' => t('Error message text in case of an missing e-mail address', array(), $options),
+    'default' => _ecas_get_default_warning_message(ECAS_WARNING_MESSAGE_NO_EMAIL),
+    'description' => t('Text supplying information about the error caused by the absence of the e-mail in the EU Login profile.'),
+    'required' => TRUE,
+    'group' => 'ecas',
+    'localize' => TRUE,
+  );
+
+  $variables[ECAS_WARNING_MESSAGE_EXISTING_EMAIL] = array(
+    'type' => 'text_format',
+    'title' => t('Error message text in case of an e-mail address already used', array(), $options),
+    'default' => _ecas_get_default_warning_message(ECAS_WARNING_MESSAGE_EXISTING_EMAIL),
+    'description' => t('Text supplying information about the error caused by the an e-mail in the EU Login profile used in another.'),
+    'required' => TRUE,
+    'group' => 'ecas',
+    'localize' => TRUE,
+  );
+
+  $variables[ECAS_WARNING_MESSAGE_NOT_CREATED] = array(
+    'type' => 'text_format',
+    'title' => t('Error message text in case of an drupal user is not created', array(), $options),
+    'default' => _ecas_get_default_warning_message(ECAS_WARNING_MESSAGE_NOT_CREATED),
+    'description' => t('Text supplying information about the error caused by the non-creation of Drupal user from an EU Login profile.'),
+    'required' => TRUE,
+    'group' => 'ecas',
+    'localize' => TRUE,
+  );
+
+  $variables[ECAS_WARNING_MESSAGE_INCOMPLETE_USER] = array(
+    'type' => 'text_format',
+    'title' => t('Error message text in case of an ecas user is incomplete', array(), $options),
+    'default' => _ecas_get_default_warning_message(ECAS_WARNING_MESSAGE_INCOMPLETE_USER),
+    'description' => t(
+      'Text supplying information about the error because the EU Login profile does not contain the required data, other then the email.'
+    ),
+    'required' => TRUE,
+    'group' => 'ecas',
+    'localize' => TRUE,
+  );
+
+  $variables[ECAS_LOGIN_MESSAGE] = array(
+    'type' => 'string',
+    'title' => t('Login message', array(), $options),
+    'default' => _ecas_get_default_login_message(),
+    'description' => t('Status message shown to the user after login. Available placeholders: %ecas_username.'),
+    'group' => 'ecas',
+    'localize' => TRUE,
+  );
+
+  $variables[ECAS_WARNING_MESSAGE] = array(
+    'type' => 'text_format',
+    'title' => t('Warning page message', array(), $options),
+    'default' => _ecas_get_default_warning_message(ECAS_WARNING_MESSAGE),
+    'description' => t('Message on the warning page when a blocked account user is trying to log in'),
+    'group' => 'ecas',
+    'localize' => TRUE,
+  );
+
+  return $variables;
+}
+
+/**
+ * Implements hook_variable_group_info().
+ */
+function ecas_variable_group_info() {
+  $groups['ecas'] = array(
+    'title' => t('Ecas'),
+    'description' => t('Configure tracking behavior to get insights into your website traffic and marketing effectiveness.'),
+    'access' => 'administer piwik',
+    'path' => array('admin/config/ecas/settings'),
+  );
+
+  return $groups;
+}

--- a/profiles/common/modules/custom/ecas/ecas.variable.inc
+++ b/profiles/common/modules/custom/ecas/ecas.variable.inc
@@ -70,6 +70,15 @@ function ecas_variable_info($options) {
     'localize' => TRUE,
   );
 
+  $variables[ECAS_WARNING_MESSAGE_SOCIAL] = array(
+    'type' => 'text_format',
+    'title' => t('Error message text in case of social login', array(), $options),
+    'default' => _ecas_get_default_warning_message(ECAS_WARNING_MESSAGE_SOCIAL),
+    'description' => t('Warning when a user with more then authenticated role is trying to log in with social media login.'),
+    'group' => 'ecas',
+    'localize' => TRUE,
+  );
+
   return $variables;
 }
 

--- a/profiles/common/modules/custom/ecas/ecas_import_users/ecas_import_users.module
+++ b/profiles/common/modules/custom/ecas/ecas_import_users/ecas_import_users.module
@@ -143,7 +143,7 @@ function ecas_import_users_admin_settings($form, &$form_state) {
  */
 function ecas_import_users_page_content() {
   // Display tabs.
-  $output = theme('tabs_tabset', menu_local_tasks());
+  $output = '';
 
   // Forms.
   if (function_exists('getLdapEntries')) {
@@ -296,9 +296,8 @@ function ecas_import_users_show_user_content() {
   );
 
   // Display tabs.
-  $output = theme('tabs_tabset', menu_local_tasks());
   $form = drupal_get_form('ecas_import_users_show_user_content_form', $import_arguments);
-  $output .= drupal_render($form);
+  $output = drupal_render($form);
 
   return $output;
 }
@@ -489,42 +488,65 @@ function ecas_import_users_show_user_content_form_submit($form, &$form_state) {
 
   $imported_users = array();
   foreach ($users as $value) {
-    if ($value != '0') {
-      list($uid, $mail, $firstname, $lastname, $domain, $departmentnumber) = explode('|', $value);
-      $account = user_load_by_name($uid);
-      // If the user account doesn't exit.
-      if (!$account) {
-
-        // 1 is "active", 0 is "blocked".
-        $account = ecas_create_user($uid, array(
-          'status' => variable_get('ecas_import_users_default_status', 1),
-        ));
-
-        if ($account && $account->uid > 0) {
-          // Save user profile data.
-          ecas_sync_user_info(
-              $account,
-              array(
-                'cas:email' => $mail,
-                'cas:firstName' => $firstname,
-                'cas:lastName' => $lastname,
-                'cas:domain' => $domain,
-                'cas:departmentNumber' => $departmentnumber,
-              ),
-              // This allows other modules to detect a user creation.
-              array('ecas_import_users_user_creation' => TRUE)
-          );
-          drupal_set_message(t('User @user_uid imported', array('@user_uid' => $uid)));
-          $imported_users[] = $uid;
-        }
-        else {
-          drupal_set_message(t('User @user_uid not imported', array('@user_uid' => $uid)));
-        }
-      }
-      else {
-        drupal_set_message(t('User @user_uid not imported', array('@user_uid' => $uid)));
-      }
+    if (empty($value)) {
+      continue;
     }
+
+    list($uid, $mail, $firstname, $lastname, $domain, $departmentnumber) = explode('|', $value);
+    $account = user_load_by_name($uid);
+
+    // If the user account exit, we continue with the next one, no update.
+    if ($account) {
+      drupal_set_message(t('User @user_uid not imported because it already exists.', array('@user_uid' => $uid)));
+      continue;
+    }
+
+    // Let's prepare the account object from ladp data.
+    $ldap_attributes = array(
+      'cas:email' => $mail,
+      'cas:firstName' => $firstname,
+      'cas:lastName' => $lastname,
+      'cas:domain' => $domain,
+      'cas:departmentNumber' => $departmentnumber,
+    );
+    $account = ecas_prepare_drupal_user($uid, NULL, $ldap_attributes);
+
+    $ecas_sync_user_info_args = array('ecas_import_users_user_creation' => $account->is_new);
+
+    // Let's sync other ladp user data on drupal user ones according to the
+    // site specificity.
+    // There is no save inside, that will be do after further validations.
+    $account_edit = ecas_sync_drupal_user_with_ecas_info(
+      $account,
+      $ldap_attributes,
+      // This allows other modules to detect a user creation.
+      $ecas_sync_user_info_args
+    );
+
+    // Check the validity of the user.
+    // The ecas user must have an defined e-mail; otherwise the drupal
+    // authentication is denied.
+    if (empty($account_edit['mail'])) {
+      drupal_set_message(t('User @user_uid is not imported because the e-mail is missing.', array('@user_uid' => $uid)), 'error');
+      continue;
+    }
+
+    // Check that the email is not present for another account.
+    if (ecas_is_email_already_used($account_edit['mail'], $account)) {
+      drupal_set_message(t('User @user_uid is not imported because the e-mail is already used by another account.', array('@user_uid' => $uid)), 'error');
+      continue;
+    }
+
+    // Time to save the user.
+    $saved_account = ecas_save_user($account, $account_edit, $ldap_attributes, $ecas_sync_user_info_args);
+
+    if (!$saved_account || ($account->uid === 0)) {
+      drupal_set_message(t('User @user_uid is not imported correctly because of an issue during the Drupal user saving.', array('@user_uid' => $uid)), 'error');
+      continue;
+    }
+
+    drupal_set_message(t('User @user_uid is imported correctly.', array('@user_uid' => $uid)));
+    $imported_users[] = $uid;
   }
   module_invoke_all('ecas_users_imported', array('imported_users' => $imported_users));
 

--- a/profiles/common/modules/custom/ecas/includes/ecas.admin.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.admin.inc
@@ -152,7 +152,7 @@ function ecas_admin_settings() {
     '#rows' => 5,
     '#description' => t('Message on the warning page when a blocked account user is trying to log in'),
   );
-  
+
   _ecas_text_format_set_default_value($form['param'], ECAS_WARNING_MESSAGE);
 
   $form['param'][ECAS_WARNING_MESSAGE_NO_EMAIL] = array(
@@ -162,50 +162,50 @@ function ecas_admin_settings() {
     '#rows' => 5,
     '#description' => t('Text supplying information about the error caused by the an e-mail in the EU Login profile used in another.'),
   );
-  
+
   _ecas_text_format_set_default_value(
     $form['param'],
     ECAS_WARNING_MESSAGE_NO_EMAIL
   );
 
- $form['param'][ECAS_WARNING_MESSAGE_EXISTING_EMAIL] = array(
-   '#type' => 'text_format',
-   '#title' => t('Error message text in case of an e-mail address already used'),
-   '#cols' => 60,
-   '#rows' => 5,
-   '#description' => t('Text supplying information about the error caused by the an e-mail in the EU Login profile used in another.'),
- );
- 
- _ecas_text_format_set_default_value(
+  $form['param'][ECAS_WARNING_MESSAGE_EXISTING_EMAIL] = array(
+    '#type' => 'text_format',
+    '#title' => t('Error message text in case of an e-mail address already used'),
+    '#cols' => 60,
+    '#rows' => 5,
+    '#description' => t('Text supplying information about the error caused by the an e-mail in the EU Login profile used in another.'),
+  );
+
+  _ecas_text_format_set_default_value(
    $form['param'],
    ECAS_WARNING_MESSAGE_EXISTING_EMAIL
- );
+  );
 
- $form['param'][ECAS_WARNING_MESSAGE_NOT_CREATED] = array(
-   '#type' => 'text_format',
-   '#title' => t('Error message text in case of an drupal user is not created'),
-   '#cols' => 60,
-   '#rows' => 5,
-   '#description' => t('Text supplying information about the error caused by the non-creation of Drupal user from an EU Login profile.'),
- );
- _ecas_text_format_set_default_value(
+  $form['param'][ECAS_WARNING_MESSAGE_NOT_CREATED] = array(
+    '#type' => 'text_format',
+    '#title' => t('Error message text in case of an drupal user is not created'),
+    '#cols' => 60,
+    '#rows' => 5,
+    '#description' => t('Text supplying information about the error caused by the non-creation of Drupal user from an EU Login profile.'),
+  );
+  _ecas_text_format_set_default_value(
    $form['param'],
    ECAS_WARNING_MESSAGE_NOT_CREATED
- );
+  );
 
- $form['param'][ECAS_WARNING_MESSAGE_INCOMPLETE_USER] = array(
-   '#type' => 'text_format',
-   '#title' => t('Error message text in case of an ecas user is incomplete'),
-   '#cols' => 60,
-   '#rows' => 5,
-   '#description' => t(
+  $form['param'][ECAS_WARNING_MESSAGE_INCOMPLETE_USER] = array(
+    '#type' => 'text_format',
+    '#title' => t('Error message text in case of an ecas user is incomplete'),
+    '#cols' => 60,
+    '#rows' => 5,
+    '#description' => t(
      'Text supplying information about the error because the EU Login profile does not contain the required data, other then the email.'
-   ),
- );
- _ecas_text_format_set_default_value(
+    ),
+  );
+  _ecas_text_format_set_default_value(
    $form['param'],
    ECAS_WARNING_MESSAGE_INCOMPLETE_USER
- );
+  );
 
   $form['param']['ecas_update_mail_address'] = array(
     '#type' => 'checkbox',
@@ -332,25 +332,25 @@ function _ecas_domains() {
 }
 
 /**
-  * Sets the default value of a text_format form input based on a variable.
-  *
-  * @param array $form_param_input
-  *   The 'param' item of the form input containing the where to set the
-  *   default value.
-  * @param string $variable_name
-  *   The variable name containing the default value.
-  */
+ * Sets the default value of a text_format form input based on a variable.
+ *
+ * @param array $form_param_input
+ *   The 'param' item of the form input containing the where to set the
+ *   default value.
+ * @param string $variable_name
+ *   The variable name containing the default value.
+ */
 function _ecas_text_format_set_default_value(array &$form_param_input, $variable_name) {
 
- $value = variable_get($variable_name, _ecas_get_default_warning_message($variable_name));
+  $value = variable_get($variable_name, _ecas_get_default_warning_message($variable_name));
 
- if (is_array($value)) {
-   $form_param_input[$variable_name]['#default_value'] = $value['value'];
-   $form_param_input[$variable_name]['#format'] = $value['format'];
+  if (is_array($value)) {
+    $form_param_input[$variable_name]['#default_value'] = $value['value'];
+    $form_param_input[$variable_name]['#format'] = $value['format'];
 
-   return;
- }
+    return;
+  }
 
- $form_param_input[$variable_name]['#default_value'] = $value;
- $form_param_input[$variable_name]['#format'] = filter_default_format();
+  $form_param_input[$variable_name]['#default_value'] = $value;
+  $form_param_input[$variable_name]['#format'] = filter_default_format();
 }

--- a/profiles/common/modules/custom/ecas/includes/ecas.admin.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.admin.inc
@@ -5,10 +5,6 @@
  * Administration forms for the ECAS module.
  */
 
-// Include the minimum codebase for this module.
-$constants_ecas_module_include = drupal_get_path('module', 'ecas') . '/includes/ecas.constants.inc';
-include_once $constants_ecas_module_include;
-
 /**
  * Implements hook_help().
  *
@@ -142,32 +138,80 @@ function ecas_admin_settings() {
     '#description' => t('Status of the user account after creation'),
   );
 
-  $form['param']['ecas_login_message'] = array(
+  $form['param'][ECAS_LOGIN_MESSAGE] = array(
     '#type' => 'textfield',
     '#title' => t('Login message'),
-    '#default_value' => variable_get('ecas_login_message', ECAS_DEFAULT_LOGIN_MESSAGE),
+    '#default_value' => variable_get(ECAS_LOGIN_MESSAGE, _ecas_get_default_login_message()),
     '#description' => t('Status message shown to the user after login. Available placeholders: %ecas_username'),
   );
-  $form['param']['ecas_warning_message'] = array(
-    '#type' => 'textarea',
+
+  $form['param'][ECAS_WARNING_MESSAGE] = array(
+    '#type' => 'text_format',
     '#title' => t('Warning page message'),
-    '#default_value' => variable_get('ecas_warning_message', ECAS_DEFAULT_WARNING_MESSAGE),
     '#cols' => 60,
     '#rows' => 5,
     '#description' => t('Message on the warning page when a blocked account user is trying to log in'),
   );
+  
+  _ecas_text_format_set_default_value($form['param'], ECAS_WARNING_MESSAGE);
+
+  $form['param'][ECAS_WARNING_MESSAGE_NO_EMAIL] = array(
+    '#type' => 'text_format',
+    '#title' => t('Error message text in case of an missing e-mail address'),
+    '#cols' => 60,
+    '#rows' => 5,
+    '#description' => t('Text supplying information about the error caused by the an e-mail in the EU Login profile used in another.'),
+  );
+  
+  _ecas_text_format_set_default_value(
+    $form['param'],
+    ECAS_WARNING_MESSAGE_NO_EMAIL
+  );
+
+ $form['param'][ECAS_WARNING_MESSAGE_EXISTING_EMAIL] = array(
+   '#type' => 'text_format',
+   '#title' => t('Error message text in case of an e-mail address already used'),
+   '#cols' => 60,
+   '#rows' => 5,
+   '#description' => t('Text supplying information about the error caused by the an e-mail in the EU Login profile used in another.'),
+ );
+ 
+ _ecas_text_format_set_default_value(
+   $form['param'],
+   ECAS_WARNING_MESSAGE_EXISTING_EMAIL
+ );
+
+ $form['param'][ECAS_WARNING_MESSAGE_NOT_CREATED] = array(
+   '#type' => 'text_format',
+   '#title' => t('Error message text in case of an drupal user is not created'),
+   '#cols' => 60,
+   '#rows' => 5,
+   '#description' => t('Text supplying information about the error caused by the non-creation of Drupal user from an EU Login profile.'),
+ );
+ _ecas_text_format_set_default_value(
+   $form['param'],
+   ECAS_WARNING_MESSAGE_NOT_CREATED
+ );
+
+ $form['param'][ECAS_WARNING_MESSAGE_INCOMPLETE_USER] = array(
+   '#type' => 'text_format',
+   '#title' => t('Error message text in case of an ecas user is incomplete'),
+   '#cols' => 60,
+   '#rows' => 5,
+   '#description' => t(
+     'Text supplying information about the error because the EU Login profile does not contain the required data, other then the email.'
+   ),
+ );
+ _ecas_text_format_set_default_value(
+   $form['param'],
+   ECAS_WARNING_MESSAGE_INCOMPLETE_USER
+ );
 
   $form['param']['ecas_update_mail_address'] = array(
     '#type' => 'checkbox',
     '#title' => t("Update the user's mail address at login time."),
     '#default_value' => variable_get('ecas_update_mail_address', 1),
     '#description' => t('If this option is checked, the EU Login module will replace the mail address of the user with the one retrieved from the LDAP instance.'),
-  );
-  $form['param']['ecas_default_mail_address'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Default mail address'),
-    '#default_value' => variable_get('ecas_default_mail_address', ECAS_DEFAULT_MAIL_ADDRESS),
-    '#description' => t('This address will be assigned to the user if the previous option is disabled.'),
   );
 
   // ECAS has these extra user profile fields:
@@ -232,32 +276,6 @@ function ecas_admin_settings() {
     );
   }
 
-  // Commented out. No longer working and reactivating it breaks ECAS logic.
-  /*$form['param']['ecas_pages_method'] = array(
-  '#type' => 'radios',
-  '#title' => t('Force ECAS authentication on specific pages'),
-  '#options' => array(
-  ECAS_LOGIN_EXLUDE_PAGES => t('All pages except those listed'),
-  ECAS_LOGIN_INCLUDE_PAGES => t('Only the listed pages'),
-  ),
-  '#default_value' => variable_get('ecas_pages_method',
-  ECAS_LOGIN_INCLUDE_PAGES),
-  );
-  $args = array(
-  '%blog' => 'blog',
-  '%blog-wildcard' => 'blog/*',
-  '%front' => '<front>',
-  );
-  $form['param']['ecas_pages'] = array(
-  '#type' => 'textarea',
-  '#title' => '<span class="element-invisible">' . t('Pages') . '</span>',
-  '#default_value' => variable_get('ecas_pages', ECAS_DEFAULT_PAGES),
-  '#description' => t("Specify pages by using their paths.
-  Enter one path per line. The '*' character is a wildcard.
-  Example paths are %blog for the blog page and %blog-wildcard for
-  every personal blog. %front is the front page.", $args),
-  );
-   */
   // FPFIS Common SETTINGS.
   // Checkbox to enable or disable the whole FPFIS integration stuff.
   $form['param']['ecas_use_shared_fpfis'] = array(
@@ -311,4 +329,28 @@ function _ecas_domains() {
   );
   drupal_alter('ecas_domains', $known_ecas_domains);
   return $known_ecas_domains;
+}
+
+/**
+  * Sets the default value of a text_format form input based on a variable.
+  *
+  * @param array $form_param_input
+  *   The 'param' item of the form input containing the where to set the
+  *   default value.
+  * @param string $variable_name
+  *   The variable name containing the default value.
+  */
+function _ecas_text_format_set_default_value(array &$form_param_input, $variable_name) {
+
+ $value = variable_get($variable_name, _ecas_get_default_warning_message($variable_name));
+
+ if (is_array($value)) {
+   $form_param_input[$variable_name]['#default_value'] = $value['value'];
+   $form_param_input[$variable_name]['#format'] = $value['format'];
+
+   return;
+ }
+
+ $form_param_input[$variable_name]['#default_value'] = $value;
+ $form_param_input[$variable_name]['#format'] = filter_default_format();
 }

--- a/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
@@ -4,6 +4,8 @@
  * @file
  * Contains the constants used for connecting to the ECAS server.
  */
+ 
+define('ECAS_MIN_PHPCAS_VERSION', "1.3.3");
 
 $use_shared_fpfis = variable_get('ecas_use_shared_fpfis', FALSE);
 if ($use_shared_fpfis) {
@@ -34,8 +36,6 @@ define('ECAS_DEFAULT_CHANGE_PASSWORD_URL', 'https://ecas.ec.europa.eu/cas/init/p
 
 define('ECAS_DEFAULT_DEBUG_LOGPATH', 'phpCas.log');
 
-define('ECAS_DEFAULT_LOGIN_MESSAGE', 'Logged in via EU Login as %ecas_username.');
-define('ECAS_DEFAULT_WARNING_MESSAGE', 'Your account is not yet approved');
 define('ECAS_DEFAULT_MAIL_ADDRESS', 'unknown.mail@nomail.nodomain.tld');
 
 define('ECAS_DEFAULT_PROFILE_FIRSTNAME_FIELD', 'field_firstname');
@@ -49,3 +49,48 @@ define('ECAS_GATEWAY', 2);
 define('ECAS_DEFAULT_PAGES', '');
 define('ECAS_LOGIN_EXLUDE_PAGES', 0);
 define('ECAS_LOGIN_INCLUDE_PAGES', 1);
+
+/**
+  * ECAS group for CEM team users.
+  */
+define('ECAS_CEM_ECAS_GROUP', 'COMM_CEM');
+
+ /**
+  * Name of the ecas login message variable.
+  */
+define('ECAS_LOGIN_MESSAGE', 'ecas_login_message');
+
+ /**
+  * Name of the ecas login message variable.
+  */
+define('ECAS_WARNING_MESSAGE', 'ecas_warning_message');
+
+ /**
+  * Name of the ecas no email variable message variable.
+  */
+define('ECAS_WARNING_MESSAGE_NO_EMAIL', 'ecas_no_email_message');
+
+ /**
+  * Name of the ecas existing email  message variable.
+  */
+define('ECAS_WARNING_MESSAGE_EXISTING_EMAIL', 'ecas_existing_mail_message');
+
+ /**
+  * Name of the ecas existing email  message variable.
+  */
+define('ECAS_WARNING_MESSAGE_NOT_CREATED', 'ecas_not_created_message');
+
+ /**
+  * Name of the ecas incomplete user  message variable.
+  */
+define('ECAS_WARNING_MESSAGE_INCOMPLETE_USER', 'ecas_incomplete_user_message');
+
+ /**
+  * Ids for the different reasons causing a ECAS login failures.
+  */
+define('ECAS_WARNING_REASON_NO_EMAIL', 'no_mail');
+define('ECAS_WARNING_REASON_EXISTING_EMAIL', 'mail_already_exists');
+define('ECAS_WARNING_REASON_NOT_CREATED', 'not_created');
+define('ECAS_WARNING_REASON_BLOCKED', 'account_blocked');
+define('ECAS_WARNING_REASON_INCOMPLETE_USER', 'ecas_incomplete_user');
+define('ECAS_WARNING_REASON_UNKNOWN', 'unknown');

--- a/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
@@ -4,7 +4,7 @@
  * @file
  * Contains the constants used for connecting to the ECAS server.
  */
- 
+
 define('ECAS_MIN_PHPCAS_VERSION', "1.3.3");
 
 $use_shared_fpfis = variable_get('ecas_use_shared_fpfis', FALSE);
@@ -55,37 +55,37 @@ define('ECAS_LOGIN_INCLUDE_PAGES', 1);
   */
 define('ECAS_CEM_ECAS_GROUP', 'COMM_CEM');
 
- /**
+/**
   * Name of the ecas login message variable.
   */
 define('ECAS_LOGIN_MESSAGE', 'ecas_login_message');
 
- /**
+/**
   * Name of the ecas login message variable.
   */
 define('ECAS_WARNING_MESSAGE', 'ecas_warning_message');
 
- /**
+/**
   * Name of the ecas no email variable message variable.
   */
 define('ECAS_WARNING_MESSAGE_NO_EMAIL', 'ecas_no_email_message');
 
- /**
+/**
   * Name of the ecas existing email  message variable.
   */
 define('ECAS_WARNING_MESSAGE_EXISTING_EMAIL', 'ecas_existing_mail_message');
 
- /**
+/**
   * Name of the ecas existing email  message variable.
   */
 define('ECAS_WARNING_MESSAGE_NOT_CREATED', 'ecas_not_created_message');
 
- /**
+/**
   * Name of the ecas incomplete user  message variable.
   */
 define('ECAS_WARNING_MESSAGE_INCOMPLETE_USER', 'ecas_incomplete_user_message');
 
- /**
+/**
   * Ids for the different reasons causing a ECAS login failures.
   */
 define('ECAS_WARNING_REASON_NO_EMAIL', 'no_mail');

--- a/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
@@ -86,8 +86,14 @@ define('ECAS_WARNING_MESSAGE_NOT_CREATED', 'ecas_not_created_message');
 define('ECAS_WARNING_MESSAGE_INCOMPLETE_USER', 'ecas_incomplete_user_message');
 
 /**
+  * Name of the ecas no email variable message variable.
+  */
+define('ECAS_WARNING_MESSAGE_SOCIAL', 'social_role_not_allowed_message');
+
+/**
   * Ids for the different reasons causing a ECAS login failures.
   */
+define('ECAS_WARNING_REASON_SOCIAL', 'social_role_not_allowed');
 define('ECAS_WARNING_REASON_NO_EMAIL', 'no_mail');
 define('ECAS_WARNING_REASON_EXISTING_EMAIL', 'mail_already_exists');
 define('ECAS_WARNING_REASON_NOT_CREATED', 'not_created');

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -6,11 +6,6 @@
  */
 
 /**
- * ECAS group for CEM team users.
- */
-define('ECAS_CEM_ECAS_GROUP', 'COMM_CEM');
-
-/**
  * Checks if the given user is an ECAS user.
  *
  * @param object $user
@@ -27,6 +22,7 @@ function _is_ecas_user($user) {
       }
     }
   }
+
   return FALSE;
 }
 
@@ -141,14 +137,38 @@ function _ecas_menu(array &$items) {
     'type' => MENU_SUGGESTED_ITEM,
   );
 
-  $items['ecas_warning_page'] = array(
+  // NEPT-520: the use of eu login in the path has 2 goals:
+  // The first is to give a path value aligned with the new official name of
+  // the European SSO tool.
+  // The second is avoiding to complicate the suffix based language negotiation
+  // process by adding an new exception in the "ecas" path exception in the
+  // process.
+  // see nexteuropa_multilingual_language_negotiation_url_rewrite_callback().
+  $items['eulogin_warning/%'] = array(
     'title' => 'EU Login warning',
     'page callback' => 'ecas_warning_page',
+    'page arguments' => array(1),
     'access arguments' => array('access content'),
     'type' => MENU_CALLBACK,
   );
 
   return $items;
+}
+
+/**
+  * Implements hook_theme().
+  */
+function ecas_theme() {
+ return array(
+   'ecas_profile_warning_page' => array(
+     'variables' =>
+       array(
+         'warning_title' => NULL,
+         'warning_text' => NULL,
+       ),
+     'template' => 'theme/templates/ecas-profile-warning-page',
+   ),
+ );
 }
 
 /**
@@ -197,7 +217,14 @@ function ecas_menu_check() {
  * Redirects the user to the ECAS login page.
  */
 function ecas_login_page() {
-  ecas_login_check();
+  try {
+   ecas_login_check();
+  }
+  catch (Exception $e) {
+    watchdog_exception('user', $e);
+    _ecas_warning_goto(ECAS_WARNING_REASON_UNKNOWN, NULL, 'The EU login connection failed.');
+  }
+
   $destination = variable_get('site_frontpage', 'node');
 
   // If it is the user's first CAS login and initial login redirection is
@@ -265,18 +292,21 @@ function ecas_logout($full_logout = TRUE, $call_hook_user_logout = TRUE) {
  */
 function ecas_save_page() {
   // The page is saved only if it is not done already.
-  if (!isset($_SESSION['ecas_goto'])) {
-    if (arg(0) == 'ecas') {
-      // Saving the ECAS page does not make sense, use HTTP referer (absolute
-      // URL) instead.
-      $referer = (isset($_GET['referer'])) ? $_GET['referer'] : $_SERVER['HTTP_REFERER'];
-      $_SESSION['ecas_goto'] = $referer;
-    }
-    else {
-      // Save the Drupal path (i.e. not an absolute URL).
-      $_SESSION['ecas_goto'] = $_GET['q'];
-    }
+  if (isset($_SESSION['ecas_goto'])) {
+    return;
   }
+  
+  if (arg(0) == 'ecas') {
+    // Saving the ECAS page does not make sense, use HTTP referer (absolute
+    // URL) instead.
+    $referer = (isset($_GET['referer'])) ? $_GET['referer'] : $_SERVER['HTTP_REFERER'];
+    $_SESSION['ecas_goto'] = $referer;
+    
+    return;
+  }
+  
+  // Save the Drupal path (i.e. not an absolute URL).
+  $_SESSION['ecas_goto'] = $_GET['q'];
 }
 
 /**
@@ -296,25 +326,26 @@ function ecas_save_page() {
  *   time.
  *   It is the same array structure as in the user_save().
  *
- * @see ecas_sync_user_info()
+ * @see ecas_sync_drupal_user_with_ecas_info()
  */
 function ecas_sync_profile_core(&$user, array $user_info, array &$edit = array()) {
   $field_firstname = trim(variable_get('ecas_profile_core_firstname_field', 'field_firstname'));
   $field_lastname = trim(variable_get('ecas_profile_core_lastname_field', 'field_lastname'));
   $field_ecasmail = trim(variable_get('ecas_profile_core_ecas_email_field', 'field_ecas_mail'));
   $field_ecascreator = trim(variable_get('ecas_profile_core_ecas_creator_field', 'field_creator'));
+  $user_fields = field_info_instances('user', 'user');
 
   // You can now access the fields without knowing the language.
-  if (!empty($field_firstname) && isset($user->{$field_firstname})) {
+  if (!empty($field_firstname) && isset($user_fields[$field_firstname])) {
     $edit[$field_firstname][LANGUAGE_NONE][0]['value'] = $user_info['cas:firstName'];
   }
-  if (!empty($field_lastname) && isset($user->{$field_lastname})) {
+  if (!empty($field_lastname) && isset($user_fields[$field_lastname])) {
     $edit[$field_lastname][LANGUAGE_NONE][0]['value'] = $user_info['cas:lastName'];
   }
-  if (!empty($field_ecasmail) && isset($user->{$field_ecasmail})) {
+  if (!empty($field_ecasmail) && isset($user_fields[$field_ecasmail])) {
     $edit[$field_ecasmail][LANGUAGE_NONE][0]['value'] = $user_info['cas:email'];
   }
-  if (!empty($field_ecascreator) && isset($user->{$field_ecascreator})) {
+  if (!empty($field_ecascreator) && isset($user_fields[$field_ecascreator])) {
     if ($user_info['cas:domain'] == 'external') {
       $edit[$field_ecascreator][LANGUAGE_NONE][0]['value'] = $user_info['cas:domain'];
     }
@@ -325,7 +356,7 @@ function ecas_sync_profile_core(&$user, array $user_info, array &$edit = array()
 }
 
 /**
- * Update various information of a given user.
+ * Update various information of a given user and save them.
  *
  * Update information: core mail address, profile, Content Profile, roles, ...
  * When all information has been synced, this function invokes the
@@ -342,12 +373,53 @@ function ecas_sync_profile_core(&$user, array $user_info, array &$edit = array()
  * @param array $args
  *   Extra parameters, not used directly in this function but passed to the
  *   info_ecas_update() hook.
+ *
+ * @deprecated
+ *   Use the combination of ecas_sync_drupal_user_on_ecas_info() and
+ *   ecas_save_user() instead.
  */
 function ecas_sync_user_info(&$user, array $user_info, array $args) {
-  $edit = array();
+  $account_edit = ecas_sync_drupal_user_on_ecas_info($user, $user_info, $args);
+  ecas_save_user($user, $account_edit, $user_info, $args);
+}
+
+/**
+  * Synchronizes the Drupal user with the Ecas data.
+  *
+  * Update information: core mail address, profile, Content Profile, roles, ...
+  *
+  * When all information has been synced, this function invokes the
+  * hook_ecas_sync_user_info() and hook_ecas_user_roles_alter() hooks.
+  *
+  * The function does not save the synchronized user object. That must be done
+  * later through ecas_save_user().
+  *
+  * @param object $user
+  *   A user object.
+  * @param array $user_info
+  *   An associative array with the following interesting keys:
+  *   - mail: mail address.
+  *   - givenname: first name.
+  *   - sn: last name.
+  *   These values will be used to fill fields/profiles/...
+  * @param array $args
+  *   Extra parameters, not used directly in this function but passed to the
+  *   ecas_sync_user_info() and ecas_user_roles_alter() hooks.
+  *
+  * @return array
+  *   An array of fields and values to save like user_save() uses.
+  *   For example array('name' => 'My name').
+  *   Key / value pairs added to the $edit['data'] will be serialized and
+  *   saved in the {users.data} column.
+  *
+  * @see ecas_save_user()
+  */
+function ecas_sync_drupal_user_with_ecas_info(&$user, array $user_info, array $args) {
+  $edit = (array) $user;
+   
   // Update the user mail in the users table.
   if (variable_get('ecas_update_mail_address', TRUE)) {
-    $edit['mail'] = $user_info['cas:email'];
+    $edit['mail'] = (isset($user_info['cas:email'])) ? $user_info['cas:email'] : '';
   }
 
   // Update extra core user fields.
@@ -365,14 +437,7 @@ function ecas_sync_user_info(&$user, array $user_info, array $args) {
   // Let the opportunity to modules to alter user roles.
   drupal_alter('ecas_user_roles', $edit['roles'], $user, $user_info, $args);
 
-  // Fix : save file object replaced by fid by user_save function.
-  $picture = $user->picture;
-  user_save($user, $edit);
-  $user->mail = $user_info['cas:email'];
-  $user->picture = $picture;
-
-  // Old hook implementation. we keep it for backward compatibility.
-  module_invoke_all('info_ecas_update', $user, $user_info, $args);
+  return $edit;
 }
 
 /**
@@ -441,133 +506,156 @@ function ecas_login_check() {
   ecas_save_page();
 
   _ecas_init_phpcas_client();
-
-  // Adds an optional "domain" parameter to the login URL - this allows Drupal
-  // admins to specify the default ecas domain to be displayed on the login
-  // page when none could be found in the cookies sent by the browser.
-  $ecas_domain = (string) variable_get('ecas_domain', '');
-  if (drupal_strlen($ecas_domain)) {
-    $initial_server_login_url = phpCAS::getServerLoginURL();
-    $custom_server_login_url = sprintf('%s&domain=%s', $initial_server_login_url, urlencode($ecas_domain));
-    phpCAS::setServerLoginURL($custom_server_login_url);
-  }
-
-  // Preparing validation URL to retrieve attributes as well :
-  $assurance_level = variable_get('ecas_assurance_level', constant('ECAS_DEFAULT_ASSURANCE_LEVEL'));
-  $validate_server_url = 'https://' . FPFIS_ECAS_URL . ':' . FPFIS_ECAS_PORT;
-  $validate_server_url .= FPFIS_ECAS_URI . '/TicketValidationService?assuranceLevel=' . $assurance_level . '&ticketTypes=SERVICE,PROXY&userDetails=true&groups=*';
-  phpCAS::setServerServiceValidateURL($validate_server_url);
+  _ecas_prepare_phpcas_url();
 
   if ($force_login === ECAS_LOGIN) {
     phpCAS::forceAuthentication();
   }
 
-  if (phpCAS::isAuthenticated() && (($force_login === ECAS_GATEWAY) || ($force_login === ECAS_LOGIN))) {
-    $ecas_name = phpCAS::getUser();
-    // @codingStandardsIgnoreStart: NEPT-1332: To be fixed during refactoring.
-    $ecas_attributes = phpCAS::getAttributes();
-    $ecas_groups = $ecas_attributes['cas:groups'];
-    $ecas_email = $ecas_attributes['cas:email'];
-    // @codingStandardsIgnoreEnd
-    // Try to log into Drupal.
-    $account = user_load_by_name($ecas_name);
-
-    // Extra process to filter ECAS user.
-    drupal_alter('ecas_extra_filter', $ecas_name, $account, $_SESSION['ecas_goto']);
-  }
-  else {
-    // These variables will be checked by later conditions.
-    $account = FALSE;
-    $ecas_name = NULL;
+// Check the user is authenticated by ecas.
+  // if not, we stop here with a warning message page.
+  if (!phpCAS::isAuthenticated()) {
+    _ecas_warning_goto(
+      ECAS_WARNING_REASON_UNKNOWN,
+      NULL,
+      'ECAS authentication failed for unexpected reasons.'
+    );
   }
 
-  // If we don't have a user register them.
-  if (!$account && !empty($ecas_name)) {
+  // Get ecas user data.
+  $ecas_name = phpCAS::getUser();
+  $ecas_attributes = phpCAS::getAttributes();
 
-    $account = ecas_create_user($ecas_name);
-
-    if ($account && $account->uid > 0) {
-      $_SESSION['ecas_goto'] = sprintf('user/%d/edit', $account->uid);
-    }
-
-    // Set a session variable to denote this the initial login.
-    $_SESSION['ecas_first_login'] = TRUE;
-
-    // Also set an extra parameter for ecas_sync_user_info() -- this allows
-    // other modules to detect a user creation.
-    $ecas_sync_user_info_args['ecas_user_creation'] = TRUE;
+  // If no ecas attribute are available, we cannot achieve the user login.
+  // We stop the process and redirect the user to the warning page.
+  if (empty($ecas_attributes) || empty($ecas_name)) {
+    _ecas_warning_goto(
+      ECAS_WARNING_REASON_INCOMPLETE_USER,
+      NULL,
+      'Login process failed for "%ecas_name" because of an EU login user with missing required attributes.',
+      array(
+        '%ecas_name' => !empty($ecas_name) ? $ecas_name : 'Unknown user name',
+      )
+    );
   }
 
-  // Final check to make sure we have a good user.
-  if ($account && $account->uid > 0) {
-    // Retrieve information about the user from ECAS attributes.
-    $user_info = phpCAS::getAttributes();
+  $ecas_social_login = $ecas_attributes['cas:employeeType'];
+  $ecas_user_language = ecas_get_ecas_user_language($ecas_attributes);
 
-    // Update her information.
-    if (!empty($user_info)) {
-      ecas_sync_user_info($account, $user_info, $ecas_sync_user_info_args);
-    }
-    else {
-      $args = array(':username' => $account->name);
-      drupal_set_message(t('Warning: no information could be found for username :username', $args));
-    }
-
-    // Case when account is blocked.
-    if ($account->status == 0) {
-      _ecas_session_end();
-      drupal_goto('ecas_warning_page');
-    }
-    // When returning with same ECAS login as before closing Drupal session.
-    else {
-      if (
-        isset($account->data['ecas_login_date']) &&
-        $account->data['ecas_login_date'] == $user_info['cas:loginDate']
-      ) {
-
-        $msg = 'Rejected ECAS reused login: %n (ECAS)';
-        watchdog('user', $msg, array('%n' => $account->name), WATCHDOG_NOTICE);
-
-        _ecas_session_end();
-
-        $url = phpCAS::getServerLogoutURL() . '?url=' . _ecas_get_url_site_frontpage();
-        $msg = t('Your EU Login session needs to be renewed. For security reasons, please <a href="@url">logout and login again</a>.', ['@url' => $url]);
-        drupal_set_message($msg, 'error');
-
-        drupal_goto(_ecas_get_url_site_frontpage());
-      }
-      else {
-
-        $user = $account;
-        user_login_finalize();
-
-        $edit = ['data' => []];
-        $edit['data']['ecas_login_date'] = $user_info['cas:loginDate'];
-        user_save($user, $edit);
-
-        // Optionally set a non-secure cookie meaning "the user has logged in
-        // using HTTPS and should not use HTTP for the duration of this
-        // session".
-        $http_cookie_name = variable_get('ecas_sticky_cookie_name', 'drupal_stick_to_https');
-        if (drupal_strlen($http_cookie_name)) {
-          global $base_path;
-          setcookie($http_cookie_name, variable_get('ecas_sticky_cookie_value', 'y'), 0, $base_path, '.' . $_SERVER['HTTP_HOST'], FALSE, TRUE);
-        }
-
-        // @todo It is not possible to reliably translate dynamic content using
-        //   the t() function. This should be done using i18n_variable instead.
-        // @see https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-3637
-        // @codingStandardsIgnoreStart
-        drupal_set_message(t(variable_get('ecas_login_message', ECAS_DEFAULT_LOGIN_MESSAGE), array('%ecas_username' => $user->name)));
-        // @codingStandardsIgnoreEnd
-      }
-    }
+  // Let's check after an existing Drupal account.
+  $account = user_load_by_name($ecas_name);
+  // Check if the mail is in use.
+  if (!$account &&  $ecas_social_login != 'v') {
+    $account = user_load_by_mail($ecas_attributes['cas:email']);
   }
-  // If we have a good user.
-  else {
-    unset($_SESSION['phpCAS']);
-    $user = drupal_anonymous_user();
+  // Let's already give the chance to other module to alter the
+  // account structure.
+  drupal_alter('ecas_extra_filter', $ecas_name, $account, $_SESSION['ecas_goto']);
+
+  // Prepare the Drupal user object.
+  $account = ecas_prepare_drupal_user($ecas_name, $account, $ecas_attributes);
+
+  // Check if the user has not been logged in and arrives in this process by
+  // mistake.
+  // If it happens, we redirect him to the front page and ask him to log out
+  // and log in again.
+  if (
+    isset($account->data['ecas_login_date']) &&
+    ($account->data['ecas_login_date'] == $ecas_attributes['cas:loginDate'])
+  ) {
+
+    $msg = 'Rejected ECAS reused login: %n (ECAS)';
+    watchdog('user', $msg, array('%n' => $account->name), WATCHDOG_NOTICE);
+
+    _ecas_session_end();
+
+    $url = phpCAS::getServerLogoutURL() . '?url=' . _ecas_get_site_frontpage_full_url();
+    $msg = t(
+      'Your EU Login session needs to be renewed. For security reasons, please <a href="@url">logout and login again</a>.',
+      array('@url' => $url)
+    );
+    drupal_set_message($msg, 'error');
+    // No need to continue, redirect the user to the front page.
+    drupal_goto('<front>');
   }
 
+  // Also set an extra parameter for ecas_sync_user_info() -- this allows
+  // other modules to detect a user creation.
+  $ecas_sync_user_info_args['ecas_user_creation'] = $_SESSION['ecas_first_login'];
+
+  // Synchronize data between Drupal user object and Ecas ones according to the
+  // site specificity.
+  // There is no save inside, that will be do after further validations.
+  $account_edit = ecas_sync_drupal_user_with_ecas_info($account, $ecas_attributes, $ecas_sync_user_info_args);
+
+  // Before saving and as we gave a last chance to other modules to change the
+  // user data, check the validity of the user that must be saved.
+  // The ecas user must have a defined e-mail; otherwise the drupal
+  // authentication is denied.
+  if (empty($account_edit['mail'])) {
+    _ecas_warning_goto(
+      ECAS_WARNING_REASON_NO_EMAIL,
+      $ecas_user_language,
+      'Login denied for %ecas_name because it has no e-mail defined.',
+      array(
+        '%ecas_name' => $ecas_name,
+      )
+    );
+  }
+
+  // Check that the email is not used for another account; otherwise the drupal
+  // authentication is denied.
+  if ($ecas_social_login == 'v' && ecas_is_email_already_used($account_edit['mail'], $account)) {
+    _ecas_warning_goto(
+      ECAS_WARNING_REASON_EXISTING_EMAIL,
+      $ecas_user_language,
+      'Login denied for %ecas_name because the e-mail is already used by another account.',
+      array(
+        '%ecas_name' => $ecas_name,
+      )
+    );
+  }
+
+  // Time to save the user.
+  $saved_account = ecas_save_user($account, $account_edit, $ecas_attributes, $ecas_sync_user_info_args);
+
+  if (empty($saved_account->status)) {
+    _ecas_warning_goto(
+      ECAS_WARNING_REASON_BLOCKED,
+      $ecas_user_language,
+      'Login denied for %ecas_name because the account is not active yet.',
+      array(
+        '%ecas_name' => $ecas_name,
+      )
+    );
+  }
+
+  // Finalize the user login.
+  $user = $saved_account;
+  user_login_finalize();
+
+  // Optionally set a non-secure cookie meaning "the user has logged in
+  // using HTTPS and should not use HTTP for the duration of this
+  // session".
+  $http_cookie_name = variable_get('ecas_sticky_cookie_name', 'drupal_stick_to_https');
+  if (drupal_strlen($http_cookie_name)) {
+    global $base_path;
+    setcookie($http_cookie_name, variable_get('ecas_sticky_cookie_value', 'y'), 0, $base_path, '.' . $_SERVER['HTTP_HOST'], FALSE, TRUE);
+  }
+
+  // Check if it is the first login, if yes, redirect the user to user edit
+  // form.
+  if (!empty($_SESSION['ecas_first_login'])) {
+    $_SESSION['ecas_goto'] = sprintf('user/%d/edit', $user->uid);
+  }
+
+  // Before ending, display the login success message.
+  $message = variable_get(ECAS_LOGIN_MESSAGE, _ecas_get_default_login_message());
+  $message = format_string(
+    $message,
+    array('%ecas_username' => $user->name)
+  );
+  drupal_set_message(filter_xss($message));
 }
 
 /**
@@ -635,6 +723,391 @@ function ecas_block_info() {
   );
 
   return $blocks;
+}
+
+/**
+ * Page callback; displays the 'ecas_warning_page' page.
+ *
+ * @param string $reason
+ *   The id of the warning reason.
+ *
+ * @return string
+ *   The themed warning page display.
+ */
+function ecas_warning_page($reason) {
+  $theme_variables = array('warning_title' => t("Your site's account cannot be created"));
+
+  switch ($reason) {
+    case ECAS_WARNING_REASON_BLOCKED:
+      $theme_variables['warning_title'] = t("Your site's account is currently blocked");
+      $message_key = ECAS_WARNING_MESSAGE;
+      break;
+
+    case ECAS_WARNING_REASON_NO_EMAIL:
+      $message_key = ECAS_WARNING_MESSAGE_NO_EMAIL;
+      break;
+
+    case ECAS_WARNING_REASON_EXISTING_EMAIL:
+      $message_key = ECAS_WARNING_MESSAGE_EXISTING_EMAIL;
+      break;
+
+    case ECAS_WARNING_REASON_NOT_CREATED:
+      $message_key = ECAS_WARNING_MESSAGE_NOT_CREATED;
+      break;
+
+    case ECAS_WARNING_REASON_INCOMPLETE_USER:
+      $message_key = ECAS_WARNING_MESSAGE_INCOMPLETE_USER;
+      break;
+
+    default:
+      $theme_variables['warning_text'] = t("The reason is unknown. Please contact the site's administrator.");
+
+      return theme('ecas_profile_warning_page', $theme_variables);
+
+  }
+
+  $message = variable_get($message_key, _ecas_get_default_warning_message($message_key));
+  // NEPT-520: Fallback process for sites that have set the ecas variable values
+  // before the i18n variable integration in the ecas module.
+  if (!is_array($message)) {
+    watchdog(
+      'user',
+      'The %message_key value is not updated to set the text filter to apply on it. Please update the ECAS settings.',
+      array('%message_key' => $message_key),
+      WATCHDOG_WARNING
+    );
+    $message = array('value' => $message);
+  }
+  $theme_variables['warning_text'] = _ecas_filter_variable_text($message);
+
+  return theme('ecas_profile_warning_page', $theme_variables);
+}
+
+/**
+ * Creates an ECAS user.
+ *
+ * @param string $ecas_name
+ *   The ECAS name of the user.
+ * @param array $defaults
+ *   An array of user fields and properties to save on the user object.
+ *
+ * @return false|\stdClass
+ *   The user object, or FALSE if the user could not be created.
+ */
+function ecas_create_user($ecas_name, $defaults = array()) {
+  $user_default = array_merge(array(
+    'name' => $ecas_name,
+    'pass' => user_password(),
+    'init' => $ecas_name,
+    'status' => variable_get('ecas_account_option', 1),
+    'access' => REQUEST_TIME,
+    'auth_ecas' => 'ecas_' . $ecas_name,
+    'mail' => variable_get('ecas_default_mail_address', ECAS_DEFAULT_MAIL_ADDRESS),
+  ), $defaults);
+
+  // Now save the user.
+  $account = user_save(drupal_anonymous_user(), $user_default);
+
+  // Register the user has ECAS authentication.
+  db_insert('authmap')
+    ->fields(array(
+      'authname' => $ecas_name,
+      'uid' => $account->uid,
+      'module' => 'ecas',
+    ))
+    ->execute();
+
+  watchdog('user', 'new user: %n (ECAS)', array('%n' => $account->name), WATCHDOG_NOTICE, l(t('edit user'), sprintf('admin/user/edit/%d', $account->uid)));
+
+  if ($account) {
+    $account = user_load_by_name($account->name);
+  }
+
+  return $account;
+}
+
+/**
+ * Saves the Drupal user object from ecas synchronized data.
+ *
+ * @param object $account
+ *   The Drupal user object on which the saving action is done.
+ * @param array $edit
+ *   An array of fields and values to save.
+ * @param array $ecas_user_info
+ *   Associative array with the user related ecas attributes.
+ * @param array $args
+ *   Extra parameters, not used directly in this function but passed to the
+ *   info_ecas_update() hook.
+ *
+ * @return bool|Object
+ *   A fully-loaded $user object upon successful save or FALSE if the
+ *   save failed.
+ *
+ * @see user_save()
+ */
+function ecas_save_user($account, $edit, array $ecas_user_info, array $args = array()) {
+  // Fix : save file object replaced by fid by user_save function.
+  // See at the end of the function.
+  if (isset($account->picture)) {
+    $picture = $account->picture;
+  }
+
+  // Store the user name first to use it in watchdog in case of failure and
+  // $account loses it during the saving operation.
+  $name = 'Unknown user';
+  if (isset($account->name)) {
+    $name = $account->name;
+  }
+
+  // Set the ecas_login_date user attribute based on 'cas:loginDate' value.
+  if (isset($ecas_user_info['cas:loginDate'])) {
+    $edit['data']['ecas_login_date'] = $ecas_user_info['cas:loginDate'];
+    $account->access = REQUEST_TIME;
+  }
+
+  $account = user_save($account, $edit);
+
+  // Check to make sure we have a good Drupal user.
+  if (!$account || $account->uid == 0) {
+    watchdog(
+      'user',
+      'Drupal user save failed for %name.',
+      array('%name' => $name),
+      WATCHDOG_ERROR
+    );
+
+    return FALSE;
+  }
+
+  if (!empty($_SESSION['ecas_first_login'])) {
+    // Register the user has ECAS authentication.
+    db_insert('authmap')
+      ->fields(array(
+        'authname' => $account->name,
+        'uid' => $account->uid,
+        'module' => 'ecas',
+      ))
+      ->execute();
+
+    watchdog(
+      'user',
+      'new user: %n (ECAS)',
+      array('%n' => $account->name),
+      WATCHDOG_NOTICE,
+      l(t('edit user'), sprintf('admin/user/edit/%d', $account->uid))
+    );
+  }
+
+  // Ensure the the picture is correctly set in the account object
+  // before passing to the hook_info_ecas_update().
+  if (isset($picture)) {
+    $account->picture = $picture;
+  }
+  // Old hook implementation. we keep it for backward compatibility.
+  module_invoke_all('info_ecas_update', $account, $ecas_user_info, $args);
+
+  // Load the user account and update realname, to ensure the safe_value of
+  // fields are updated.
+  cache_clear_all();
+  $update_account = user_load($account->uid, TRUE);
+  realname_update($update_account);
+  return $account;
+}
+
+/**
+ * Gets the user's department structure.
+ *
+ * @param array $user_info
+ *   The user's attributes retrieved from the LDAP.
+ *
+ * @return array
+ *   The service to which the user belongs:
+ *    - 'dg': User's DG Acronym or FALSE if not given;
+ *    - 'directorate': User's directorate name or FALSE if not given;
+ *    - 'unit': User's unit name or FALSE if not given;
+ *    - 'sub_unit': User's sub-unit name or FALSE if not given;
+ *    - 'full_name": The full name of the user's department.
+ *
+ * @see phpCAS::getAttributes()
+ */
+function ecas_get_user_department($user_info) {
+  if (!empty($user_info['cas:departmentNumber'])) {
+    $department = array('full_name' => $user_info['cas:departmentNumber']);
+    $organizations = explode('.', $user_info['cas:departmentNumber']);
+
+    $department += array(
+      'dg' => (!empty($organizations[0])) ? $organizations[0] : FALSE,
+      'directorate' => (!empty($organizations[1])) ? $organizations[1] : FALSE,
+      'unit' => (!empty($organizations[2])) ? $organizations[2] : FALSE,
+      'sub_unit' => (!empty($organizations[3])) ? $organizations[3] : FALSE,
+    );
+
+    return $department;
+  }
+
+  return array();
+}
+
+/**
+ * Gets the user language code for a specified ecas user.
+ *
+ * @param array $user_info
+ *   Associative array with the user data coming from ecas.
+ *   All array keys are prefixed by 'cas:'.
+ *
+ * @return object|bool
+ *   The drupal language object associated to the ecas user language or FALSE
+ *   if not found.
+ */
+function ecas_get_ecas_user_language(array $user_info = array()) {
+  if (empty($user_info['cas:locale'])) {
+    return FALSE;
+  }
+
+  $user_locale = $user_info['cas:locale'];
+  $enabled_language_list = language_list('enabled');
+  $enabled_language_list = reset($enabled_language_list);
+
+  return isset($enabled_language_list[$user_locale]) ? $enabled_language_list[$user_locale] : FALSE;
+}
+
+/**
+ * Checks if the e-mail address is not already used by a user.
+ *
+ * It does not use "user_load_by_mail" because this function is case sensitive
+ * with some DB types.
+ *
+ * @param string $email
+ *   The e-mail to control.
+ * @param object $account
+ *   (optional) An account to exclude from the control.
+ *
+ * @return bool
+ *   True if the e-mail is already used by a user; otherwise FALSE.
+ *
+ * @see user_load_by_mail()
+ * @see user_account_form_validate()
+ */
+function ecas_is_email_already_used($email, $account = NULL) {
+  $email = trim($email);
+
+  $query = db_select('users')
+    ->fields('users', array('uid'))
+    ->condition('mail', db_like($email), 'LIKE')
+    ->range(0, 1);
+
+  if (!empty($account) && !empty($account->uid)) {
+    $query->condition('uid', $account->uid, '<>');
+  }
+
+  return (bool) $query->execute()->fetchField();
+}
+
+/**
+ * Prepares the Drupal user based on the ECAS user data.
+ *
+ * @param string $ecas_name
+ *   The Ecas user name.
+ * @param object $account
+ *   An already existing Drupal user account linked to the Ecas user.
+ * @param array $ecas_user_attributes
+ *   The Ecas user attributes.
+ *
+ * @return object
+ *   The Drupal user object as already registered or a default object with the
+ *   minimum properties needed for validity checks: name, new, init, password,
+ *   status, auth_ecas, mail, access.
+ */
+function ecas_prepare_drupal_user($ecas_name, $account = NULL, array $ecas_user_attributes = array()) {
+  if ($account) {
+    // Set a session variable to denote this is an initial login (uid = 0) or
+    // not.
+    $_SESSION['ecas_first_login'] = empty($account->uid);
+
+    return $account;
+  }
+
+  // Prepare the account object to use the same validity check mechanism
+  // for known and unknown users.
+  // Logic based on an initial set to anonymous user is taken from user module.
+  $account = drupal_anonymous_user();
+  $account->name = $ecas_name;
+  $account->pass = user_password();
+  $account->init = $ecas_name;
+  $account->status = variable_get('ecas_account_option', 1);
+  $account->auth_ecas = 'ecas_' . $ecas_name;
+  $account->timezone = variable_get('date_default_timezone', @date_default_timezone_get());
+  $account->is_new = 1;
+  // Leave email uncontrolled yet, the control on the email value
+  // will be done later, after giving the opportunity to other modules to
+  // implement their own check or email setting.
+  if (!empty($ecas_user_attributes['cas:email'])) {
+    $account->mail = $ecas_user_attributes['cas:email'];
+  }
+
+  // Set a session variable to denote this is the initial login.
+  $_SESSION['ecas_first_login'] = TRUE;
+
+  return $account;
+}
+
+/**
+ * Initializes the phpCas client.
+ */
+function _ecas_init_phpcas_client() {
+  $server_version     = (string) variable_get('cas_version', '2.0');
+  $server_ecas_server = FPFIS_ECAS_URL;
+  $server_port        = FPFIS_ECAS_PORT;
+  $server_uri         = FPFIS_ECAS_URI;
+  $start_session      = (boolean) FALSE;
+
+  // Drupal takes care of its own session.
+  $assurance_level = variable_get('ecas_assurance_level', constant('ECAS_DEFAULT_ASSURANCE_LEVEL'));
+
+  // Before using the phpCas client, we optionally set it in debug mode.
+  if (variable_get('ecas_phpcas_debug', FALSE)) {
+    $logpath = variable_get('ecas_phpcas_debug_logpath', constant('ECAS_DEFAULT_DEBUG_LOGPATH'));
+    // As specified in ecas_admin_settings(), we do not check whether the
+    // logpath is writable or not.
+    if (drupal_strlen($logpath)) {
+      phpCAS::setDebug($logpath);
+    }
+  }
+
+  phpCAS::client(
+    $server_version,
+    $server_ecas_server,
+    $server_port,
+    $server_uri,
+    $start_session,
+    $assurance_level
+  );
+  phpCAS::setNoCasServerValidation();
+
+  foreach (variable_get('ecas_curl_options', array()) as $key => $value) {
+    phpCAS::setExtraCurlOption($key, $value);
+  }
+}
+
+/**
+ * Sets the URL used by the phpCas client.
+ */
+function _ecas_prepare_phpcas_url() {
+  // Adds an optional "domain" parameter to the login URL - this allows Drupal
+  // admins to specify the default ecas domain to be displayed on the login
+  // page when none could be found in the cookies sent by the browser.
+  $ecas_domain = (string) variable_get('ecas_domain', '');
+  if (drupal_strlen($ecas_domain)) {
+    $initial_server_login_url = phpCAS::getServerLoginURL();
+    $custom_server_login_url = sprintf('%s&domain=%s', $initial_server_login_url, urlencode($ecas_domain));
+    phpCAS::setServerLoginURL($custom_server_login_url);
+  }
+
+  // Preparing validation URL to retrieve attributes as well :
+  $assurance_level = variable_get('ecas_assurance_level', constant('ECAS_DEFAULT_ASSURANCE_LEVEL'));
+  $validate_server_url = 'https://' . FPFIS_ECAS_URL . ':' . FPFIS_ECAS_PORT;
+  $validate_server_url .= FPFIS_ECAS_URI . '/TicketValidationService?assuranceLevel=' . $assurance_level . '&ticketTypes=SERVICE,PROXY&userDetails=true&groups=*';
+  phpCAS::setServerServiceValidateURL($validate_server_url);
 }
 
 /**
@@ -727,141 +1200,6 @@ function _ecas_force_login() {
 }
 
 /**
- * Page callback; displays the 'ecas_warning_page' page.
- */
-function ecas_warning_page() {
-  $output = '';
-
-  $output .= '<h2 class="ecl-heading ecl-heading--h2">' . t('Account blocked') . '</h2>';
-  $output .= '<p>' . variable_get('ecas_warning_message', t('Your account is not yet approved')) . '</p>';
-
-  return $output;
-}
-
-/**
- * Initializes the phpCas client.
- */
-function _ecas_init_phpcas_client() {
-  $server_version     = (string) variable_get('cas_version', '2.0');
-  $server_ecas_server = FPFIS_ECAS_URL;
-  $server_port        = FPFIS_ECAS_PORT;
-  $server_uri         = FPFIS_ECAS_URI;
-  $start_session      = (boolean) FALSE;
-
-  // Drupal takes care of its own session.
-  $assurance_level = variable_get('ecas_assurance_level', constant('ECAS_DEFAULT_ASSURANCE_LEVEL'));
-
-  // Before using the phpCas client, we optionally set it in debug mode.
-  if (variable_get('ecas_phpcas_debug', FALSE)) {
-    $logpath = variable_get('ecas_phpcas_debug_logpath', constant('ECAS_DEFAULT_DEBUG_LOGPATH'));
-    // As specified in ecas_admin_settings(), we do not check whether the
-    // logpath is writable or not.
-    if (drupal_strlen($logpath)) {
-      phpCAS::setDebug($logpath);
-    }
-  }
-
-  phpCAS::client(
-    $server_version,
-    $server_ecas_server,
-    $server_port,
-    $server_uri,
-    $start_session,
-    $assurance_level
-  );
-
-  $cert_path = variable_get('ecas_certificate_path', '');
-  if ($cert_path) {
-    phpCAS::setCasServerCACert($cert_path, TRUE);
-  }
-  else {
-    phpCAS::setNoCasServerValidation();
-  }
-
-  foreach (variable_get('ecas_curl_options', array()) as $key => $value) {
-    phpCAS::setExtraCurlOption($key, $value);
-  }
-}
-
-/**
- * Creates an ECAS user.
- *
- * @param string $ecas_name
- *   The ECAS name of the user.
- * @param array $defaults
- *   An array of user fields and properties to save on the user object.
- *
- * @return false|\stdClass
- *   The user object, or FALSE if the user could not be created.
- */
-function ecas_create_user($ecas_name, $defaults = array()) {
-  $user_default = array_merge(array(
-    'name' => $ecas_name,
-    'pass' => user_password(),
-    'init' => $ecas_name,
-    'status' => variable_get('ecas_account_option', 1),
-    // @todo Use REQUEST_TIME instead of time().
-    'access' => time(),
-    'auth_ecas' => 'ecas_' . $ecas_name,
-    'mail' => variable_get('ecas_default_mail_address', ECAS_DEFAULT_MAIL_ADDRESS),
-  ), $defaults);
-
-  // Now save the user.
-  $account = user_save(drupal_anonymous_user(), $user_default);
-
-  // Register the user has ECAS authentication.
-  db_insert('authmap')
-    ->fields(array(
-      'authname' => $ecas_name,
-      'uid' => $account->uid,
-      'module' => 'ecas',
-    ))
-    ->execute();
-
-  watchdog('user', 'new user: %n (ECAS)', array('%n' => $account->name), WATCHDOG_NOTICE, l(t('edit user'), sprintf('admin/user/edit/%d', $account->uid)));
-
-  if ($account) {
-    $account = user_load_by_name($account->name);
-  }
-
-  return $account;
-}
-
-/**
- * Gets the user's department structure.
- *
- * @param array $user_info
- *   The user's attributes retrieved from the LDAP.
- *
- * @return array
- *   The service to which the user belongs:
- *    - 'dg': User's DG Acronym or FALSE if not given;
- *    - 'directorate': User's directorate name or FALSE if not given;
- *    - 'unit': User's unit name or FALSE if not given;
- *    - 'sub_unit': User's sub-unit name or FALSE if not given;
- *    - 'full_name": The full name of the user's department.
- *
- * @see phpCAS::getAttributes()
- */
-function ecas_get_user_department($user_info) {
-  if (!empty($user_info['cas:departmentNumber'])) {
-    $department = array('full_name' => $user_info['cas:departmentNumber']);
-    $organizations = explode('.', $user_info['cas:departmentNumber']);
-
-    $department += array(
-      'dg' => (!empty($organizations[0])) ? $organizations[0] : FALSE,
-      'directorate' => (!empty($organizations[1])) ? $organizations[1] : FALSE,
-      'unit' => (!empty($organizations[2])) ? $organizations[2] : FALSE,
-      'sub_unit' => (!empty($organizations[3])) ? $organizations[3] : FALSE,
-    );
-
-    return $department;
-  }
-
-  return array();
-}
-
-/**
  * End session and set global variable $user to anonymous.
  */
 function _ecas_session_end() {
@@ -870,24 +1208,144 @@ function _ecas_session_end() {
   session_destroy();
 
   $user = drupal_anonymous_user();
+}
 
-  // Since the user is blocked, we absolutely want to redirect the user
-  // to the ECAS warning page - thus, we unset any previously set
-  // destination.
+/**
+ * Get the full URL of the homepage of the site.
+ *
+ * @return string
+ *   The full URL of the homepage of the site.
+ */
+function _ecas_get_site_frontpage_full_url() {
+  return url('<front>', ['absolute' => TRUE]);
+}
+
+/**
+ * Triggers the redirection to the ecas warning page with the right parameters.
+ *
+ * @param string $path_page_argument
+ *   The warning page argument to use for the redirection.
+ * @param object $language
+ *   The language to append to the path used in the redirection.
+ * @param string $message
+ *   (Optional) A message to use in order to log the redirection event.
+ * @param array $message_args
+ *   (Optional) Array of variables to replace in the log message on display or
+ *   NULL if message is already translated or not possible to
+ *   translate.
+ *
+ * @see drupal_goto()
+ */
+function _ecas_warning_goto($path_page_argument, $language = NULL, $message = NULL, array $message_args = array()) {
+  if (!empty($message)) {
+    watchdog('user', $message, $message_args, WATCHDOG_ERROR);
+  }
+
+  if (empty($language)) {
+    $language = language_default();
+  }
+
+  _ecas_session_end();
+
+  // Ensure that the user is correctly redirected to warning page because
+  // if drupal_goto() detects an internal path in destination parameter, it
+  // will use it instead of the submitted parameters, see function code.
   if (isset($_REQUEST['destination'])) {
     unset($_REQUEST['destination']);
   }
   if (isset($_REQUEST['edit']['destination'])) {
     unset($_REQUEST['edit']['destination']);
   }
+
+  drupal_goto('eulogin_warning/' . $path_page_argument, array('language' => $language));
 }
 
 /**
- * Get the full URL for the homepage of the site.
+ * Filters a variable text value.
+ *
+ * @param array $raw_text_parameters
+ *   Associative array of data required by the filter process:
+ *   - 'value': The text value to filter.
+ *   - 'format': (optional) The filter id to be used during the process.
  *
  * @return string
- *   The full URL for the homepage of the site.
+ *   The filtered variable value.
  */
-function _ecas_get_url_site_frontpage() {
-  return url(variable_get('site_frontpage', 'node'), ['absolute' => TRUE]);
+function _ecas_filter_variable_text(array $raw_text_parameters) {
+  if (!empty($raw_text_parameters['format'])) {
+    return check_markup($raw_text_parameters['value'], $raw_text_parameters['format']);
+  }
+
+  return check_markup($raw_text_parameters['value']);
+}
+
+/**
+ * Gets the default value of a message linked to a specific warning.
+ *
+ * @param string $related_variable_name
+ *   The name of the variable related to the default value to retrieve.
+ *
+ * @return array
+ *   The default message value and the format to apply on it.
+ *
+ * @see ecas_warning_page()
+ * @see ecas_variable_info()
+ * @see ecas_admin_settings()
+ */
+function _ecas_get_default_warning_message($related_variable_name) {
+  switch ($related_variable_name) {
+    case ECAS_WARNING_MESSAGE:
+      $value = 'Your account is not yet approved';
+      break;
+
+    case ECAS_WARNING_MESSAGE_NO_EMAIL:
+      $value = <<< EOF
+      We cannot log you in without a valid email.<br />
+      Please complete your EU-Login account or contact <a href="https://ecas.ec.europa.eu/cas/contact.html">EU-Login support</a>.
+EOF;
+      break;
+
+    case ECAS_WARNING_MESSAGE_EXISTING_EMAIL:
+      $value = <<< EOF
+      We cannot log you in as the e-mail of your EU Login e-mail is already used by another account.<br /> 
+      Please log in with this existing account.
+EOF;
+      break;
+
+    case ECAS_WARNING_MESSAGE_NOT_CREATED:
+      $value = <<< EOF
+      An error occurred that prevent us to create your account.
+EOF;
+      break;
+
+    case ECAS_WARNING_MESSAGE_INCOMPLETE_USER:
+      $value = <<< EOF
+      We do not receive all required data of your EU Login. That prevent us to create your account.<br /> 
+      Please complete your EU-Login account or contact <a href="https://ecas.ec.europa.eu/cas/contact.html">EU-Login support</a>.
+EOF;
+      break;
+
+    default:
+      $value = "The reason is unknown. Please contact the site's administrator.";
+      break;
+  }
+
+  return array(
+    'value' => $value,
+    'format' => 'filtered_html',
+  );
+}
+
+/**
+ * Gets the default value of a login message variable.
+ *
+ * @return string
+ *   The default message value.
+ *
+ * @see ecas_warning_page()
+ * @see ecas_variable_info()
+ * @see ecas_admin_settings()
+ */
+function _ecas_get_default_login_message() {
+  return 'Logged in via EU Login as %ecas_username.';
 }

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -616,6 +616,20 @@ function ecas_login_check() {
     );
   }
 
+  // Check that social login user has authenticated role only.
+  $authenticated_role = user_role_load_by_name('authenticated user');
+
+  if ($ecas_social_login == 'v' && (!user_has_role($authenticated_role->rid, $account) || count($account->roles) > 1)) {
+    _ecas_warning_goto(
+      ECAS_WARNING_REASON_SOCIAL,
+      $ecas_user_language,
+      'Login denied for %ecas_name because the account has more then authenticated role.',
+      array(
+        '%ecas_name' => $ecas_name,
+      )
+    );
+  }
+
   // Time to save the user.
   $saved_account = ecas_save_user($account, $account_edit, $ecas_attributes, $ecas_sync_user_info_args);
 
@@ -738,6 +752,11 @@ function ecas_warning_page($reason) {
   $theme_variables = array('warning_title' => t("Your site's account cannot be created"));
 
   switch ($reason) {
+    case ECAS_WARNING_REASON_SOCIAL:
+      $theme_variables['warning_title'] = t("Social login is not permitted with your users role.");
+      $message_key = ECAS_WARNING_MESSAGE_SOCIAL;
+      break;
+
     case ECAS_WARNING_REASON_BLOCKED:
       $theme_variables['warning_title'] = t("Your site's account is currently blocked");
       $message_key = ECAS_WARNING_MESSAGE;
@@ -1296,6 +1315,10 @@ function _ecas_get_default_warning_message($related_variable_name) {
   switch ($related_variable_name) {
     case ECAS_WARNING_MESSAGE:
       $value = 'Your account is not yet approved';
+      break;
+
+    case ECAS_WARNING_MESSAGE_SOCIAL:
+      $value = 'Please use a more secure login by using the EU Login form.';
       break;
 
     case ECAS_WARNING_MESSAGE_NO_EMAIL:

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -753,7 +753,7 @@ function ecas_warning_page($reason) {
 
   switch ($reason) {
     case ECAS_WARNING_REASON_SOCIAL:
-      $theme_variables['warning_title'] = t("Social login is not permitted with your users role.");
+      $theme_variables['warning_title'] = t("Your social network account does not allow you to login.");
       $message_key = ECAS_WARNING_MESSAGE_SOCIAL;
       break;
 
@@ -1318,7 +1318,7 @@ function _ecas_get_default_warning_message($related_variable_name) {
       break;
 
     case ECAS_WARNING_MESSAGE_SOCIAL:
-      $value = 'Please use a more secure login by using the EU Login form.';
+      $value = 'please use <a href="https://ecas.ec.europa.eu/cas/logout">EU login</a>.';
       break;
 
     case ECAS_WARNING_MESSAGE_NO_EMAIL:

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -156,19 +156,19 @@ function _ecas_menu(array &$items) {
 }
 
 /**
-  * Implements hook_theme().
-  */
+ * Implements hook_theme().
+ */
 function ecas_theme() {
- return array(
-   'ecas_profile_warning_page' => array(
-     'variables' =>
+  return array(
+    'ecas_profile_warning_page' => array(
+      'variables' =>
        array(
          'warning_title' => NULL,
          'warning_text' => NULL,
        ),
-     'template' => 'theme/templates/ecas-profile-warning-page',
-   ),
- );
+      'template' => 'theme/templates/ecas-profile-warning-page',
+    ),
+  );
 }
 
 /**
@@ -218,7 +218,7 @@ function ecas_menu_check() {
  */
 function ecas_login_page() {
   try {
-   ecas_login_check();
+    ecas_login_check();
   }
   catch (Exception $e) {
     watchdog_exception('user', $e);
@@ -295,16 +295,16 @@ function ecas_save_page() {
   if (isset($_SESSION['ecas_goto'])) {
     return;
   }
-  
+
   if (arg(0) == 'ecas') {
     // Saving the ECAS page does not make sense, use HTTP referer (absolute
     // URL) instead.
     $referer = (isset($_GET['referer'])) ? $_GET['referer'] : $_SERVER['HTTP_REFERER'];
     $_SESSION['ecas_goto'] = $referer;
-    
+
     return;
   }
-  
+
   // Save the Drupal path (i.e. not an absolute URL).
   $_SESSION['ecas_goto'] = $_GET['q'];
 }
@@ -384,39 +384,39 @@ function ecas_sync_user_info(&$user, array $user_info, array $args) {
 }
 
 /**
-  * Synchronizes the Drupal user with the Ecas data.
-  *
-  * Update information: core mail address, profile, Content Profile, roles, ...
-  *
-  * When all information has been synced, this function invokes the
-  * hook_ecas_sync_user_info() and hook_ecas_user_roles_alter() hooks.
-  *
-  * The function does not save the synchronized user object. That must be done
-  * later through ecas_save_user().
-  *
-  * @param object $user
-  *   A user object.
-  * @param array $user_info
-  *   An associative array with the following interesting keys:
-  *   - mail: mail address.
-  *   - givenname: first name.
-  *   - sn: last name.
-  *   These values will be used to fill fields/profiles/...
-  * @param array $args
-  *   Extra parameters, not used directly in this function but passed to the
-  *   ecas_sync_user_info() and ecas_user_roles_alter() hooks.
-  *
-  * @return array
-  *   An array of fields and values to save like user_save() uses.
-  *   For example array('name' => 'My name').
-  *   Key / value pairs added to the $edit['data'] will be serialized and
-  *   saved in the {users.data} column.
-  *
-  * @see ecas_save_user()
-  */
+ * Synchronizes the Drupal user with the Ecas data.
+ *
+ * Update information: core mail address, profile, Content Profile, roles, ...
+ *
+ * When all information has been synced, this function invokes the
+ * hook_ecas_sync_user_info() and hook_ecas_user_roles_alter() hooks.
+ *
+ * The function does not save the synchronized user object. That must be done
+ * later through ecas_save_user().
+ *
+ * @param object $user
+ *   A user object.
+ * @param array $user_info
+ *   An associative array with the following interesting keys:
+ *   - mail: mail address.
+ *   - givenname: first name.
+ *   - sn: last name.
+ *   These values will be used to fill fields/profiles/...
+ * @param array $args
+ *   Extra parameters, not used directly in this function but passed to the
+ *   ecas_sync_user_info() and ecas_user_roles_alter() hooks.
+ *
+ * @return array
+ *   An array of fields and values to save like user_save() uses.
+ *   For example array('name' => 'My name').
+ *   Key / value pairs added to the $edit['data'] will be serialized and
+ *   saved in the {users.data} column.
+ *
+ * @see ecas_save_user()
+ */
 function ecas_sync_drupal_user_with_ecas_info(&$user, array $user_info, array $args) {
   $edit = (array) $user;
-   
+
   // Update the user mail in the users table.
   if (variable_get('ecas_update_mail_address', TRUE)) {
     $edit['mail'] = (isset($user_info['cas:email'])) ? $user_info['cas:email'] : '';
@@ -512,7 +512,7 @@ function ecas_login_check() {
     phpCAS::forceAuthentication();
   }
 
-// Check the user is authenticated by ecas.
+  // Check the user is authenticated by ecas.
   // if not, we stop here with a warning message page.
   if (!phpCAS::isAuthenticated()) {
     _ecas_warning_goto(

--- a/profiles/common/modules/custom/ecas/theme/templates/ecas-profile-warning-page.tpl.php
+++ b/profiles/common/modules/custom/ecas/theme/templates/ecas-profile-warning-page.tpl.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Template file for theme('ecas_profile_error_page').
+ *
+ * Variables available:
+ *   $error_text: (mandatory) the main text describing the detected error.
+ */
+?>
+<h2 class="ecl-heading ecl-heading--h2"><?php print $warning_title; ?></h2>
+<div class="ecl-editor">
+  <?php print $warning_text; ?>
+</div>

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1182,6 +1182,7 @@ projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
 projects[ec_europa][download][tag] = 0.0.14
+projects[ec_europa][patch][] = patches/nept-2585-remove-site-switcher.patch
 
 ; ==============
 ; Custom modules

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -463,18 +463,13 @@ projects[maxlength][subdir] = "contrib"
 projects[maxlength][version] = "3.2-beta2"
 
 projects[media][subdir] = contrib
-projects[media][version] = 2.21
+projects[media][version] = 2.23
 ; Embedded documents in the WYSIWYG can be very hard to delete.
 ; https://www.drupal.org/node/2028231
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-771
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1015
 ; Media markup navigation causes duplicated links
 projects[media][patch][] = https://www.drupal.org/files/issues/media-delete-embedded-document-2028231-11.patch
-
-; Ensure the media_wysiwyg.filter.js is loaded.
-; https://www.drupal.org/project/media/issues/3039731
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2243
-projects[media][patch][] = https://www.drupal.org/files/issues/2019-03-13/add-js-library-3039731-1.patch
 
 projects[media_avportal][subdir] = "contrib"
 projects[media_avportal][version] = "1.5"

--- a/resources/patches/nept-2585-remove-site-switcher.patch
+++ b/resources/patches/nept-2585-remove-site-switcher.patch
@@ -1,0 +1,10 @@
+diff --git a/templates/site_switcher/site-switcher.tpl.php b/templates/site_switcher/site-switcher.tpl.php
+index 53f14f7e..25cdf3cc 100644
+--- a/templates/site_switcher/site-switcher.tpl.php
++++ b/templates/site_switcher/site-switcher.tpl.php
+@@ -6,5 +6,4 @@
+  */
+ ?>
+ <div<?php print $atomium['attributes']['wrapper']; ?>>
+-  <?php print render($links); ?>
+ </div>


### PR DESCRIPTION
## NEPT-520

### Description

Prevent EU Login to create 2 users with the same email, Do not allow user that have other roles than "Authenticated" to login using social network, but force them to use EU Login form.

### Change log

- Added:
  - ecas.variable.inc
  - theme/templates/ecas-profile-warning-page.tpl.php 
- Changed: Refactored code
- Security:
  - Prevent duplicate email
  - Prevent social login if user is other then authenticated


