### PR TITLE
NEPT-2110: Responsive menu should not be always open.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1181,7 +1181,7 @@ projects[atomium][version] = 2.12
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
-projects[ec_europa][download][tag] = 0.0.14
+projects[ec_europa][download][tag] = 0.0.14.1
 projects[ec_europa][patch][] = patches/nept-2585-remove-site-switcher.patch
 
 ; ==============


### PR DESCRIPTION
## NEPT-2110

### Description

Responsive menu should not always be expanded.

### Change log
- Fixed: Javascript call that collapses the menu.

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
