### PR TITLE
NEPT-2668: Make Language selector compatible with content translation.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1183,6 +1183,7 @@ projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
 projects[ec_europa][download][tag] = 0.0.14
 projects[ec_europa][patch][] = patches/nept-2585-remove-site-switcher.patch
+projects[ec_europa][patch][] = patches/nept-2668-language-switcher.patch
 
 ; ==============
 ; Custom modules

--- a/resources/patches/nept-2668-language-switcher.patch
+++ b/resources/patches/nept-2668-language-switcher.patch
@@ -1,0 +1,32 @@
+diff --git a/templates/lang_select_site/lang_select_site.component.inc b/templates/lang_select_site/lang_select_site.component.inc
+index a8c22d41..1020887d 100644
+--- a/templates/lang_select_site/lang_select_site.component.inc
++++ b/templates/lang_select_site/lang_select_site.component.inc
+@@ -48,22 +48,24 @@ function ec_europa_preprocess_lang_select_site(array &$variables, $hook) {
+   $languages_list = language_list('enabled');
+   $variables['code'] = $language_current->language;
+   $variables['label'] = $language_current->name;
++  $destination = drupal_get_destination();
++  $translations = translation_path_get_translations($destination['destination']);
+ 
+   $variables['url'] = url(
+     'language-selector/site-language', array(
+       'html' => TRUE,
+       'query' => array(
+-        drupal_get_destination(),
++        $destination,
+       ),
+     )
+   );
+ 
+   // Build the list of links.
+-  $languages = array_map(function ($language) use ($variables) {
++  $languages = array_map(function ($language) use ($variables, $translations) {
+     return array(
+       '#theme' => _atomium_extend_theme_hook('link', $variables['theme_hook_original']),
+       '#text' => $language->name,
+-      '#path' => current_path(),
++      '#path' => (isset($translations[$language->language])) ? $translations[$language->language] : current_path(),
+       '#options' => array(
+         'attributes' => array(
+           'class' => array(


### PR DESCRIPTION
## NEPT-2668

### Description

Make Language selector compatible with content translation, language selector did not work when multilingual support was enabled with node translation.

### Change log

- Added: Patch nept-2668-language-switcher.patch
- Changed: ec_europa_preprocess_lang_select_site()
