### PR TITLE
NEPT-2730: Remove unecessary translator of type 'DGT Connector'

### DIFF
--- a/profiles/common/modules/features/nexteuropa_dgt_connector/README.md
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/README.md
@@ -119,6 +119,9 @@ which points here:
 
 and edits 'DGT Connector'.
 
+Only UUID 1 can delete the translator, should you need to perform this
+operation on playground or production, please send a request to CEM.
+
 ### TRANSLATOR SETTINGS
 - *Auto accept finished translations*: Check this if the site owner wants to
 review a translation before publishing it.

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.module
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.module
@@ -31,7 +31,7 @@ function tmgmt_poetry_entity_info_alter(&$entity_info) {
  */
 function _tmgmt_poetry_translator_access($op, $translator, $account) {
   if (!empty($translator) && $translator->plugin == 'poetry') {
-    if ($op == 'delete'  && $translator->name != 'tmgmt_poetry_test_translator') {
+    if ($op == 'delete'  && $translator->name == 'poetry') {
       return FALSE;
     }
     else {

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.module
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.module
@@ -30,8 +30,10 @@ function tmgmt_poetry_entity_info_alter(&$entity_info) {
  *   Boolean
  */
 function _tmgmt_poetry_translator_access($op, $translator, $account) {
+  global $user;
+
   if (!empty($translator) && $translator->plugin == 'poetry') {
-    if ($op == 'delete'  && $translator->name == 'poetry') {
+    if ($op == 'delete' && $user->uid != 1) {
       return FALSE;
     }
     else {
@@ -41,7 +43,6 @@ function _tmgmt_poetry_translator_access($op, $translator, $account) {
   else {
     return tmgmt_translator_access($op, $translator, $account);
   }
-
 }
 
 /**

--- a/tests/features/field.multilingual.feature
+++ b/tests/features/field.multilingual.feature
@@ -1,4 +1,4 @@
-@javascript @maximizedwindow @api
+@javascript @api
 Feature: Field Multilingual features
   In order to easily understand the content of the European Commission
   As a citizen of the European Union

--- a/tests/features/multilingual_admin.feature
+++ b/tests/features/multilingual_admin.feature
@@ -34,7 +34,7 @@ Feature: Content translation
     And I should not see the text "Deutsch Body not for English version."
     But I should see the text "English title"
 
-  @javascript @maximizedwindow
+  @javascript
   Scenario: Make sure that I can add "title_field" fields to a view when the Estonian language is enabled.
     Given the following languages are available:
       | languages |

--- a/tests/features/page_layout.feature
+++ b/tests/features/page_layout.feature
@@ -48,7 +48,7 @@ Feature: Page Layout
       | /          | Welcome to European Commission |
       | user       | Log in                         |
 
-  @javascript @maximizedwindow @ec_resp_theme
+  @javascript @ec_resp_theme
   Scenario: Logged user can see the content in the column right and left
     Given I am logged in as a user with the 'administrator' role
     When I visit "admin/structure/types/add"


### PR DESCRIPTION
## NEPT-2730

### Description

Permit only user 1 to delete translators

### Change log

- Changed: function _tmgmt_poetry_translator_access().

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
