### PR TITLE
NEPT-2815: Fix function nesting.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1173,7 +1173,7 @@ projects[atomium][version] = 2.30
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
-projects[ec_europa][download][tag] = 0.0.26-alpha
+projects[ec_europa][download][tag] = 0.0.26
 
 ; ==============
 ; Custom modules

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1173,7 +1173,7 @@ projects[atomium][version] = 2.30
 projects[ec_europa][type] = theme
 projects[ec_europa][download][type] = git
 projects[ec_europa][download][url] = https://github.com/ec-europa/ec_europa.git
-projects[ec_europa][download][tag] = 0.0.25
+projects[ec_europa][download][tag] = 0.0.26-alpha
 
 ; ==============
 ; Custom modules


### PR DESCRIPTION
## NEPT-2815

### Description

Fix Error: Maximum function nesting level of '256' reached, aborting! in strpos() (line 2431 of /home/ec2-user/environment/platform-dev/build/includes/common.inc).

### Change log

- Changed: ec_europa version tag

### Checklist

- [x] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
