### PR TITLE
NEPT-2718: Fix error in media after maxlength is enabled.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -471,6 +471,8 @@ projects[media][version] = 2.23
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1015
 ; Media markup navigation causes duplicated links
 projects[media][patch][] = https://www.drupal.org/files/issues/media-delete-embedded-document-2028231-11.patch
+; NEPT-2718 Error thrown when maxlength module is enabled
+projects[media][patch][] = patches/media-nept-2718-maxlength-title-error.patch
 
 projects[media_avportal][subdir] = "contrib"
 projects[media_avportal][version] = "1.5"

--- a/resources/patches/media-nept-2718-maxlength-title-error.patch
+++ b/resources/patches/media-nept-2718-maxlength-title-error.patch
@@ -1,0 +1,17 @@
+diff --git a/media.module b/media.module
+index 49d47fe..c888a21 100644
+--- a/media.module
++++ b/media.module
+@@ -368,6 +368,12 @@ function media_form_field_ui_field_edit_form_alter(&$form, &$form_state) {
+     // presumably they will not need a long list of extensions.
+   }
+ 
++  if (!isset($form['instance']['widget']['type'])) {
++    $form['instance']['widget']['type'] = array(
++      '#value' => $form['#instance']['widget']['type'],
++    );
++  }
++
+   // Add a validation function to any field instance which uses the media widget
+   // to ensure that the upload destination scheme is one of the allowed schemes
+   // if any defined by settings.


### PR DESCRIPTION
## NEPT-2718

### Description

Error thrown when maxlength module is enabled.

### Change log

- Added: Patch media-nept-2718-maxlength-title-error.patch.

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
