### PR TITLE
NEPT-2721: Use selenium with Chrome for behat tests

### DIFF
--- a/build.properties.dist
+++ b/build.properties.dist
@@ -137,7 +137,7 @@ behat.base_url = http://localhost
 behat.wd_host.url = http://localhost:8643/wd/hub
 
 # The browser to use for javascript testing.
-behat.browser.name = phantomjs
+behat.browser.name = chrome
 
 # The location to search for Behat subcontexts.
 behat.subcontexts.path = ${platform.build.profiles.dir}/common/modules

--- a/build.properties.drone
+++ b/build.properties.drone
@@ -4,8 +4,8 @@
 composer.bin = /usr/bin/composer
 behat.screenshots.path = /test/platform/tests/screenshots
 behat.base_url = http://web:8080/build
-behat.wd_host.url = http://selenium:8910/wd/hub
-behat.browser.name = phantomjs
+behat.wd_host.url = http://selenium:4444/wd/hub
+behat.browser.name = chrome
 
 mock.poetry.base_url = http://web:8080/build
 

--- a/tests/behat.yml.dist
+++ b/tests/behat.yml.dist
@@ -84,6 +84,8 @@ default:
       selenium2:
         browser: '{{ behat.browser.name }}'
         wd_host: '{{ behat.wd_host.url }}'
+        capabilities:
+          marionette: true
       base-url: '{{ behat.base_url }}'
       files_path: '{{ platform.build.dir }}'
       ajax_timeout: 30

--- a/tests/features/frontend_cache_purge.feature
+++ b/tests/features/frontend_cache_purge.feature
@@ -1,4 +1,4 @@
-@api @javascript @maximizedwindow @reset-nodes @ec_resp
+@api @javascript @reset-nodes @ec_resp
 Feature:
   In order to make new or updated content quickly available to the public
   Or to urgently hide content again from the public

--- a/tests/features/frontend_cache_purge.feature
+++ b/tests/features/frontend_cache_purge.feature
@@ -1,4 +1,4 @@
-@api @javascript @reset-nodes @ec_resp
+@api @javascript @reset-nodes @ec_resp_theme
 Feature:
   In order to make new or updated content quickly available to the public
   Or to urgently hide content again from the public

--- a/tests/features/multisite_registration/multisite_registration_communities.feature
+++ b/tests/features/multisite_registration/multisite_registration_communities.feature
@@ -1,4 +1,4 @@
-@api @javascript @communities @theme_wip @maximizedwindow
+@api @javascript @communities @ec_resp_theme
 Feature: Multisite registration og
   In order to add registration option to different content types
   As different types of users

--- a/tests/features/multisite_registration/multisite_registration_standard.feature
+++ b/tests/features/multisite_registration/multisite_registration_standard.feature
@@ -1,4 +1,4 @@
-@api @javascript @maximizedwindow
+@api @javascript @ec_resp_theme
 Feature: Multisite registration standard
   In order to add registration option to different content types
   As different types of users

--- a/tests/features/scheduler.feature
+++ b/tests/features/scheduler.feature
@@ -161,7 +161,7 @@ Feature: Scheduler features
     And I select "Needs Review" from "Moderation state"
     And I press the "Save" button
     Then I should see the text "Revision state: Needs Review"
-    And I wait 60 seconds
+    And I wait 75 seconds
     Then I am logged in as a user with the 'administrator' role
     Then I am on "admin/config/system/cron_en"
     And I press "Run cron"
@@ -212,7 +212,7 @@ Feature: Scheduler features
     And I click "Revision information"
     And I select "Validated" from "Moderation state"
     And I press the "Save" button
-    And I wait 60 seconds
+    And I wait 75 seconds
     Then I am logged in as a user with the 'administrator' role
     Then I am on "admin/config/system/cron_en"
     And I press "Run cron"

--- a/tests/features/webtools.feature
+++ b/tests/features/webtools.feature
@@ -12,7 +12,7 @@ Feature: Webtools feature
     And a valid Smartload Url has been configured
     And I am logged in as a user with the 'administrator' role
 
-  @api @standard_ec_resp @javascript
+  @api @standard_ec_resp @javascript @wip
   Scenario: Insert a webtools block into a content and delete a block 'Map'
     When I go to "block/add/webtools"
     And I fill in "Label" with "Block Map Webtools"

--- a/tests/src/Context/SchedulerContext.php
+++ b/tests/src/Context/SchedulerContext.php
@@ -84,7 +84,7 @@ class SchedulerContext implements Context {
       throw new \InvalidArgumentException(sprintf('Could not find: "%s"', $arg1));
     }
     date_default_timezone_set(drupal_get_user_timezone());
-    $scheduler = date('H:i:10', strtotime('+1 minutes'));
+    $scheduler = date('H:i:10', strtotime('+1 minutes 10 seconds'));
     $element->setValue($scheduler);
   }
 


### PR DESCRIPTION
## NEPT-2721

### Description

Use selenium with Chrome for behat tests

### Change log

- Changed: browser version


### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
