### PR TITLE
NEPT-2708: Update atomium and ec_europa.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_formatters/templates/blockquote.tpl.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/templates/blockquote.tpl.php
@@ -10,5 +10,5 @@
 ?>
 
 <blockquote class="blockquote"<?php print $attributes; ?>>
-  <p><?php print render($markup);?></p>
+  <p><?php print render($markup); ?> </p>
 </blockquote>

--- a/profiles/common/modules/custom/nexteuropa_lastupdate/theme/nexteuropa-last-update-block.tpl.php
+++ b/profiles/common/modules/custom/nexteuropa_lastupdate/theme/nexteuropa-last-update-block.tpl.php
@@ -13,7 +13,7 @@
  * @see template_process()
  */
 ?>
-<?php if (!empty($label) && !empty($date)) : ?>
+<?php if (!empty($label) && !empty($date)): ?>
   <div class="last-update">
     <?php print $label; ?> : <?php print $date; ?>
   </div>

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1176,13 +1176,12 @@ projects[ec_resp][download][url] = https://github.com/ec-europa/ec_resp.git
 projects[ec_resp][download][tag] = 2.3.9
 
 projects[atomium][type] = theme
-projects[atomium][version] = 2.12
+projects[atomium][version] = 2.30
 
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
-projects[ec_europa][download][tag] = 0.0.14
-projects[ec_europa][patch][] = patches/nept-2585-remove-site-switcher.patch
+projects[ec_europa][download][tag] = 0.0.21
 
 ; ==============
 ; Custom modules


### PR DESCRIPTION
## NEPT-2708

### Description

   - atomium 7.x-2.12 -> 7.x-2.30
   - ec_europa 0.0.14 -> 0.0.21
   - Removed unneeded patch as it is integrated in new version
