### PR TITLE
NEPT-2684: Fix undefined index: path in multisite_drupal_toolbox_linkit_scan_url()

### DIFF
--- a/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/multisite_drupal_toolbox.module
@@ -1256,7 +1256,6 @@ function form_security_settings($form, &$form_state) {
  *     will become "http://example.org/settings".
  */
 function multisite_drupal_toolbox_linkit_scan_url($url, $field) {
-
   global $base_url;
   // Note this function has been heavily modified.
   // To see original see linkit.module.
@@ -1274,7 +1273,11 @@ function multisite_drupal_toolbox_linkit_scan_url($url, $field) {
     form_set_error($field, t('Please insert a complete url. ex: !url', array('!url' => 'http://www.myurl.com')));
     return FALSE;
   }
-  $parts['path'] = $parts_url['path'];
+
+  if (!empty($parts_url['path'])) {
+    $parts['path'] = $parts_url['path'];
+  }
+
   if (!isset($parts['scheme'])) {
     // Not an absolute URL.
     form_set_error($field, t('Please add the protocol to the url, http or https, ex: !url', array('!url' => 'http://www.myurl.com')));


### PR DESCRIPTION
## NEPT-2684

### Description

Fix undefined index: path in multisite_drupal_toolbox_linkit_scan_url().

### Change log

- Changed: multisite_drupal_toolbox_linkit_scan_url()

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
