### PR TITLE
NEPT-2721: Merge conflict to 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,9 +250,6 @@ PHPUnit tests can be executed from the repository root by running:
 $ ./bin/phpunit -c tests/phpunit.xml
 ```
 
-## Running Drupal Simpletests on the platform
-
-Check the documentation [here](https://webgate.ec.europa.eu/fpfis/wikis/x/NJUQE)
 
 ## Checking for coding standards violations
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_fields/nexteuropa_formatters_fields.module
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_fields/nexteuropa_formatters_fields.module
@@ -436,6 +436,29 @@ function nexteuropa_formatters_fields_field_formatter_view($entity_type, $entity
           $elements[$delta] = $link;
         }
       }
+      elseif ('file' == $field['type']) {
+        foreach ($items as $delta => $item) {
+          $link = array(
+            '#theme' => 'link',
+            '#text' => $item['filename'],
+            '#path' => file_create_url($item['uri']),
+            '#options' => array(
+              'attributes' => array(
+                'target' => array(
+                  '_blank',
+                ),
+                'class'  => array(
+                  'ecl-button',
+                  'ecl-button--default',
+                  'ecl-file__download',
+                  'ecl-button--file',
+                ),
+              ),
+            ),
+          );
+          $elements[$delta] = $link;
+        }
+      }
       break;
 
     case 'ne_social_icon':

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -800,7 +800,9 @@ projects[token_filter][subdir] = "contrib"
 projects[token_filter][version] = 1.1
 
 projects[translation_overview][subdir] = "contrib"
-projects[translation_overview][version] = "2.0-beta2"
+projects[translation_overview][version] = "2.0-beta1"
+; https://www.drupal.org/node/2673314
+projects[translation_overview][patch][] = https://www.drupal.org/files/issues/translation_overview-simpletest-warning-message-2673314-2-D7.patch
 
 projects[translation_table][subdir] = "contrib"
 projects[translation_table][version] = "1.0-beta1"
@@ -824,8 +826,6 @@ projects[uuid][subdir] = "contrib"
 projects[uuid][version] = "1.3"
 ; https://www.drupal.org/project/uuid/issues/3058011
 projects[uuid][patch][] = https://git.drupalcode.org/project/uuid/commit/311a2d668f990f7547c2125cebf69b55d2349f77.diff
-; https://www.drupal.org/node/3061669
-projects[uuid][patch][] = https://www.drupal.org/files/issues/2019-09-27/uuid-fix_missing_services_test_class-3061669-17.patch
 
 projects[variable][subdir] = "contrib"
 projects[variable][version] = "2.5"


### PR DESCRIPTION
## NEPT-2721
### Description

Fix merge conflict for move to selenium

### Change log

- Changed: using selenium with chrome brownser


### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
