### PR TITLE
NEPT-2115: Content translation page wrongly shows button

### DIFF
--- a/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.module
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.module
@@ -876,7 +876,11 @@ function tmgmt_poetry_form_tmgmt_entity_ui_translate_form_alter(&$form, &$form_s
         if (_tmgmt_poetry_check_jobs_translatability($existing_jobs)) {
           // If yes, inject form elements which are allowing to sent an update
           // translation request.
-          _tmgmt_poetry_inject_request_update_elements($form);
+          $translations_possible = _tmgmt_poetry_translations_possible($form_state);
+
+          if (in_array('regular', $translations_possible)) {
+            _tmgmt_poetry_inject_request_update_elements($form);
+          }
         }
         else {
           // If no, disable action elements and provide the message box.


### PR DESCRIPTION
## NEPT-2115

### Description

Content translation page wrongly shows button "Request translation update".

### Change log

- Added: check for _tmgmt_poetry_translations_possible


### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
