### PR TITLE
NEPT-2761: Upgrade migrate to 2.11

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -532,15 +532,8 @@ projects[message][patch][2872964] = https://www.drupal.org/files/issues/2872964-
 projects[metatag][subdir] = "contrib"
 projects[metatag][version] = "1.22"
 
-; A recent version of the Migrate module is pinned that contains a fix for
-; https://www.drupal.org/node/2504517
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEXTEUROPA-4710
-; Todo: revert back to the stable version when Migrate 7.x-2.9 is released.
-projects[migrate][download][branch] = 7.x-2.x
-projects[migrate][download][revision] = bdb5a86116295df7c35fbb39bdd4397f743498c1
-projects[migrate][download][type] = git
-projects[migrate][subdir] = contrib
-projects[migrate][patch][2909252] = https://www.drupal.org/files/issues/clone_is_reserved_keyword-2909252-1.patch
+projects[migrate][subdir] = "contrib"
+projects[migrate][version] = "2.11"
 
 projects[mimemail][subdir] = "contrib"
 projects[mimemail][version] = "1.1"


### PR DESCRIPTION
## NEPT-2761

### Description

Upgrade migrate to 2.11

### Change log

- Changed: migrate version to 2.11

### Checklist

- [x] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
