### PR TITLE
Release 2.5.147

### DIFF
--- a/profiles/common/modules/features/idea/idea_core/idea_core.info
+++ b/profiles/common/modules/features/idea/idea_core/idea_core.info
@@ -1,7 +1,7 @@
 name = idea_core
 description = suggest ideas, vote on and discuss already submitted ideas
 core = 7.x
-package = Multisite Core Features
+package = deprecated
 dependencies[] = apachesolr
 dependencies[] = cce_basic_config
 dependencies[] = survey_core

--- a/profiles/common/modules/features/idea/idea_standard/idea_standard.info
+++ b/profiles/common/modules/features/idea/idea_standard/idea_standard.info
@@ -1,7 +1,7 @@
 name = Idea Standard
 description = Override idea_core
 core = 7.x
-package = Multisite Standard Features
+package = deprecated
 dependencies[] = idea_core
 features[features_api][] = api:2
 features[ctools][] = context:context:3

--- a/profiles/common/modules/features/nexteuropa_editorial/nexteuropa_editorial.install
+++ b/profiles/common/modules/features/nexteuropa_editorial/nexteuropa_editorial.install
@@ -89,7 +89,7 @@ function nexteuropa_editorial_install() {
   multisite_config_service('user')->grantPermission(NEXTEUROPA_EDITORIAL_TEAM_MEMBER_ROLE, $permissions, 'nexteuropa_editorial');
 
   // Set "administrator" permissions.
-  multisite_config_service('user')->grantPermission('administrator', $permissions);
+  multisite_config_service('user')->grantPermission('administrator', $permissions, 'nexteuropa_editorial');
 
   // Rebuilds the node access database.
   node_access_rebuild();

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -671,7 +671,7 @@ projects[registry_autoload][patch][2870868] = https://www.drupal.org/files/issue
 
 projects[rules][subdir] = "contrib"
 projects[rules][version] = "2.11"
-projects[rules][patch][] = https://www.drupal.org/files/issues/file_events-826986-31_0.patch
+projects[rules][patch][] = https://www.drupal.org/files/issues/2020-03-19/file_events-826986-42.patch
 
 projects[scheduler][subdir] = "contrib"
 projects[scheduler][version] = 1.5

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -779,7 +779,7 @@ projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2019-02-04/check_
 projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2018-04-17/2955245-5.patch
 ; https://www.drupal.org/node/3021843
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2178
-projects[tmgmt][patch][] =  https://www.drupal.org/files/issues/2019-09-17/translation_not_taking_into_account_the_source_data_update-3021843-22.patch
+projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2020-02-26/translation_not_taking_into_account_the_source_data_update-3021843-23.patch
 
 projects[token][subdir] = "contrib"
 projects[token][version] = "1.7"


### PR DESCRIPTION
## NEPT-2822

### Description

Release 2.5.147

### Change log

- Changed: https://webgate.ec.europa.eu/fpfis/wikis/display/OPENEU/Release+notes+2.5.147

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
