### PR TITLE
NEPT-2709: Restrict effect of user_administrator filtering.

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.module
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.module
@@ -538,19 +538,32 @@ function cce_basic_config_query_alter(QueryAlterableInterface $query) {
     return;
   }
 
+  $path = current_path();
+
+  if ($path !== 'admin/people') {
+    return;
+  }
+
   $tables = &$query->getTables();
 
-  if (
-    isset($tables['u']) &&
-    (
-      (isset($tables['u']['table']) && $tables['u']['table'] == 'users') ||
-      (isset($tables['u']['base']) && $tables['u']['base']['table'] && $tables['u']['base']['table'] == 'users')
-    )
-  ) {
+  if (isset($tables['u']) && isset($tables['u']['table']) && $tables['u']['table'] == 'users') {
     $account = user_load_by_name('user_administrator');
 
     if (!empty($account)) {
       $query->condition('u.uid', $account->uid, '<>');
+    }
+  }
+}
+
+/**
+ * Implements hook_views_query_alter().
+ */
+function cce_basic_config_views_query_alter(&$view, &$query) {
+  if ($view->base_table == 'users') {
+    $account = user_load_by_name('user_administrator');
+
+    if (!empty($account)) {
+      $query->add_where('users', 'users.uid', $account->uid, '<>');
     }
   }
 }

--- a/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.strongarm.inc
+++ b/profiles/common/modules/features/nexteuropa_core/nexteuropa_core.strongarm.inc
@@ -50,7 +50,7 @@ function nexteuropa_core_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'chosen_minimum_width';
-  $strongarm->value = '250';
+  $strongarm->value = '200';
   $export['chosen_minimum_width'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/tests/features/dblog.feature
+++ b/tests/features/dblog.feature
@@ -9,6 +9,7 @@ Scenario: Filter log messages
   Given I am logged in as a user with the 'administrator' role
   When I go to "admin/reports/dblog"
   Then I click on element "#dblog-filter-form a.fieldset-title"
+  And I click on element "#edit-severity"
   And I select "info" from "Severity"
   And I press "Filter"
   Then I should see "Session opened for" in the "user" row

--- a/tests/features/dblog.feature
+++ b/tests/features/dblog.feature
@@ -8,6 +8,7 @@ Feature: Administrators can check information on Recent log messages page
 Scenario: Filter log messages
   Given I am logged in as a user with the 'administrator' role
   When I go to "admin/reports/dblog"
+  Then I click on element "#dblog-filter-form a.fieldset-title"
   And I select "info" from "Severity"
   And I press "Filter"
   Then I should see "Session opened for" in the "user" row

--- a/tests/features/dblog.feature
+++ b/tests/features/dblog.feature
@@ -10,5 +10,5 @@ Scenario: Filter log messages
   When I go to "admin/reports/dblog"
   And I select "info" from "Severity"
   And I press "Filter"
-  Then I should see "dblog module installed." in the "system" row
+  Then I should see "Session opened for" in the "user" row
   

--- a/tests/features/dblog.feature
+++ b/tests/features/dblog.feature
@@ -4,7 +4,7 @@ Feature: Administrators can check information on Recent log messages page
   As an administrator
   I can access to the Recent log messages page
 
-@api
+@api  @javascript
 Scenario: Filter log messages
   Given I am logged in as a user with the 'administrator' role
   When I go to "admin/reports/dblog"

--- a/tests/features/dblog.feature
+++ b/tests/features/dblog.feature
@@ -9,8 +9,7 @@ Scenario: Filter log messages
   Given I am logged in as a user with the 'administrator' role
   When I go to "admin/reports/dblog"
   Then I click on element "#dblog-filter-form a.fieldset-title"
-  And I click on element "#edit-severity"
-  And I select "info" from "Severity"
+  And I fill in "Severity" with "info"
   And I press "Filter"
   Then I should see "Session opened for" in the "user" row
   

--- a/tests/features/dblog.feature
+++ b/tests/features/dblog.feature
@@ -1,0 +1,14 @@
+@api @ec_resp
+Feature: Administrators can check information on Recent log messages page
+  In order to monitors the website
+  As an administrator
+  I can access to the Recent log messages page
+
+@api
+Scenario: Filter log messages
+  Given I am logged in as a user with the 'administrator' role
+  When I go to "admin/reports/dblog"
+  And I select "info" from "Severity"
+  And I press "Filter"
+  Then I should see "dblog module installed." in the "system" row
+  

--- a/tests/features/dblog.feature
+++ b/tests/features/dblog.feature
@@ -8,8 +8,9 @@ Feature: Administrators can check information on Recent log messages page
 Scenario: Filter log messages
   Given I am logged in as a user with the 'administrator' role
   When I go to "admin/reports/dblog"
-  Then I click on element "#dblog-filter-form a.fieldset-title"
-  And I fill in "Severity" with "info"
+  And I click on element "#dblog-filter-form a.fieldset-title"
+  And I click on element "#edit_severity_chosen ul.chosen-choices"
+  And I click on element "#edit_severity_chosen li.active-result[data-option-array-index='5']"
   And I press "Filter"
   Then I should see "Session opened for" in the "user" row
   


### PR DESCRIPTION
## NEPT-2709

### Description

Restrict effect of user_administrator filtering.

### Change log

- Added: hook_views_query_alter to cce_basic_config
- Changed: hook_query_alter in cce_basic_config
- Fixed: Filtering of admin/reports/dblog

### Commands

drush cc all

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
