### PR TITLE
NEPT-2688: Fix runing simpletests in the platform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ PHPUnit tests can be executed from the repository root by running:
 $ ./bin/phpunit -c tests/phpunit.xml
 ```
 
+## Running Drupal Simpletests on the platform
+
+Check the documentation [here](https://webgate.ec.europa.eu/fpfis/wikis/x/NJUQE)
 
 ## Checking for coding standards violations
 

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -772,9 +772,7 @@ projects[token_filter][subdir] = "contrib"
 projects[token_filter][version] = 1.1
 
 projects[translation_overview][subdir] = "contrib"
-projects[translation_overview][version] = "2.0-beta1"
-; https://www.drupal.org/node/2673314
-projects[translation_overview][patch][] = https://www.drupal.org/files/issues/translation_overview-simpletest-warning-message-2673314-2-D7.patch
+projects[translation_overview][version] = "2.0-beta2"
 
 projects[translation_table][subdir] = "contrib"
 projects[translation_table][version] = "1.0-beta1"
@@ -798,6 +796,8 @@ projects[uuid][subdir] = "contrib"
 projects[uuid][version] = "1.3"
 ; https://www.drupal.org/project/uuid/issues/3058011
 projects[uuid][patch][] = https://git.drupalcode.org/project/uuid/commit/311a2d668f990f7547c2125cebf69b55d2349f77.diff
+; https://www.drupal.org/node/3061669
+projects[uuid][patch][] = https://www.drupal.org/files/issues/2019-09-27/uuid-fix_missing_services_test_class-3061669-17.patch
 
 projects[variable][subdir] = "contrib"
 projects[variable][version] = "2.5"


### PR DESCRIPTION
## NEPT-2688

### Description

Fix runing simpletests in the platform.

### Change log

- Added: patch in UUID module, update translation_overview module

### Commands

```drush updb```

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
