### PR TITLE
NEPT-2582: Fix revision timestamp

### DIFF
--- a/profiles/common/modules/custom/version_management/version_management.module
+++ b/profiles/common/modules/custom/version_management/version_management.module
@@ -135,7 +135,8 @@ function version_management_node_presave($node) {
   }
 
   // Process node to keep date.
-  $node->changed = $node->original->changed;
+  unset($node->changed);
+  $node->revision_timestamp = $node->timestamp;
 
 }
 

--- a/profiles/common/modules/custom/version_management/version_management.module
+++ b/profiles/common/modules/custom/version_management/version_management.module
@@ -135,8 +135,7 @@ function version_management_node_presave($node) {
   }
 
   // Process node to keep date.
-  unset($node->changed);
-  $node->timestamp = $node->original->workbench_moderation['current']->timestamp;
+  $node->changed = $node->original->workbench_moderation['current']->timestamp;
 
 }
 

--- a/profiles/common/modules/custom/version_management/version_management.module
+++ b/profiles/common/modules/custom/version_management/version_management.module
@@ -135,7 +135,7 @@ function version_management_node_presave($node) {
   }
 
   // Process node to keep date.
-  $node->changed = $node->original->workbench_moderation['current']->timestamp;
+  $node->changed = $node->original->changed;
 
 }
 


### PR DESCRIPTION
## NEPT-2582

### Description

Get correct revision timestamp in node_revision table.

### Change log

- Changed: fixed timestamp in version_management.module


### Commands

drush cc all

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
