### PR TITLE
NEPT-2655: views_data_export is not compatible with PHP 7.2

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -819,6 +819,9 @@ projects[views_bulk_operations][patch][] = https://www.drupal.org/files/issues/n
 
 projects[views_data_export][subdir] = "contrib"
 projects[views_data_export][version] = "3.2"
+; PHP 7 compatibility Issue
+; https://www.drupal.org/project/views_data_export/issues/3005288
+projects[views_data_export][patch][] = https://www.drupal.org/files/issues/2018-10-09/views_data_export-phpcs_warning-php_tag.patch
 
 projects[views_datasource][version] = "1.0-alpha2"
 projects[views_datasource][subdir] = "contrib"


### PR DESCRIPTION
## NEPT-2655

### Description

views_data_export is not compatible with PHP 7.2

### Change log

- Added: patch to fix compatibility issue with php 7.2
