### PR TITLE
NEPT-2770: Fix globan and CCK position

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_cookie_consent_kit/css/nexteuropa_cookie_consent.css
+++ b/profiles/common/modules/custom/nexteuropa_cookie_consent_kit/css/nexteuropa_cookie_consent.css
@@ -1,0 +1,14 @@
+/*
+* Styling to prevent CCK and Globan from switching places
+* !important needed to override inline style
+*/
+
+#cookie-consent-banner {
+  margin-top: 28px !important;
+}
+#globan#globan {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+}

--- a/profiles/common/modules/custom/nexteuropa_cookie_consent_kit/nexteuropa_cookie_consent_kit.info
+++ b/profiles/common/modules/custom/nexteuropa_cookie_consent_kit/nexteuropa_cookie_consent_kit.info
@@ -5,3 +5,4 @@ configure = admin/config/system/nexteuropa-cookie-consent-kit
 package = NextEuropa
 
 dependencies[] = path
+stylesheets[all][] = css/nexteuropa_cookie_consent.css


### PR DESCRIPTION
## NEPT-2770

### Description

Updated fix for the Globan and CCK position problems

### Change log

- Added: nexteuropa_cookie_consent.css


### Checklist

- [x] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
