### PR TITLE
NEPT-2813: Fix wrong function ecas_sync_drupal_user_on_ecas_info call.

### DIFF
--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -375,11 +375,11 @@ function ecas_sync_profile_core(&$user, array $user_info, array &$edit = array()
  *   info_ecas_update() hook.
  *
  * @deprecated
- *   Use the combination of ecas_sync_drupal_user_on_ecas_info() and
+ *   Use the combination of ecas_sync_drupal_user_with_ecas_info() and
  *   ecas_save_user() instead.
  */
 function ecas_sync_user_info(&$user, array $user_info, array $args) {
-  $account_edit = ecas_sync_drupal_user_on_ecas_info($user, $user_info, $args);
+  $account_edit = ecas_sync_drupal_user_with_ecas_info($user, $user_info, $args);
   ecas_save_user($user, $account_edit, $user_info, $args);
 }
 


### PR DESCRIPTION
## NEPT-2813

### Description

Fix ecas function calling from `ecas_sync_drupal_user_on_ecas_info()`, to correct name `ecas_sync_drupal_user_with_ecas_info()`.

### Change log

- Fixed: ecas function call
### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
