### PR TITLE
NEPT-2629: phpvideotoolkit library not compatible php 7.2

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -786,6 +786,7 @@ projects[video][version] = "2.14"
 projects[video][patch][] = patches/video-revert_issue-1891012-0.patch
 ;NEPT-2629 PHP7 compatibility
 projects[video][patch][] = patches/phpvideotoolkit-2629.patch
+projects[video][patch][] = https://www.drupal.org/files/issues/2019-08-06/video-php7.2-3039351-3-7.x.patch
 ;MULTISITE-883 security
 projects[video][patch][] = patches/video-security-883.patch
 

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -784,6 +784,9 @@ projects[variable][version] = "2.5"
 projects[video][subdir] = "contrib"
 projects[video][version] = "2.14"
 projects[video][patch][] = patches/video-revert_issue-1891012-0.patch
+;NEPT-2629 PHP7 compatibility
+projects[video][patch][] = patches/phpvideotoolkit-2629.patch
+;MULTISITE-883 security
 projects[video][patch][] = patches/video-security-883.patch
 
 projects[views][subdir] = "contrib"

--- a/resources/patches/phpvideotoolkit-2629.patch
+++ b/resources/patches/phpvideotoolkit-2629.patch
@@ -1,0 +1,18 @@
+--- libraries/phpvideotoolkit/phpvideotoolkit.php5.php	2019-08-29 14:18:50.000000000 +0200
++++ libraries/phpvideotoolkit/phpvideotoolkit.php5.php	2019-08-29 14:21:05.000000000 +0200
+@@ -2621,14 +2621,9 @@
+    * @return array An array of codecs available to ffmpeg.
+    */
+   public static function getAvailableCodecs($type=FALSE) {
+-// 			check to see if this is a static call
+-    if (isset($this) === FALSE) {
+       $toolkit = new PHPVideoToolkit();
+       $info = $toolkit->getFFmpegInfo();
+-    }
+-    else {
+-      $info = $this->getFFmpegInfo();
+-    }
++    
+ // 			are we checking for particluar method?
+     $return_vals = array();
+     if ($type === FALSE) {


### PR DESCRIPTION
## NEPT-2629

### Description

phpvideotoolkit library not compatible php 7.2

### Change log

- Added: patches for phpvideotoolkit library to fix php7 compatibility


