### PR TITLE
NEPT-2762: Upgrade Leaflet.draw to v0.4.14 and uglify-js to 2.8.29.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1087,7 +1087,7 @@ libraries[jquery][directory_name] = "jquery"
 libraries[Leaflet.draw][destination] = "libraries"
 libraries[Leaflet.draw][download][type] = "git"
 libraries[Leaflet.draw][download][url] = https://github.com/Leaflet/Leaflet.draw.git
-libraries[Leaflet.draw][download][tag] = "v0.3.0"
+libraries[Leaflet.draw][download][tag] = "v0.4.14"
 
 ; modernizr 2.8.3
 libraries[modernizr][download][url] = https://github.com/Modernizr/Modernizr/archive/v2.8.3.zip


### PR DESCRIPTION
## NEPT-2762

### Description

Upgrade Leaflet.draw to v0.4.14 and uglify-js to 2.8.29.

### Change log

- Changed: Leaflet.draw version to v0.4.14

### Commands

[Insert commands here]

### Checklist

- [x] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
