### PR TITLE
NEPT-2781: Make burger and mega menu compatible.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1180,7 +1180,7 @@ projects[atomium][version] = 2.12
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
-projects[ec_europa][download][tag] = 0.0.14.1
+projects[ec_europa][download][branch] = nept-2781
 projects[ec_europa][patch][] = patches/nept-2585-remove-site-switcher.patch
 projects[ec_europa][patch][] = patches/nept-2668-language-switcher.patch
 


### PR DESCRIPTION
## NEPT-2781

### Description

Make burger and mega menu compatible.

### Change log

- Changed: Ec_europa version

### Commands

drush cc all

### Checklist

- [x] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
