### PR TITLE
NEPT-2585: Add a patch to remove the switcher from the old version of ec_europa

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1182,6 +1182,7 @@ projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
 projects[ec_europa][download][tag] = 0.0.14
+projects[ec_europa][patch][] = patches/nept-2585-remove-site-switcher.patch
 
 ; ==============
 ; Custom modules

--- a/resources/patches/nept-2585-remove-site-switcher.patch
+++ b/resources/patches/nept-2585-remove-site-switcher.patch
@@ -1,0 +1,10 @@
+diff --git a/templates/site_switcher/site-switcher.tpl.php b/templates/site_switcher/site-switcher.tpl.php
+index 53f14f7e..25cdf3cc 100644
+--- a/templates/site_switcher/site-switcher.tpl.php
++++ b/templates/site_switcher/site-switcher.tpl.php
+@@ -6,5 +6,4 @@
+  */
+ ?>
+ <div<?php print $atomium['attributes']['wrapper']; ?>>
+-  <?php print render($links); ?>
+ </div>


### PR DESCRIPTION
## NEPT-2585

### Description

Add a patch to remove the switcher from the old version of ec_europa

### Change log

- Added: Patch to remove the switcher from the old version of ec_europa

