### PR TITLE
NEPT-2683: Mark idea modules as deprecated.

### DIFF
--- a/profiles/common/modules/features/idea/idea_core/idea_core.info
+++ b/profiles/common/modules/features/idea/idea_core/idea_core.info
@@ -1,7 +1,7 @@
 name = idea_core
 description = suggest ideas, vote on and discuss already submitted ideas
 core = 7.x
-package = Multisite Core Features
+package = deprecated
 dependencies[] = apachesolr
 dependencies[] = cce_basic_config
 dependencies[] = survey_core

--- a/profiles/common/modules/features/idea/idea_standard/idea_standard.info
+++ b/profiles/common/modules/features/idea/idea_standard/idea_standard.info
@@ -1,7 +1,7 @@
 name = Idea Standard
 description = Override idea_core
 core = 7.x
-package = Multisite Standard Features
+package = deprecated
 dependencies[] = idea_core
 features[features_api][] = api:2
 features[ctools][] = context:context:3


### PR DESCRIPTION
## NEPT-2683

### Description

Mark idea modules as deprecated.

### Change log

- Changed: package in info files for idea modules.

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
