### PR TITLE
NEPT-2722: Upgrade nexteuropa_varnish to version 1.0.8

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1171,4 +1171,4 @@ projects[nexteuropa_varnish][subdir] = "custom"
 projects[nexteuropa_varnish][type] = module
 projects[nexteuropa_varnish][download][type] = git
 projects[nexteuropa_varnish][download][url] = https://github.com/ec-europa/digit-ne-varnish.git
-projects[nexteuropa_varnish][download][tag] = v1.0.7
+projects[nexteuropa_varnish][download][tag] = v1.0.8

--- a/tests/features/frontend_cache_purge.feature
+++ b/tests/features/frontend_cache_purge.feature
@@ -12,6 +12,7 @@ Feature:
     And these modules are enabled
       | modules            |
       | nexteuropa_varnish |
+      | rules_admin        |
     And I am logged in as a user with the "administrator" role
 
   Scenario: View purge rules.


### PR DESCRIPTION
## NEPT-2722

### Description

Upgrade nexteuropa_varnish to version 1.0.8

### Change log

- Added: Support for rules by creating a flush regex action


### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
