### PR TITLE
NEPT-2768: Hotfix 7.69 in release 2.5.143

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -97,3 +97,6 @@ projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-500_excep
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2201
 ; https://www.drupal.org/project/drupal/issues/421586
 projects[drupal][patch][] = https://www.drupal.org/files/issues/2019-08-19/node-post-setting-with-test-421586-31.patch
+
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2768
+projects[drupal][patch][] = https://git.drupalcode.org/project/drupal/commit/75689e47e66de30b11ca26d8018c678c05a028a0.diff


### PR DESCRIPTION
## NEPT-2768
### Description

Hotfix 7.69 in release 2.5.143

### Change log
- Security: Security: SA-CORE-2019-012

### Commands

[Insert commands here]

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
