### PR TITLE
NEPT-2728: Fix realname issue with ecas.

### DIFF
--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -928,8 +928,12 @@ function ecas_save_user($account, $edit, array $ecas_user_info, array $args = ar
   // Load the user account and update realname, to ensure the safe_value of
   // fields are updated.
   cache_clear_all();
-  $update_account = user_load($account->uid, TRUE);
-  realname_update($update_account);
+
+  if (module_exists('realname')) {
+    $update_account = user_load($account->uid, TRUE);
+    realname_update($update_account);
+  }
+
   return $account;
 }
 


### PR DESCRIPTION
## NEPT-2728

### Description

Fixed realname in ecas.inc throws fatal error.

### Change log

- Fixed: if statement around realname_update() in ecas.inc.


### Commands

[Insert commands here]

### Checklist

- [x] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
