### PR TITLE
NEPT-2745: Create a Paste from Word filter

### DIFF
--- a/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
+++ b/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
@@ -7,8 +7,13 @@
   Drupal.behaviors.multisite_wysiwyg_paste_from_word = {
     attach: function () {
       $(function () {
+        var activeFilter = [];
+
         for (var i in CKEDITOR.instances) {
           CKEDITOR.instances[i].on('paste', function (evt) {
+            if (activeFilter[i] !== true) {
+              return;
+            }
             // Create a standalone filter.
             var rules = 'em strong abrr img cite blockquote code ul ol li dl dt td br p; a[href]';
             var filter = new CKEDITOR.filter(rules),
@@ -18,11 +23,19 @@
             filter.applyTo(fragment);
             fragment.writeHtml(writer);
             evt.data.dataValue = writer.getHtml();
-        });
+            activeFilter[i] = false;
+          });
 
-          CKEDITOR.instances[i].on('afterCommandExec', function (event) {
-            // console.log(event.data.name);
-            // this.filter.disabled = true;.
+          // Enable filer when button is pressed.
+          CKEDITOR.instances[i].on('beforeCommandExec', function (event) {
+            if (event.data.name === 'pastefromword') {
+              activeFilter[i] = true;
+            }
+          });
+
+          // Remove browser incompatibility notice.
+          CKEDITOR.instances[i].on('instanceReady', function(ev) {
+            ev.editor.lang.clipboard.pasteNotification = "Press %1 to paste.";
           });
         }
       });

--- a/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
+++ b/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
@@ -15,7 +15,7 @@
               return;
             }
             // Create a standalone filter.
-            var rules = 'em strong abrr img cite blockquote code ul ol li dl dt table tr td br p; a[href]';
+            var rules = 'h2 h3 h4 h5 h6 em strong abrr cite blockquote code ul ol li dl dt table tr td br; a[href]; img[src, alt]; p[align]';
             var filter = new CKEDITOR.filter(rules),
             // Parse the HTML string to a pseudo-DOM structure.
             fragment = CKEDITOR.htmlParser.fragment.fromHtml(evt.data.dataValue),

--- a/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
+++ b/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
@@ -1,16 +1,15 @@
-
 /**
  * @file
- * afterPasteFromWord
+ * AfterPasteFromWord.
  */
-        
+
 (function ($) {
   Drupal.behaviors.multisite_wysiwyg_paste_from_word = {
     attach: function () {
       $(function () {
         for (var i in CKEDITOR.instances) {
-          CKEDITOR.instances[i].on('paste', function(evt) {
-            // Create a standalone filter
+          CKEDITOR.instances[i].on('paste', function (evt) {
+            // Create a standalone filter.
             var rules = 'em strong abrr img cite blockquote code ul ol li dl dt td br p; a[href]';
             var filter = new CKEDITOR.filter(rules),
             // Parse the HTML string to a pseudo-DOM structure.
@@ -20,10 +19,10 @@
             fragment.writeHtml(writer);
             evt.data.dataValue = writer.getHtml();
         });
-          
+
           CKEDITOR.instances[i].on('afterCommandExec', function (event) {
-            //console.log(event.data.name);
-            //this.filter.disabled = true;
+            // console.log(event.data.name);
+            // this.filter.disabled = true;.
           });
         }
       });
@@ -31,4 +30,3 @@
 
   }
 })(jQuery);
-

--- a/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
+++ b/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
@@ -15,7 +15,7 @@
               return;
             }
             // Create a standalone filter.
-            var rules = 'em strong abrr img cite blockquote code ul ol li dl dt td br p; a[href]';
+            var rules = 'em strong abrr img cite blockquote code ul ol li dl dt table tr td br p; a[href]';
             var filter = new CKEDITOR.filter(rules),
             // Parse the HTML string to a pseudo-DOM structure.
             fragment = CKEDITOR.htmlParser.fragment.fromHtml(evt.data.dataValue),

--- a/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
+++ b/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
@@ -14,12 +14,33 @@
             if (activeFilter[i] !== true) {
               return;
             }
+
             // Create a standalone filter.
             var rules = 'h2 h3 h4 h5 h6 em strong abrr cite blockquote code ul ol li dl dt table tr td br; a[href]; img[src, alt]; p[align]';
             var filter = new CKEDITOR.filter(rules),
             // Parse the HTML string to a pseudo-DOM structure.
             fragment = CKEDITOR.htmlParser.fragment.fromHtml(evt.data.dataValue),
             writer = new CKEDITOR.htmlParser.basicWriter();
+            // Some needed transformations.
+            filter.addTransformations([
+              [
+                {
+                  element: 'b',
+                  right: function (el, tools) {
+                    tools.transform(el, 'strong');
+                  }
+                }
+              ],
+              [
+                {
+                  element: 'i',
+                  right: function (el, tools) {
+                    tools.transform(el, 'em');
+                  }
+                }
+              ]
+            ]);
+
             filter.applyTo(fragment);
             fragment.writeHtml(writer);
             evt.data.dataValue = writer.getHtml();

--- a/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
+++ b/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
@@ -34,7 +34,7 @@
           });
 
           // Remove browser incompatibility notice.
-          CKEDITOR.instances[i].on('instanceReady', function(ev) {
+          CKEDITOR.instances[i].on('instanceReady', function (ev) {
             ev.editor.lang.clipboard.pasteNotification = "Press %1 to paste.";
           });
         }

--- a/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
+++ b/profiles/common/modules/features/multisite_wysiwyg/ckeditor/plugins/paste_from_word/filter.js
@@ -1,0 +1,34 @@
+
+/**
+ * @file
+ * afterPasteFromWord
+ */
+        
+(function ($) {
+  Drupal.behaviors.multisite_wysiwyg_paste_from_word = {
+    attach: function () {
+      $(function () {
+        for (var i in CKEDITOR.instances) {
+          CKEDITOR.instances[i].on('paste', function(evt) {
+            // Create a standalone filter
+            var rules = 'em strong abrr img cite blockquote code ul ol li dl dt td br p; a[href]';
+            var filter = new CKEDITOR.filter(rules),
+            // Parse the HTML string to a pseudo-DOM structure.
+            fragment = CKEDITOR.htmlParser.fragment.fromHtml(evt.data.dataValue),
+            writer = new CKEDITOR.htmlParser.basicWriter();
+            filter.applyTo(fragment);
+            fragment.writeHtml(writer);
+            evt.data.dataValue = writer.getHtml();
+        });
+          
+          CKEDITOR.instances[i].on('afterCommandExec', function (event) {
+            //console.log(event.data.name);
+            //this.filter.disabled = true;
+          });
+        }
+      });
+    }
+
+  }
+})(jQuery);
+

--- a/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
+++ b/profiles/common/modules/features/multisite_wysiwyg/multisite_wysiwyg.module
@@ -36,6 +36,9 @@ function multisite_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
     if (in_array('Link', $settings['toolbar'][0])) {
       drupal_add_js(drupal_get_path('module', 'multisite_wysiwyg') . '/ckeditor/link_alter.js');
     }
+
+    // TODO: add this only if paste from word plugin is enabled.
+    drupal_add_js(drupal_get_path('module', 'multisite_wysiwyg') . '/ckeditor/plugins/paste_from_word/filter.js');
   }
 }
 


### PR DESCRIPTION
## NEPT-2745

### Description

Implements a filer activated with paste from word, which filters at next paste.

### Change log

- Added: js file with drupal behaviour

### Commands

drush cc css-js

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
