### PR TITLE
NEPT-2768: Upgrade Drupal core to latest version.

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = "core"
-projects[drupal][version] = "7.67"
+projects[drupal][version] = "7.69"
 
 ; AJAX callbacks not properly working with the language url suffix.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-4268
@@ -89,10 +89,6 @@ projects[drupal][patch][] = https://www.drupal.org/files/issues/2018-09-28/filte
 ; https://www.drupal.org/project/drupal/issues/2083635
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2438
 projects[drupal][patch][] = https://www.drupal.org/files/locale.module-array_unshift-warning-fix.patch
-; HTTP status 200 returned for ”Additional uncaught exception thrown while handling exception”
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2429
-; https://www.drupal.org/project/drupal/issues/2666908
-projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-500_exception_on_exception-12221055-6.patch
 ; Hide username in RSS feed if content type is set to hide author.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2201
 ; https://www.drupal.org/project/drupal/issues/421586


### PR DESCRIPTION
## NEPT-2768

### Description

Upgrade Drupal core to latest version.

### Change log

- Changed: Upgrade drupal to 7.69

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
