### PR TITLE
NEPT-2793: Upgrade Honeypot

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -385,7 +385,7 @@ projects[geophp][download][type] = git
 projects[geophp][subdir] = "contrib"
 
 projects[honeypot][subdir] = "contrib"
-projects[honeypot][version] = "1.25"
+projects[honeypot][version] = "1.26"
 
 projects[i18n][subdir] = "contrib"
 projects[i18n][version] = "1.26"


### PR DESCRIPTION
## NEPT-2793

### Description

Upgrade Honeypot to 7.x-1.26

### Change log

- Changed: upgraded Honeypot 


### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
