### PR TITLE
NEPT-2501: remove useless patches.

### DIFF
--- a/resources/multisite_drupal_communities.make
+++ b/resources/multisite_drupal_communities.make
@@ -17,15 +17,3 @@ projects[og-delete][download][url] = "http://git.drupal.org/project/OG-Delete.gi
 projects[og-delete][subdir] = "contrib"
 projects[og-delete][patch][] = patches/og_delete-remove_community-4481-2.patch
 projects[og-delete][patch][] = patches/og_delete-warning_fix-issue-3629.patch
-
-# Issue #2411041: Group manager always given default default role as og_is_member arguments wrong.
-# https://www.drupal.org/node/2411041
-# https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-6319
-projects[og][patch][] = http://www.drupal.org/files/issues/2411041-og-og_is_member-2.patch
-
-projects[og_linkchecker][download][branch] = 7.x-1.x 
-projects[og_linkchecker][download][revision] = 7257d0e
-projects[og_linkchecker][download][type] = git
-projects[og_linkchecker][subdir] = contrib
-projects[og_linkchecker][patch][] = https://www.drupal.org/files/issues/og_linkchecker-og-2-x-compatibility-2214661-2.patch
-


### PR DESCRIPTION
## NEPT-2501
### Description

remove useless patches.

### Change log

- Removed: 2 patches that are no longer needed

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
