### PR TITLE
NEPT-2695: Add date metatag and fixes.

### DIFF
--- a/profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.metatag.inc
+++ b/profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.metatag.inc
@@ -297,7 +297,7 @@ function nexteuropa_metatags_metatag_info() {
   $info['tags']['date'] = array(
     'label' => t('Date'),
     'name' => 'date',
-    'description' => '',
+    'description' => 'Date associated with the resource.',
   ) + $ne_defaults;
 
   return $info;

--- a/profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.metatag.inc
+++ b/profiles/common/modules/features/nexteuropa_metatags/nexteuropa_metatags.metatag.inc
@@ -56,6 +56,9 @@ function nexteuropa_metatags_metatag_config_default() {
       'value' => !empty($classification) ? $classification : '',
       'readonly' => 'readonly',
     ),
+    'date' => array(
+      'value' => '[current-date:short]',
+    ),
     // Basic tags.
     'description' => array(
       'value' => '[site:name] - [site:slogan]',
@@ -72,9 +75,6 @@ function nexteuropa_metatags_metatag_config_default() {
     ),
     'content-language' => array(
       'value' => '[language:language-ui:language]',
-    ),
-    'date' => array(
-      'value' => '[current-date:short]',
     ),
     'dcterms.format' => array(
       'value' => 'text/html',
@@ -258,9 +258,6 @@ function nexteuropa_metatags_metatag_info() {
   $ne_defaults = array(
     'class' => 'DrupalTextMetaTag',
     'group' => 'nexteuropa',
-    'element' => array(
-      '#theme' => 'metatag_property',
-    ),
     'context' => array('global'),
   );
 
@@ -295,6 +292,12 @@ function nexteuropa_metatags_metatag_info() {
     'label' => t('Reference'),
     'description' => t('Usually the acronym of the DG / Site name (max. 30 characters).<br/>This text will supply information to METADATA "Reference".<br/>See the <a href="http://ec.europa.eu/ipg/content/optimise/metadata/annex1_en.htm#section_1" target="_blank">IPG guidelines</a> for more information.'),
     'select_or_other' => TRUE,
+  ) + $ne_defaults;
+
+  $info['tags']['date'] = array(
+    'label' => t('Date'),
+    'name' => 'date',
+    'description' => '',
   ) + $ne_defaults;
 
   return $info;

--- a/tests/features/nexteuropa_metatags.feature
+++ b/tests/features/nexteuropa_metatags.feature
@@ -36,7 +36,7 @@ Feature: NextEuropa Metatags feature
   Scenario: As anonymous I should see the nexteuropa tags (Creator, IPG Classification, Reference)
     Given I am on the homepage
     And I am an anonymous user
-    Then the response should contain the meta tag with the "creator" name the "property" type and the "COMM/DG/UNIT" content
-    And the response should contain the meta tag with the "classification" name the "property" type and the "03000" content
-    And the response should contain the meta tag with the "reference" name the "property" type and the "European Commission" content
+    Then the response should contain the meta tag with the "creator" name and the "COMM/DG/UNIT" content
+    And the response should contain the meta tag with the "classification" name and the "03000" content
+    And the response should contain the meta tag with the "reference" name and the "European Commission" content
     And the response should contain the meta tag with the "og:image" name the "property" type and the "/tests/files/logo.png" content

--- a/tests/src/Context/MinkContext.php
+++ b/tests/src/Context/MinkContext.php
@@ -571,6 +571,18 @@ class MinkContext extends DrupalExtensionMinkContext {
   }
 
   /**
+   * Checks that HTML response contains the specified meta tag.
+   *
+   * It checks the name and the content attributes values.
+   *
+   * @Then the response should contain the meta tag with the :arg1 name and the :arg2 content
+   */
+  public function responseShouldContainMetaTagWithNameAndContent($arg1, $arg2) {
+    $metatag = $this->getMetaTagByName($arg1);
+    assert($arg2, equals($metatag->getAttribute('content')), sprintf('The meta tag "%s" does not have "%s" as content attribute.', $arg1, $arg2));
+  }
+
+  /**
    * Gets the meta tag NodeElement from the type attribute value.
    *
    * @param string $name
@@ -581,11 +593,16 @@ class MinkContext extends DrupalExtensionMinkContext {
    * @return \Behat\Mink\ElementNodeElement
    *   The meta tag node element.
    */
-  protected function getMetaTagByName($name, $type) {
+  protected function getMetaTagByName($name, $type = NULL) {
     $page = $this->getSession()->getPage();
-    $meta_type = sprintf('meta[%s="%s"]', $type, $name);
-    $element = $page->find('css', $meta_type);
+    if ($type) {
+      $meta_type = sprintf('meta[%s="%s"]', $type, $name);
+    }
+    else {
+      $meta_type = $page->find('css', sprintf('meta[name="%s"]', $name));
+    }
 
+    $element = $page->find('css', $meta_type);
     assert($element, isNotEmpty(), sprintf('The meta tag type "%s" with "%s" name has not been found', $type, $name));
 
     return $element;

--- a/tests/src/Context/MinkContext.php
+++ b/tests/src/Context/MinkContext.php
@@ -595,12 +595,10 @@ class MinkContext extends DrupalExtensionMinkContext {
    */
   protected function getMetaTagByName($name, $type = NULL) {
     $page = $this->getSession()->getPage();
-    if ($type) {
-      $meta_type = sprintf('meta[%s="%s"]', $type, $name);
+    if (!isset($type)) {
+      $type = "name";
     }
-    else {
-      $meta_type = $page->find('css', sprintf('meta[name="%s"]', $name));
-    }
+    $meta_type = sprintf('meta[%s="%s"]', $type, $name);
 
     $element = $page->find('css', $meta_type);
     assert($element, isNotEmpty(), sprintf('The meta tag type "%s" with "%s" name has not been found', $type, $name));


### PR DESCRIPTION
## NEPT-2695

### Description

Date meta tag disappeared in Platform 2.6, this ads it back and changes from property to name.

### Change log

- Added: Date to nexteuropa_metatags_metatag_info();
- Removed: Formatter 'metatag_property' from meta element

### Commands

drush cc all

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
