### PR TITLE
NEPT-2719: Remove dependency to multisite_og_button.

### DIFF
--- a/profiles/common/modules/features/nexteuropa_communities/nexteuropa_communities.info
+++ b/profiles/common/modules/features/nexteuropa_communities/nexteuropa_communities.info
@@ -9,7 +9,6 @@ dependencies[] = entityreference_prepopulate
 dependencies[] = features
 dependencies[] = field_group
 dependencies[] = list
-dependencies[] = multisite_og_button
 dependencies[] = nexteuropa_multilingual
 dependencies[] = og_ui
 dependencies[] = options


### PR DESCRIPTION
## NEPT-2719

### Description

Fix nexteuropa_communities requires multisite_og_button

### Change log

- Removed: Dependency to multisite_og_button

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
