### PR TITLE
NEPT-2690: Patch for PHP 7.3 compatibility.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -813,6 +813,8 @@ projects[video][patch][] = patches/phpvideotoolkit-2629.patch
 projects[video][patch][] = https://www.drupal.org/files/issues/2019-08-06/video-php7.2-3039351-3-7.x.patch
 ;MULTISITE-883 security
 projects[video][patch][] = patches/video-security-883.patch
+;NEPT-2690 PHP7.3 compatibility
+projects[video][patch][] = https://www.drupal.org/files/issues/2019-08-20/continue_in_switch-3042169-2.patch
 
 projects[views][subdir] = "contrib"
 projects[views][version] = 3.23


### PR DESCRIPTION
## NEPT-2690

### Description

Patch for PHP 7.3 compatibility.

### Change log

- Added: Patch for PHP 7.3 compatibility

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
