### PR TITLE
NEPT-2693: Fix PHP 7.3 compatibility issues

### DIFF
--- a/profiles/common/modules/custom/multisite_drupal_toolbox/templates/form--filter-security-settings.tpl.php
+++ b/profiles/common/modules/custom/multisite_drupal_toolbox/templates/form--filter-security-settings.tpl.php
@@ -1,3 +1,10 @@
+<?php
+
+/**
+ * @file
+ * Template to foce using hook_multisite_drupal_toolbox_filter_options_alter.
+ */
+?>
 <p>For security matters, this form has been removed.</p>
 
 <p>If you still want to configure the allowed tags, you need to do it via code.</p>


### PR DESCRIPTION
## NEPT-2693
### Description
Fix PHP 7.3 compatibility issues

### Change log

- Fixed: PHP 7.3 warning resolved

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
