### PR TITLE
NEPT-2714: Upgrade maxlength to version 3.3.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -461,7 +461,7 @@ projects[mailsystem][subdir] = "contrib"
 projects[mailsystem][version] = "2.34"
 
 projects[maxlength][subdir] = "contrib"
-projects[maxlength][version] = "3.2-beta2"
+projects[maxlength][version] = "3.3"
 
 projects[media][subdir] = contrib
 projects[media][version] = 2.23


### PR DESCRIPTION
## NEPT-2714
### Description

Upgrade maxlength to version 3.3 due to a security advisory. The changes in the upgrade are minor changes.

### Change log

- Changed: maxlenth version to 3.3 in multisite_drupal_standard.make 

### Checklist

- [x] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
