### PR TITLE
NEPT-2613: Block FTP protocol in link fields.

### DIFF
--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.install
@@ -22,12 +22,16 @@ function multisite_drupal_toolbox_enable() {
   // Drupal minimum value.
   multisite_config_service('filter')->enableTextFilter('basic_html', 'toolbox_sanitize');
   multisite_config_service('filter')->setTextFilterWeight('basic_html', 'toolbox_sanitize', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT);
+  multisite_config_service('filter')->setTextFilterWeight('basic_html', 'filter_url', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT - 1);
   multisite_config_service('filter')->enableTextFilter('filtered_html', 'toolbox_sanitize');
   multisite_config_service('filter')->setTextFilterWeight('filtered_html', 'toolbox_sanitize', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT);
+  multisite_config_service('filter')->setTextFilterWeight('filtered_html', 'filter_url', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT - 1);
   multisite_config_service('filter')->enableTextFilter('full_html', 'toolbox_sanitize');
   multisite_config_service('filter')->setTextFilterWeight('full_html', 'toolbox_sanitize', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT);
+  multisite_config_service('filter')->setTextFilterWeight('full_html', 'filter_url', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT - 1);
   multisite_config_service('filter')->enableTextFilter('full_html_track', 'toolbox_sanitize');
   multisite_config_service('filter')->setTextFilterWeight('full_html_track', 'toolbox_sanitize', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT);
+  multisite_config_service('filter')->setTextFilterWeight('full_html_track', 'filter_url', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT - 1);
 }
 
 /**
@@ -91,6 +95,7 @@ function multisite_drupal_toolbox_update_7202() {
       // It is a one shot and no exotic value has been detected in sub-sites;
       // no need to complicating more.
       multisite_config_service('filter')->setTextFilterWeight($format_machine_name, 'toolbox_sanitize', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT);
+      multisite_config_service('filter')->setTextFilterWeight($format_machine_name, 'filter_url', MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT - 1);
       watchdog('multisite drupal toolbox', '"Updatedb process: toolbox_sanitize" has been enabled for @text_format.', array('@text_format' => $format_machine_name), WATCHDOG_INFO);
       continue;
     }

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
@@ -571,13 +571,11 @@ function multisite_drupal_toolbox_sanitize($content) {
  * Remove ftp: protocol from field values.
  */
 function multisite_drupal_toolbox_preprocess_field(&$variables) {
-  switch ($variables['element']['#field_type']) {
-    case 'link_field':
-      foreach ($variables['items'] as $key => $value) {
-        $variables['items'][$key]['#element']['url'] = multisite_drupal_toolbox_filter_xss_bad_protocol($value['#element']['url']);
-        $variables['items'][$key]['#element']['display_url'] = multisite_drupal_toolbox_filter_xss_bad_protocol($value['#element']['display_url']);
-      }
-      break;
+  if ($variables['element']['#field_type'] === 'link_field') {
+    foreach ($variables['items'] as $key => $value) {
+      $variables['items'][$key]['#element']['url'] = multisite_drupal_toolbox_filter_xss_bad_protocol($value['#element']['url']);
+      $variables['items'][$key]['#element']['display_url'] = multisite_drupal_toolbox_filter_xss_bad_protocol($value['#element']['display_url']);
+    }
   }
 }
 

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
@@ -565,7 +565,6 @@ function multisite_drupal_toolbox_sanitize($content) {
   return multisite_drupal_toolbox_filter_xss($content, multisite_drupal_toolbox_get_default_filter_options());
 }
 
-
 /**
  * Implements hook_preprocess_field().
  *

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
@@ -534,7 +534,7 @@ function multisite_drupal_toolbox_filter_format_update($format) {
 }
 
 /**
- * Implements hook_filter_info_alter().
+ * Implements hook_filter_info().
  */
 function multisite_drupal_toolbox_filter_info() {
   $info['toolbox_sanitize'] = array(
@@ -544,6 +544,27 @@ function multisite_drupal_toolbox_filter_info() {
   );
 
   return $info;
+}
+
+/**
+ * Implements hook_filter_info_alter().
+ */
+function multisite_drupal_toolbox_filter_info_alter(&$info) {
+  $info['filter_html_escape']['process callback'] = '_multisite_drupal_toolbox_filter_html_escape';
+}
+
+/**
+ * Alter filter process callback for the token input filter.
+ *
+ * @param string $text
+ *   The text to filter.
+ *
+ * @see multisite_drupal_toolbox_filter_info_alter()
+ */
+function _multisite_drupal_toolbox_filter_html_escape($text) {
+  $text = str_ireplace('ftp://', '//', $text);
+
+  return _filter_html_escape($text);
 }
 
 /**

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
@@ -6,8 +6,7 @@
  */
 
 define('MULTISITE_DRUPAL_TOOLBOX_FEATURES_REVERT_BLACKLISTED', 'cce_basic_config,multisite_settings_core');
-define('MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT', -50);
-define('MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MAX_WEIGHT', 50);
+define('MULTISITE_DRUPAL_TOOLBOX_DRUPAL_MIN_WEIGHT', -49);
 
 /**
  * Implements hook_permission().

--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
@@ -565,6 +565,38 @@ function multisite_drupal_toolbox_sanitize($content) {
   return multisite_drupal_toolbox_filter_xss($content, multisite_drupal_toolbox_get_default_filter_options());
 }
 
+
+/**
+ * Implements hook_preprocess_field().
+ *
+ * Remove ftp: protocol from field values.
+ */
+function multisite_drupal_toolbox_preprocess_field(&$variables) {
+  switch ($variables['element']['#field_type']) {
+    case 'link_field':
+      foreach ($variables['items'] as $key => $value) {
+        $variables['items'][$key]['#element']['url'] = multisite_drupal_toolbox_filter_xss_bad_protocol($value['#element']['url']);
+        $variables['items'][$key]['#element']['display_url'] = multisite_drupal_toolbox_filter_xss_bad_protocol($value['#element']['display_url']);
+      }
+      break;
+  }
+}
+
+/**
+ * Implements template_preprocess_views_view_fields().
+ *
+ * Remove ftp: protocol from field values.
+ */
+function multisite_drupal_toolbox_preprocess_views_view_fields(&$vars) {
+  $fields = &$vars['fields'];
+
+  foreach ($fields as $key => $value) {
+    if (!empty($value->handler->field_info) && $value->handler->field_info['type'] === 'link_field') {
+      $fields[$key]->content = str_ireplace('ftp://', '//', $fields[$key]->content);
+    }
+  }
+}
+
 /**
  * Public function to disable a content type.
  *

--- a/profiles/common/modules/features/multisite_wysiwyg/ckeditor/link_alter.js
+++ b/profiles/common/modules/features/multisite_wysiwyg/ckeditor/link_alter.js
@@ -33,7 +33,7 @@
           var ftpIndex = false;
           for (i = dialogDefinition.getContents('info').get('protocol')['items'].length - 1; i >= 0; i--) {
             ftpIndex = dialogDefinition.getContents('info').get('protocol')['items'][i].indexOf("ftp://");
-            
+
             if (ftpIndex !== -1) {
               dialogDefinition.getContents('info').get('protocol')['items'].splice(i, 1);
             }

--- a/profiles/common/modules/features/multisite_wysiwyg/ckeditor/link_alter.js
+++ b/profiles/common/modules/features/multisite_wysiwyg/ckeditor/link_alter.js
@@ -29,6 +29,15 @@
               }
           }
           targetTab.elements[0].children[0].items = optionsToKeep;
+          // NEPT-2613: Block FTP protocol from the wysiwyg filters.
+          var ftpIndex = false;
+          for (i = dialogDefinition.getContents('info').get('protocol')['items'].length - 1; i >= 0; i--) {
+            ftpIndex = dialogDefinition.getContents('info').get('protocol')['items'][i].indexOf("ftp://");
+            
+            if (ftpIndex !== -1) {
+              dialogDefinition.getContents('info').get('protocol')['items'].splice(i, 1);
+            }
+          }
         }
     });
 })();


### PR DESCRIPTION
## NEPT-2613

### Description

Block FTP protocol in link fields.

### Change log

- Added:
   - hook_preprocess_field()
   - template_preprocess_views_view_fields().

### Commands

drush cc all

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
