### PR TITLE
NEPT-2807: Fix filesize() fail.

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -93,3 +93,7 @@ projects[drupal][patch][] = https://www.drupal.org/files/locale.module-array_uns
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2201
 ; https://www.drupal.org/project/drupal/issues/421586
 projects[drupal][patch][] = https://www.drupal.org/files/issues/2019-08-19/node-post-setting-with-test-421586-31.patch
+; filesize() fails for remote files -- called from file_save()
+; https://www.drupal.org/project/drupal/issues/3087532
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2807
+projects[drupal][patch][] = https://www.drupal.org/files/issues/2019-12-09/core-remote_file_save-3087532-3.patch


### PR DESCRIPTION
## NEPT-2807

### Description

Core patch, fix filesize() fail.

### Change log

- Added: core-remote_file_save-3087532-3.patch

### Checklist

- [x] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
