### PR TITLE
NEPT-2691: Upgrade to latest version of mpdf which supports 7.4.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1088,7 +1088,7 @@ libraries[modernizr][destination] = "../common/libraries"
 libraries[mpdf][download][type]= "file"
 libraries[mpdf][download][request_type]= "get"
 libraries[mpdf][download][file_type] = "zip"
-libraries[mpdf][download][url] = https://github.com/mpdf/mpdf/archive/v8.0.2.zip
+libraries[mpdf][download][url] = https://github.com/mpdf/mpdf/archive/v8.0.4.zip
 libraries[mpdf][destination] = "libraries"
 
 ; Leaflet


### PR DESCRIPTION
## NEPT-2691

### Description

Upgrade to latest version of mpdf which supports 7.4.

### Change log

- Changed: mpdf version


### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
