### PR TITLE
NEPT-2729: Fix realname dependencies.

### DIFF
--- a/profiles/common/modules/features/ec_profiles/ec_profiles.info
+++ b/profiles/common/modules/features/ec_profiles/ec_profiles.info
@@ -2,6 +2,7 @@ name = EC Profiles
 package = Multisite Features
 core = 7.x
 dependencies[] = user_field_privacy
+dependencies[] = realname
 description = Provides a page listing users.
 features[ctools][] = views:views_default:3.0
 features[views_view][] = people


### PR DESCRIPTION
## NEPT-2729

### Description

Fix realname dependencies.

### Commands to run
```drush fr -y ec_profiles.dependencies```

### Change log

- Added: dependency to realname in ec_profiles

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
