### PR TITLE
NEPT-2774: Upgrade NE Varnish version to v1.0.9.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1182,4 +1182,4 @@ projects[nexteuropa_varnish][subdir] = "custom"
 projects[nexteuropa_varnish][type] = module
 projects[nexteuropa_varnish][download][type] = git
 projects[nexteuropa_varnish][download][url] = https://github.com/ec-europa/digit-ne-varnish.git
-projects[nexteuropa_varnish][download][tag] = v1.0.8
+projects[nexteuropa_varnish][download][tag] = v1.0.9


### PR DESCRIPTION
## NEPT-2774

### Description

Move fixes from https://github.com/ec-europa/platform-dev/pull/2835 to platform 2.6.

### Change log

- Changed: digit-ne-varnish version to v1.0.9

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
