### PR TITLE
NEPT-2499

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -209,6 +209,9 @@ projects[entity_translation][download][branch] = 7.x-1.x
 projects[entity_translation][patch][] = https://www.drupal.org/files/issues/2018-07-25/workbench_moderation-1707156-83.patch
 ; https://www.drupal.org/node/2856927
 projects[entity_translation][patch][] = https://www.drupal.org/files/issues/entity_translation-2856927-8-dual_setter_logic.patch
+; NEPT-2499: Content types with another language than English don't show their values.
+; https://www.drupal.org/project/entity_translation/issues/2877103
+projects[entity_translation][patch][] = https://www.drupal.org/files/issues/2018-10-03/entity_translation-content_not_in_current_language-2877103-17.patch
 
 projects[entitycache][subdir] = "contrib"
 projects[entitycache][version] = 1.5


### PR DESCRIPTION
## NEPT-2499

### Description

Fix content types with another language than English don't show their values.

### Change log

- Added: Patch entity_translation-content_not_in_current_language-2877103-17.patch

### Checklist

- [x] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
