### PR TITLE
NEPT-2692: PHP 7.3 compatibility.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_fields/nexteuropa_formatters_fields.module
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_fields/nexteuropa_formatters_fields.module
@@ -316,7 +316,7 @@ function nexteuropa_formatters_fields_field_formatter_view($entity_type, $entity
           case 'entityreference':
             // If the access is denied to the term, we do not display it.
             if (empty($item['access'])) {
-              continue;
+              continue 2;
             }
             // Calling EntityReferenceHandler::getLabel() would make a repeated,
             // wasteful call to entity_access().
@@ -347,7 +347,7 @@ function nexteuropa_formatters_fields_field_formatter_view($entity_type, $entity
           case 'entityreference':
             // If the access is denied to the term, we do not display it.
             if (empty($item['access'])) {
-              continue;
+              continue 2;
             }
             // Calling EntityReferenceHandler::getLabel() would make a repeated,
             // wasteful call to entity_access().


### PR DESCRIPTION
## NEPT-2692
### Description
PHP 7.3 compatibility fix in nexteuropa_formatters

### Change log

- Changed: continue keyword in switch.

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
