### PR TITLE
NEPT-2737: Fix tracking changes regression.

### DIFF
--- a/profiles/common/modules/features/nexteuropa_trackedchanges/js/nexteuropa_trackedchanges_ckeditor.js
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/js/nexteuropa_trackedchanges_ckeditor.js
@@ -7,7 +7,7 @@
   Drupal.behaviors.nexteuropa_trackedchanges_ckeditor = {
     attach: function () {
       $(function () {
-        function filterTracked(event) {
+        function filterTracked (event) {
           var editor = event.editor;
           var editorContent = editor.getData();
           var trackedChanges = editorContent.search('(<span[^>]+class\s*=\s*(")ice-[^>]*>)[^<]*(</span>)');

--- a/profiles/common/modules/features/nexteuropa_trackedchanges/js/nexteuropa_trackedchanges_ckeditor.js
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/js/nexteuropa_trackedchanges_ckeditor.js
@@ -7,13 +7,13 @@
   Drupal.behaviors.nexteuropa_trackedchanges_ckeditor = {
     attach: function () {
       $(function () {
-        function filterTracked (event) {
+        function filterTracked(event) {
           var editor = event.editor;
           var editorContent = editor.getData();
           var trackedChanges = editorContent.search('(<span[^>]+class\s*=\s*(")ice-[^>]*>)[^<]*(</span>)');
 
           if (trackedChanges >= 0) {
-            $('select.filter-list option').each(function(index, option) {
+            $('select.filter-list option').each(function (index, option) {
               if (Drupal.settings.tracking_profiles.indexOf(option.value) === -1) {
                 $('select.filter-list option').eq(index).prop('disabled', 'disabled');
               }

--- a/profiles/common/modules/features/nexteuropa_trackedchanges/js/nexteuropa_trackedchanges_ckeditor.js
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/js/nexteuropa_trackedchanges_ckeditor.js
@@ -7,32 +7,31 @@
   Drupal.behaviors.nexteuropa_trackedchanges_ckeditor = {
     attach: function () {
       $(function () {
+        function filterTracked(event) {
+          var editor = event.editor;
+          var editorContent = editor.getData();
+          var trackedChanges = editorContent.search('(<span[^>]+class\s*=\s*(")ice-[^>]*>)[^<]*(</span>)');
+
+          if (trackedChanges >= 0) {
+            $('select.filter-list option').each(function(index, option) {
+              if (Drupal.settings.tracking_profiles.indexOf(option.value) === -1) {
+                $('select.filter-list option').eq(index).prop('disabled', 'disabled');
+              }
+            });
+          }
+        }
+
         for (var i in CKEDITOR.instances) {
           CKEDITOR.instances[i].on('configLoaded', function (event) {
-            var editor = event.editor;
-            var editorContent = editor.getData();
-            var trackedChanges = editorContent.search('(<span[^>]+class\s*=\s*(")ice-[^>]*>)[^<]*(</span>)');
-            if (trackedChanges >= 0) {
-              $('select.filter-list').prop('disabled', 'disabled');
-            }
+            filterTracked(event);
           });
 
           CKEDITOR.instances[i].on('change', function (event) {
-            var editor = event.editor;
-            var editorContent = editor.getData();
-            var trackedChanges = editorContent.search('(<span[^>]+class\s*=\s*(")ice-[^>]*>)[^<]*(</span>)');
-            if (trackedChanges >= 0) {
-              $('select.filter-list').prop('disabled', 'disabled');
-            }
+            filterTracked(event);
           });
 
           CKEDITOR.instances[i].on('afterCommandExec', function (event) {
-            var editor = event.editor;
-            var editorContent = editor.getData();
-            var trackedChanges = editorContent.search('(<span[^>]+class\s*=\s*(")ice-[^>]*>)[^<]*(</span>)');
-            if (trackedChanges === -1) {
-              $('select.filter-list').removeProp('disabled');
-            }
+            filterTracked(event);
           });
         }
       });

--- a/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.module
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.module
@@ -778,7 +778,7 @@ function nexteuropa_trackedchanges_cron_queue_info() {
 function nexteuropa_trackedchanges_form_node_form_alter(&$form, &$form_state, $form_id) {
   $wysiwyg_profiles = _nexteuropa_trackedchanges_get_profiles();
   $tracking_profiles = array();
-  
+
   if (!empty($wysiwyg_profiles['info'])) {
     foreach ($wysiwyg_profiles['info'] as $name => $profile) {
       if ($profile['cke_lite_status'] === TRUE) {

--- a/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.module
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.module
@@ -779,16 +779,18 @@ function nexteuropa_trackedchanges_form_node_form_alter(&$form, &$form_state, $f
   $wysiwyg_profiles = _nexteuropa_trackedchanges_get_profiles();
   $tracking_profiles = array();
   
-  foreach ($wysiwyg_profiles['info'] as $name => $profile) {
-    if ($profile['cke_lite_status'] === TRUE) {
-      $tracking_profiles[] = $name;
+  if (!empty($wysiwyg_profiles['info'])) {
+    foreach ($wysiwyg_profiles['info'] as $name => $profile) {
+      if ($profile['cke_lite_status'] === TRUE) {
+        $tracking_profiles[] = $name;
+      }
     }
-  }
-  
-  drupal_add_js(array('tracking_profiles' => $tracking_profiles), 'setting');
 
-  $form['#attached']['js'][] = array(
-    'data' => drupal_get_path('module', 'nexteuropa_trackedchanges') . '/js/nexteuropa_trackedchanges_ckeditor.js',
-    'type' => 'file',
-  );
+    drupal_add_js(array('tracking_profiles' => $tracking_profiles), 'setting');
+
+    $form['#attached']['js'][] = array(
+      'data' => drupal_get_path('module', 'nexteuropa_trackedchanges') . '/js/nexteuropa_trackedchanges_ckeditor.js',
+      'type' => 'file',
+    );
+  }
 }

--- a/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.module
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/nexteuropa_trackedchanges.module
@@ -776,6 +776,17 @@ function nexteuropa_trackedchanges_cron_queue_info() {
  * Implements hook_form_BASE_FORM_ID_alter().
  */
 function nexteuropa_trackedchanges_form_node_form_alter(&$form, &$form_state, $form_id) {
+  $wysiwyg_profiles = _nexteuropa_trackedchanges_get_profiles();
+  $tracking_profiles = array();
+  
+  foreach ($wysiwyg_profiles['info'] as $name => $profile) {
+    if ($profile['cke_lite_status'] === TRUE) {
+      $tracking_profiles[] = $name;
+    }
+  }
+  
+  drupal_add_js(array('tracking_profiles' => $tracking_profiles), 'setting');
+
   $form['#attached']['js'][] = array(
     'data' => drupal_get_path('module', 'nexteuropa_trackedchanges') . '/js/nexteuropa_trackedchanges_ckeditor.js',
     'type' => 'file',

--- a/tests/features/change_tracking_workflow.feature
+++ b/tests/features/change_tracking_workflow.feature
@@ -35,8 +35,6 @@ Feature: Change tracking features
     And I should see the message "Change tracking enabled on full_html WYSIWYG profile"
     When I go to "node/add/page"
     And I fill in the content's title with "This is a page I want to reference"
-    Then I should not see the "Start tracking changes" button in the "Body" WYSIWYG editor
-    And I should not see the "Stop tracking changes" button in the "Body" WYSIWYG editor
     When  I fill in the rich text editor "Body" with "Text should change because life is always moving."
     And I press "Save"
     And I click "Edit draft"


### PR DESCRIPTION
## NEPT-2737

### Description

Instead of freezing current format if there are tracked changes, we should block those formats that are not "enabled" there.

### Change log

- Changed: Text profile disable behaviour.
- Fixed: Behat test for tracked changes.

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
