### PR TITLE
NEPT-2790: Apply standards to files with codingStandardsIgnoreFile

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_banner_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_banner_rows.php
@@ -7,8 +7,6 @@
 
 /**
  * Class to define a row plugin handler.
- *
- * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_banner_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_banner_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_banner_rows.php
@@ -7,6 +7,8 @@
 
 /**
  * Class to define a row plugin handler.
+ *
+ * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_banner_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_banner_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_banner_rows.php
@@ -8,7 +8,7 @@
 /**
  * Class to define a row plugin handler.
  *
- * @codingStandardsIgnoreFile
+ * @codingStandardsIgnoreFile.
  */
 class nexteuropa_formatters_views_banner_rows extends views_plugin_row {
 
@@ -60,16 +60,18 @@ class nexteuropa_formatters_views_banner_rows extends views_plugin_row {
   }
 
   /**
-   * Render a row object. This usually passes through to a theme template
-   * of some form, but not always.
+   * Render a row object.
    *
-   * @param stdClass $row
+   * This usually passes through to a theme template of some form,
+   * but not always.
+   *
+   * @param object $row
    *   A single row of the query result, so an element of $view->result.
    *
    * @return string
    *   The rendered output of a single row, used by the style plugin.
    */
-  function render($row) {
+  public function render($row) {
     static $row_index;
     if (!isset($row_index)) {
       $row_index = 0;
@@ -90,15 +92,16 @@ class nexteuropa_formatters_views_banner_rows extends views_plugin_row {
   /**
    * Retrieves a views field value from the style plugin.
    *
-   * @param $index
-   *   The index count of the row as expected by views_plugin_style::get_field().
-   * @param $field_id
+   * @param int $index
+   *   The index count of the row expected by views_plugin_style::get_field().
+   * @param string $field_id
    *   The ID assigned to the required field in the display.
    */
-  function get_field($index, $field_id) {
+  public function get_field($index, $field_id) {
     if (empty($this->view->style_plugin) || !is_object($this->view->style_plugin) || empty($field_id)) {
       return '';
     }
     return $this->view->style_plugin->get_field($index, $field_id);
   }
+
 }

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_banner_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_banner_rows.php
@@ -8,7 +8,7 @@
 /**
  * Class to define a row plugin handler.
  *
- * @codingStandardsIgnoreFile.
+ * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_banner_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_blockquote_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_blockquote_rows.php
@@ -8,7 +8,7 @@
 /**
  * Class to define a row plugin handler.
  *
- * @codingStandardsIgnoreFile
+ * @codingStandardsIgnoreFile.
  */
 class nexteuropa_formatters_views_blockquote_rows extends views_plugin_row {
 
@@ -50,16 +50,18 @@ class nexteuropa_formatters_views_blockquote_rows extends views_plugin_row {
   }
 
   /**
-   * Render a row object. This usually passes through to a theme template
-   * of some form, but not always.
+   * Render a row object.
    *
-   * @param stdClass $row
+   * This usually passes through to a theme template of some form,
+   * but not always.
+   *
+   * @param object $row
    *   A single row of the query result, so an element of $view->result.
    *
    * @return string
    *   The rendered output of a single row, used by the style plugin.
    */
-  function render($row) {
+  public function render($row) {
     static $row_index;
     if (!isset($row_index)) {
       $row_index = 0;
@@ -79,15 +81,16 @@ class nexteuropa_formatters_views_blockquote_rows extends views_plugin_row {
   /**
    * Retrieves a views field value from the style plugin.
    *
-   * @param $index
-   *   The index count of the row as expected by views_plugin_style::get_field().
-   * @param $field_id
+   * @param int $index
+   *   The index count of the row expected by views_plugin_style::get_field().
+   * @param string $field_id
    *   The ID assigned to the required field in the display.
    */
-  function get_field($index, $field_id) {
+  public function get_field($index, $field_id) {
     if (empty($this->view->style_plugin) || !is_object($this->view->style_plugin) || empty($field_id)) {
       return '';
     }
     return $this->view->style_plugin->get_field($index, $field_id);
   }
+
 }

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_blockquote_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_blockquote_rows.php
@@ -7,8 +7,6 @@
 
 /**
  * Class to define a row plugin handler.
- *
- * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_blockquote_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_blockquote_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_blockquote_rows.php
@@ -7,6 +7,8 @@
 
 /**
  * Class to define a row plugin handler.
+ *
+ * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_blockquote_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_blockquote_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_blockquote_rows.php
@@ -8,7 +8,7 @@
 /**
  * Class to define a row plugin handler.
  *
- * @codingStandardsIgnoreFile.
+ * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_blockquote_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_card_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_card_rows.php
@@ -7,6 +7,8 @@
 
 /**
  * Class to define a row plugin handler.
+ *
+ * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_card_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_card_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_card_rows.php
@@ -8,7 +8,7 @@
 /**
  * Class to define a row plugin handler.
  *
- * @codingStandardsIgnoreFile.
+ * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_card_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_card_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_card_rows.php
@@ -7,8 +7,6 @@
 
 /**
  * Class to define a row plugin handler.
- *
- * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_card_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_card_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_card_rows.php
@@ -8,7 +8,7 @@
 /**
  * Class to define a row plugin handler.
  *
- * @codingStandardsIgnoreFile
+ * @codingStandardsIgnoreFile.
  */
 class nexteuropa_formatters_views_card_rows extends views_plugin_row {
 
@@ -44,7 +44,7 @@ class nexteuropa_formatters_views_card_rows extends views_plugin_row {
       '#type' => 'select',
       '#required' => TRUE,
       '#title' => t('URL'),
-      '#description' => t('Target URL of the card, needs to be a url or text field. '),
+      '#description' => t('Target URL of the card, needs to be a url or text field.'),
       '#options' => $fields,
       '#default_value' => $this->options['url'],
     );
@@ -69,16 +69,18 @@ class nexteuropa_formatters_views_card_rows extends views_plugin_row {
   }
 
   /**
-   * Render a row object. This usually passes through to a theme template
-   * of some form, but not always.
+   * Render a row object.
    *
-   * @param stdClass $row
+   * This usually passes through to a theme template of some form,
+   * but not always.
+   *
+   * @param object $row
    *   A single row of the query result, so an element of $view->result.
    *
    * @return string
    *   The rendered output of a single row, used by the style plugin.
    */
-  function render($row) {
+  public function render($row) {
     static $row_index;
     if (!isset($row_index)) {
       $row_index = 0;
@@ -100,15 +102,16 @@ class nexteuropa_formatters_views_card_rows extends views_plugin_row {
   /**
    * Retrieves a views field value from the style plugin.
    *
-   * @param $index
-   *   The index count of the row as expected by views_plugin_style::get_field().
-   * @param $field_id
+   * @param int $index
+   *   The index count of the row expected by views_plugin_style::get_field().
+   * @param string $field_id
    *   The ID assigned to the required field in the display.
    */
-  function get_field($index, $field_id) {
+  public function get_field($index, $field_id) {
     if (empty($this->view->style_plugin) || !is_object($this->view->style_plugin) || empty($field_id)) {
       return '';
     }
     return $this->view->style_plugin->get_field($index, $field_id);
   }
+
 }

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_expandable_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_expandable_rows.php
@@ -7,8 +7,6 @@
 
 /**
  * Class to define a row plugin handler.
- *
- * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_expandable_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_expandable_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_expandable_rows.php
@@ -7,6 +7,8 @@
 
 /**
  * Class to define a row plugin handler.
+ *
+ * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_expandable_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_expandable_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_expandable_rows.php
@@ -8,7 +8,7 @@
 /**
  * Class to define a row plugin handler.
  *
- * @codingStandardsIgnoreFile.
+ * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_expandable_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_expandable_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_expandable_rows.php
@@ -8,7 +8,7 @@
 /**
  * Class to define a row plugin handler.
  *
- * @codingStandardsIgnoreFile
+ * @codingStandardsIgnoreFile.
  */
 class nexteuropa_formatters_views_expandable_rows extends views_plugin_row {
 
@@ -70,23 +70,25 @@ class nexteuropa_formatters_views_expandable_rows extends views_plugin_row {
   }
 
   /**
-   * Render a row object. This usually passes through to a theme template
-   * of some form, but not always.
+   * Render a row object.
    *
-   * @param stdClass $row
+   * This usually passes through to a theme template of some form,
+   * but not always.
+   *
+   * @param object $row
    *   A single row of the query result, so an element of $view->result.
    *
    * @return string
    *   The rendered output of a single row, used by the style plugin.
    */
-  function render($row) {
+  public function render($row) {
     static $row_index;
 
     $row_index = isset($row_index) ? $row_index + 1 : 0;
 
     // In order to have automatic theme hooks suggestions.
     $theme = array(
-      sprintf('%s__%s__%s__%s', 'expandable', $this->view->name, $this->view->current_display, 'row_' . $row_index)
+      sprintf('%s__%s__%s__%s', 'expandable', $this->view->name, $this->view->current_display, 'row_' . $row_index),
     );
 
     return theme($theme,
@@ -101,15 +103,16 @@ class nexteuropa_formatters_views_expandable_rows extends views_plugin_row {
   /**
    * Retrieves a views field value from the style plugin.
    *
-   * @param $index
-   *   The index count of the row as expected by views_plugin_style::get_field().
-   * @param $field_id
+   * @param int $index
+   *   The index count of the row expected by views_plugin_style::get_field().
+   * @param string $field_id
    *   The ID assigned to the required field in the display.
    */
-  function get_field($index, $field_id) {
+  public function get_field($index, $field_id) {
     if (empty($this->view->style_plugin) || !is_object($this->view->style_plugin) || empty($field_id)) {
       return '';
     }
     return $this->view->style_plugin->get_field($index, $field_id);
   }
+
 }

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_timelines_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_timelines_rows.php
@@ -7,6 +7,8 @@
 
 /**
  * Class to define a row plugin handler.
+ *
+ * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_timelines_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_timelines_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_timelines_rows.php
@@ -8,7 +8,7 @@
 /**
  * Class to define a row plugin handler.
  *
- * @codingStandardsIgnoreFile.
+ * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_timelines_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_timelines_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_timelines_rows.php
@@ -7,8 +7,6 @@
 
 /**
  * Class to define a row plugin handler.
- *
- * @codingStandardsIgnoreFile
  */
 class nexteuropa_formatters_views_timelines_rows extends views_plugin_row {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_timelines_rows.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/nexteuropa_core_views_timelines_rows.php
@@ -8,7 +8,7 @@
 /**
  * Class to define a row plugin handler.
  *
- * @codingStandardsIgnoreFile
+ * @codingStandardsIgnoreFile.
  */
 class nexteuropa_formatters_views_timelines_rows extends views_plugin_row {
 
@@ -69,16 +69,18 @@ class nexteuropa_formatters_views_timelines_rows extends views_plugin_row {
   }
 
   /**
-   * Render a row object. This usually passes through to a theme template
-   * of some form, but not always.
+   * Render a row object.
    *
-   * @param stdClass $row
+   * This usually passes through to a theme template of some form,
+   * but not always.
+   *
+   * @param object $row
    *   A single row of the query result, so an element of $view->result.
    *
    * @return string
    *   The rendered output of a single row, used by the style plugin.
    */
-  function render($row) {
+  public function render($row) {
     static $row_index;
     if (!isset($row_index)) {
       $row_index = 0;
@@ -100,15 +102,16 @@ class nexteuropa_formatters_views_timelines_rows extends views_plugin_row {
   /**
    * Retrieves a views field value from the style plugin.
    *
-   * @param $index
-   *   The index count of the row as expected by views_plugin_style::get_field().
-   * @param $field_id
+   * @param int $index
+   *   The index count of the row expected by views_plugin_style::get_field().
+   * @param string $field_id
    *   The ID assigned to the required field in the display.
    */
-  function get_field($index, $field_id) {
+  public function get_field($index, $field_id) {
     if (empty($this->view->style_plugin) || !is_object($this->view->style_plugin) || empty($field_id)) {
       return '';
     }
     return $this->view->style_plugin->get_field($index, $field_id);
   }
+
 }

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/style/nexteuropa_link_blocks_style.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/style/nexteuropa_link_blocks_style.php
@@ -7,8 +7,6 @@
 
 /**
  * Views style plugin.
- *
- * @codingStandardsIgnoreFile
  */
 class nexteuropa_link_blocks_style extends views_plugin_style {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/style/nexteuropa_link_blocks_style.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/style/nexteuropa_link_blocks_style.php
@@ -7,6 +7,8 @@
 
 /**
  * Views style plugin.
+ *
+ * @codingStandardsIgnoreFile
  */
 class nexteuropa_link_blocks_style extends views_plugin_style {
 

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/style/nexteuropa_link_blocks_style.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/style/nexteuropa_link_blocks_style.php
@@ -1,28 +1,32 @@
 <?php
+
 /**
  * @file
- * nexteuropa_links_block_style.php.
+ * Nexteuropa_links_block_style.php.
  */
+
 /**
  * Views style plugin.
  *
- * @codingStandardsIgnoreFile
+ * @codingStandardsIgnoreFile.
  */
 class nexteuropa_link_blocks_style extends views_plugin_style {
+
   /**
-   * Set default options
+   * Set default options.
    */
-  function option_definition() {
+  public function option_definition() {
     $options = parent::option_definition();
     $options['type'] = array('default' => 'ul');
     $options['class'] = array('default' => '');
     $options['wrapper_class'] = array('default' => 'other_class');
     return $options;
   }
+
   /**
    * Render the given style.
    */
-  function options_form(&$form, &$form_state) {
+  public function options_form(&$form, &$form_state) {
     parent::options_form($form, $form_state);
     $form['type'] = array(
       '#type' => 'radios',
@@ -45,10 +49,11 @@ class nexteuropa_link_blocks_style extends views_plugin_style {
       '#default_value' => $this->options['class'],
     );
   }
+
   /**
    * {@inheritdoc}
    */
-  function render_grouping_sets($sets, $level = 0) {
+  public function render_grouping_sets($sets, $level = 0) {
     $output = array();
     foreach ($sets as $set) {
       $row = reset($set['rows']);
@@ -86,7 +91,7 @@ class nexteuropa_link_blocks_style extends views_plugin_style {
               '#tag' => 'li',
               '#value' => $set['rows'][$index]->link,
               '#attributes' => array(
-                  'class' => 'ecl-link-block__item',
+                'class' => 'ecl-link-block__item',
               ),
             );
           }
@@ -104,4 +109,5 @@ class nexteuropa_link_blocks_style extends views_plugin_style {
     unset($this->view->row_index);
     return $output;
   }
+
 }

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/style/nexteuropa_link_blocks_style.php
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_views/src/views/plugins/style/nexteuropa_link_blocks_style.php
@@ -8,7 +8,7 @@
 /**
  * Views style plugin.
  *
- * @codingStandardsIgnoreFile.
+ * @codingStandardsIgnoreFile
  */
 class nexteuropa_link_blocks_style extends views_plugin_style {
 

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -20,6 +20,9 @@ projects[administration_language_negotiation][version] = "1.4"
 
 projects[advagg][subdir] = "contrib"
 projects[advagg][version] = "2.33"
+; NEPT-2790: Scan code for @codingStandardsIgnoreFile and fix
+; https://www.drupal.org/project/advagg/issues/3116299
+projects[advagg][patch][] = https://www.drupal.org/files/issues/2020-02-27/php7_compatibility-3116299-2.patch
 
 projects[advanced_help][subdir] = "contrib"
 projects[advanced_help][version] = "1.5"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -771,7 +771,7 @@ projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2019-02-04/check_
 projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2018-04-17/2955245-5.patch
 ; https://www.drupal.org/node/3021843
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2178
-projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2020-02-26/translation_not_taking_into_account_the_source_data_update-3021843-23.patch
+projects[tmgmt][patch][] =  https://www.drupal.org/files/issues/2019-09-17/translation_not_taking_into_account_the_source_data_update-3021843-22.patch
 ; https://www.drupal.org/project/tmgmt/issues/3050356
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2590
 projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2019-04-24/count_error_php_7_2-3050356-2.patch

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -23,6 +23,8 @@ projects[advagg][version] = "2.33"
 ; NEPT-2790: Scan code for @codingStandardsIgnoreFile and fix
 ; https://www.drupal.org/project/advagg/issues/3116299
 projects[advagg][patch][] = https://www.drupal.org/files/issues/2020-02-27/php7_compatibility-3116299-2.patch
+; https://github.com/ec-europa/platform-dev/pull/2869
+projects[advagg][patch][] = https://www.drupal.org/files/issues/2019-06-02/advagg_replace_continue_with_break-3058949-2.patch
 
 projects[advanced_help][subdir] = "contrib"
 projects[advanced_help][version] = "1.5"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -766,7 +766,7 @@ projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2019-02-04/check_
 projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2018-04-17/2955245-5.patch
 ; https://www.drupal.org/node/3021843
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2178
-projects[tmgmt][patch][] =  https://www.drupal.org/files/issues/2019-09-17/translation_not_taking_into_account_the_source_data_update-3021843-22.patch
+projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2020-02-26/translation_not_taking_into_account_the_source_data_update-3021843-23.patch
 ; https://www.drupal.org/project/tmgmt/issues/3050356
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2590
 projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2019-04-24/count_error_php_7_2-3050356-2.patch


### PR DESCRIPTION
## NEPT-2790

### Description

Apply standards to files with codingStandardsIgnoreFile. HTTP error 500 when accepting translations (NEMA-2653).

### Change log

- Added:
   - patch php7_compatibility-3116299-2.patch
   - advagg_replace_continue_with_break-3058949-2.patch
- Changed:
   - comments in accord with phpcs
   - patch translation_not_taking_into_account_the_source_data_update-3021843-23.patch

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
