### PR TITLE
NEPT-2749: Fix Unknown column p.is_generated

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -576,7 +576,8 @@ projects[om_maximenu][patch][1824704] = https://www.drupal.org/files/issues/fix_
 
 projects[password_policy][subdir] = "contrib"
 projects[password_policy][version] = "2.0-alpha8"
-; NEPT-2749: Column not found: 1054 Unknown column 'p.is_generated'
+;NEPT-2749: password_policy_user_load() assumes field is_generated exists
+;https://www.drupal.org/node/2978953
 projects[password_policy][patch][] = https://www.drupal.org/files/issues/2019-11-22/password_policy-check_existence_of_is_generated-2978953-7.patch
 
 projects[pathauto][subdir] = "contrib"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -576,6 +576,8 @@ projects[om_maximenu][patch][1824704] = https://www.drupal.org/files/issues/fix_
 
 projects[password_policy][subdir] = "contrib"
 projects[password_policy][version] = "2.0-alpha8"
+; NEPT-2749: Column not found: 1054 Unknown column 'p.is_generated'
+projects[password_policy][patch][] = https://www.drupal.org/files/issues/2019-11-22/password_policy-check_existence_of_is_generated-2978953-7.patch
 
 projects[pathauto][subdir] = "contrib"
 projects[pathauto][version] = "1.3"


### PR DESCRIPTION
## NEPT-2749

### Description

Fix Unknown column p.is_generated in password policy upgrade.

### Change log

- Added: patch password_policy-check_existence_of_is_generated-2978953-7.patch

### Checklist

- [x] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
