### PR TITLE
NEPT-2791: Fix 'json_settings' property_type for usage Entity API.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_json_field/nexteuropa_json_field.module
+++ b/profiles/common/modules/custom/nexteuropa_json_field/nexteuropa_json_field.module
@@ -19,6 +19,7 @@ function nexteuropa_json_field_field_info() {
       ),
       'default_widget' => 'text_textarea',
       'default_formatter' => 'json_settings_default',
+      'property_type' => 'text',
     ),
   );
 }


### PR DESCRIPTION
## NEPT-2791

### Description

I would like use Entity API `entity_metadata_wrapper()` function in my hook_node_preprocess but my field of type "json_settings" is not listed because the "property_type" is missing.

See : https://drupal.stackexchange.com/questions/162396/cant-access-custom-field-through-entity-metadata-wrapper

### Change log

- Added:
"property_type" for the custom field type "json_settings".