### PR TITLE
NEPT-2489: Upgrade to ec_europa 0.0.15

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_formatters/templates/blockquote.tpl.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/templates/blockquote.tpl.php
@@ -10,5 +10,5 @@
 ?>
 
 <blockquote class="blockquote"<?php print $attributes; ?>>
-  <p><?php print render($markup);?></p>
+  <p><?php print render($markup); ?></p>
 </blockquote>

--- a/profiles/common/modules/custom/nexteuropa_lastupdate/theme/nexteuropa-last-update-block.tpl.php
+++ b/profiles/common/modules/custom/nexteuropa_lastupdate/theme/nexteuropa-last-update-block.tpl.php
@@ -13,7 +13,7 @@
  * @see template_process()
  */
 ?>
-<?php if (!empty($label) && !empty($date)) : ?>
+<?php if (!empty($label) && !empty($date)): ?>
   <div class="last-update">
     <?php print $label; ?> : <?php print $date; ?>
   </div>

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1159,8 +1159,7 @@ projects[atomium][version] = 2.12
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
-projects[ec_europa][download][tag] = 0.0.15
-
+projects[ec_europa][download][tag] = 0.0.16
 ; ==============
 ; Custom modules
 ; ==============


### PR DESCRIPTION
## NEPT-2489

### Description

Upgrade to ec_europa 0.0.15

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

[Insert commands here]

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
