### PR TITLE
NEPT-1570: Enable context on mediagallery core.

### DIFF
--- a/profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.features.inc
+++ b/profiles/common/modules/features/multisite_mediagallery_core/multisite_mediagallery_core.features.inc
@@ -18,6 +18,9 @@ function multisite_mediagallery_core_ctools_plugin_api($module = NULL, $api = NU
   if ($module == "strongarm" && $api == "strongarm") {
     return array("version" => "1");
   }
+  if ($module == "context" && $api == "context") {
+    return array("version" => "3");
+  }
 }
 
 /**


### PR DESCRIPTION
## NEPT-1570

### Description

Fix multisite_mediagallery_core.context.inc is no longer working

### Change log

- Added: context to features.inc

### Checklist

- [x] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
