### PR TITLE
NEPT-2828: Allow to define the accepted strengths for EU Login

### DIFF
--- a/profiles/common/modules/custom/ecas/ecas.variable.inc
+++ b/profiles/common/modules/custom/ecas/ecas.variable.inc
@@ -42,10 +42,22 @@ function ecas_variable_info($options) {
 
   $variables[ECAS_WARNING_MESSAGE_INCOMPLETE_USER] = array(
     'type' => 'text_format',
-    'title' => t('Error message text in case of an ecas user is incomplete', array(), $options),
+    'title' => t('Error message text in case of an EU Login user is incomplete', array(), $options),
     'default' => _ecas_get_default_warning_message(ECAS_WARNING_MESSAGE_INCOMPLETE_USER),
     'description' => t(
       'Text supplying information about the error because the EU Login profile does not contain the required data, other then the email.'
+    ),
+    'required' => TRUE,
+    'group' => 'ecas',
+    'localize' => TRUE,
+  );
+
+  $variables[ECAS_WARNING_MESSAGE_INVALID_STRENGTH] = array(
+    'type' => 'text_format',
+    'title' => t('Error message text in case of an EU Login authentication without the required level.', array(), $options),
+    'default' => _ecas_get_default_warning_message(ECAS_WARNING_MESSAGE_INVALID_STRENGTH),
+    'description' => t(
+      'EU Login authentication method does not comply with required level.'
     ),
     'required' => TRUE,
     'group' => 'ecas',
@@ -77,6 +89,24 @@ function ecas_variable_info($options) {
     'description' => t('Warning when a user with more then authenticated role is trying to log in with social media login.'),
     'group' => 'ecas',
     'localize' => TRUE,
+  );
+
+  $variables['ecas_assurance_level_strength_medium'] = array(
+    'type' => 'text_format',
+    'title' => t('Strength for medium level', array(), $options),
+    'default' => ECAS_ASSURANCE_LEVELS_STRENGTH_MEDIUM,
+    'description' => t('Authentication methods (strengths) for level of assurance Medium.'),
+    'required' => TRUE,
+    'group' => 'ecas',
+  );
+
+  $variables['ecas_assurance_level_strength_high'] = array(
+    'type' => 'text_format',
+    'title' => t('Strength for high level', array(), $options),
+    'default' => ECAS_ASSURANCE_LEVELS_STRENGTH_HIGH,
+    'description' => t('Authentication methods (strengths) for level of assurance High.'),
+    'required' => TRUE,
+    'group' => 'ecas',
   );
 
   return $variables;

--- a/profiles/common/modules/custom/ecas/ecas_import_users/ecas_import_users.module
+++ b/profiles/common/modules/custom/ecas/ecas_import_users/ecas_import_users.module
@@ -13,6 +13,7 @@ function ecas_import_users_permission() {
     'access ecas import users function' => array(
       'title' => t('Import EU Login users'),
       'description' => t('Import users from the EU Login server into Drupal.'),
+      'restrict access' => TRUE,
     ),
   );
 }

--- a/profiles/common/modules/custom/ecas/includes/ecas.admin.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.admin.inc
@@ -27,6 +27,7 @@ function ecas_permission() {
     'administer ecas' => array(
       'title' => t('Administer ECAS'),
       'description' => t('Perform administration tasks for ECAS.'),
+      'restrict access' => TRUE,
     ),
   );
 }

--- a/profiles/common/modules/custom/ecas/includes/ecas.admin.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.admin.inc
@@ -303,10 +303,10 @@ function ecas_admin_settings() {
  */
 function _ecas_assurance_levels() {
   $assurance_levels = array(
-    'TOP' => t('TOP: Same as HIGH'),
-    'HIGH' => t('HIGH: No self-service'),
-    'MEDIUM' => t('MEDIUM: Self-service requiring the highest available level'),
-    'LOW' => t('BASIC: Self-service requiring the Basic level or above'),
+    'TOP' => t('TOP: EC only'),
+    'HIGH' => t('HIGH: + Other institutions'),
+    'MEDIUM' => t('MEDIUM: + Sponsored'),
+    'LOW' => t('LOW: + External + Self-registered'),
   );
   drupal_alter('ecas_assurance_levels', $assurance_levels);
   return $assurance_levels;

--- a/profiles/common/modules/custom/ecas/includes/ecas.admin.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.admin.inc
@@ -303,10 +303,10 @@ function ecas_admin_settings() {
  */
 function _ecas_assurance_levels() {
   $assurance_levels = array(
-    'TOP' => t('TOP: EC only'),
-    'HIGH' => t('HIGH: + Other institutions'),
-    'MEDIUM' => t('MEDIUM: + Sponsored'),
-    'LOW' => t('LOW: + External + Self-registered'),
+    'TOP' => t('TOP: Same as HIGH'),
+    'HIGH' => t('HIGH: No self-service'),
+    'MEDIUM' => t('MEDIUM: Self-service requiring the highest available level'),
+    'LOW' => t('BASIC: Self-service requiring the Basic level or above'),
   );
   drupal_alter('ecas_assurance_levels', $assurance_levels);
   return $assurance_levels;

--- a/profiles/common/modules/custom/ecas/includes/ecas.admin.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.admin.inc
@@ -163,10 +163,7 @@ function ecas_admin_settings() {
     '#description' => t('Text supplying information about the error caused by the an e-mail in the EU Login profile used in another.'),
   );
 
-  _ecas_text_format_set_default_value(
-    $form['param'],
-    ECAS_WARNING_MESSAGE_NO_EMAIL
-  );
+  _ecas_text_format_set_default_value($form['param'], ECAS_WARNING_MESSAGE_NO_EMAIL);
 
   $form['param'][ECAS_WARNING_MESSAGE_EXISTING_EMAIL] = array(
     '#type' => 'text_format',
@@ -176,10 +173,7 @@ function ecas_admin_settings() {
     '#description' => t('Text supplying information about the error caused by the an e-mail in the EU Login profile used in another.'),
   );
 
-  _ecas_text_format_set_default_value(
-   $form['param'],
-   ECAS_WARNING_MESSAGE_EXISTING_EMAIL
-  );
+  _ecas_text_format_set_default_value($form['param'], ECAS_WARNING_MESSAGE_EXISTING_EMAIL);
 
   $form['param'][ECAS_WARNING_MESSAGE_NOT_CREATED] = array(
     '#type' => 'text_format',
@@ -202,10 +196,20 @@ function ecas_admin_settings() {
      'Text supplying information about the error because the EU Login profile does not contain the required data, other then the email.'
     ),
   );
-  _ecas_text_format_set_default_value(
-   $form['param'],
-   ECAS_WARNING_MESSAGE_INCOMPLETE_USER
+
+  _ecas_text_format_set_default_value($form['param'], ECAS_WARNING_MESSAGE_INCOMPLETE_USER);
+
+  $form['param'][ECAS_WARNING_MESSAGE_INVALID_STRENGTH] = array(
+    '#type' => 'text_format',
+    '#title' => t('Error message text in case of an EU Login authentication without the required level.'),
+    '#cols' => 60,
+    '#rows' => 5,
+    '#description' => t(
+      'Text supplying information about the message text in case of an EU Login authentication without the required level.'
+    ),
   );
+
+  _ecas_text_format_set_default_value($form['param'], ECAS_WARNING_MESSAGE_INVALID_STRENGTH);
 
   $form['param']['ecas_update_mail_address'] = array(
     '#type' => 'checkbox',

--- a/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
@@ -71,19 +71,24 @@ define('ECAS_WARNING_MESSAGE', 'ecas_warning_message');
 define('ECAS_WARNING_MESSAGE_NO_EMAIL', 'ecas_no_email_message');
 
 /**
-  * Name of the ecas existing email  message variable.
+  * Name of the ecas existing email message variable.
   */
 define('ECAS_WARNING_MESSAGE_EXISTING_EMAIL', 'ecas_existing_mail_message');
 
 /**
-  * Name of the ecas existing email  message variable.
+  * Name of the ecas not created message variable.
   */
 define('ECAS_WARNING_MESSAGE_NOT_CREATED', 'ecas_not_created_message');
 
 /**
-  * Name of the ecas incomplete user  message variable.
+  * Name of the ecas incomplete user message variable.
   */
 define('ECAS_WARNING_MESSAGE_INCOMPLETE_USER', 'ecas_incomplete_user_message');
+
+/**
+ * Name of the ecas invalid strength message variable.
+ */
+define('ECAS_WARNING_MESSAGE_INVALID_STRENGTH', 'ecas_invalid_strength_message');
 
 /**
   * Name of the ecas no email variable message variable.
@@ -99,4 +104,18 @@ define('ECAS_WARNING_REASON_EXISTING_EMAIL', 'mail_already_exists');
 define('ECAS_WARNING_REASON_NOT_CREATED', 'not_created');
 define('ECAS_WARNING_REASON_BLOCKED', 'account_blocked');
 define('ECAS_WARNING_REASON_INCOMPLETE_USER', 'ecas_incomplete_user');
+define('ECAS_WARNING_REASON_INVALID_STRENGTH', 'invalid_strength');
 define('ECAS_WARNING_REASON_UNKNOWN', 'unknown');
+
+/**
+ * The full list of authentication methods for medium level of assurance is:
+ * PASSWORD_SMS, PASSWORD_SOFTWARE_TOKEN, PASSWORD_MOBILE_APP, MOBILE_APP and MDM_CERT.
+ * But it does not matter which of them we use for sending as strength.
+ * It is enough to send one of these, to ensure the medium level of assurance will be used.
+ * Also specifying others would not make any difference, since what is considered by EuLogin is
+ * the level of the method, not the method itself.
+ * The full list of authentication methods for medium level of assurance is:
+ * PASSWORD_TOKEN,PASSWORD_TOKEN_CRAM, CLIENT_CERT.
+ */
+define('ECAS_ASSURANCE_LEVELS_STRENGTH_MEDIUM', 'MOBILE_APP');
+define('ECAS_ASSURANCE_LEVELS_STRENGTH_HIGH', 'PASSWORD_TOKEN');

--- a/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
@@ -108,12 +108,16 @@ define('ECAS_WARNING_REASON_INVALID_STRENGTH', 'invalid_strength');
 define('ECAS_WARNING_REASON_UNKNOWN', 'unknown');
 
 /**
+ * Strengths used for assurance levels.
+ *
  * The full list of authentication methods for medium level of assurance is:
- * PASSWORD_SMS, PASSWORD_SOFTWARE_TOKEN, PASSWORD_MOBILE_APP, MOBILE_APP and MDM_CERT.
+ * PASSWORD_SMS, PASSWORD_SOFTWARE_TOKEN, PASSWORD_MOBILE_APP,
+ * MOBILE_APP and MDM_CERT.
  * But it does not matter which of them we use for sending as strength.
- * It is enough to send one of these, to ensure the medium level of assurance will be used.
- * Also specifying others would not make any difference, since what is considered by EuLogin is
- * the level of the method, not the method itself.
+ * It is enough to send one of these, to ensure the medium level of assurance
+ * will be used.
+ * Also specifying others would not make any difference, since what is
+ * considered by Eu Login is the level of the method, not the method itself.
  * The full list of authentication methods for medium level of assurance is:
  * PASSWORD_TOKEN,PASSWORD_TOKEN_CRAM, CLIENT_CERT.
  */

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -540,7 +540,7 @@ function ecas_login_check() {
   }
 
   $strengths_sent = _ecas_get_strengths();
-  if(!empty($strengths_sent) && $strengths_sent !== $ecas_attributes['cas:strengths']['cas:strength']) {
+  if (!empty($strengths_sent) && $strengths_sent !== $ecas_attributes['cas:strengths']['cas:strength']) {
     _ecas_warning_goto(
       ECAS_WARNING_REASON_INVALID_STRENGTH,
       NULL,
@@ -687,14 +687,14 @@ function ecas_login_check() {
 
 /**
  * Get the strengths according to the assurance level.
- **/
+ */
 function _ecas_get_strengths() {
   $assurance_level = variable_get('ecas_assurance_level', constant('ECAS_DEFAULT_ASSURANCE_LEVEL'));
 
   if ($assurance_level === 'MEDIUM') {
     return variable_get('ecas_assurance_level_strength_medium', ECAS_ASSURANCE_LEVELS_STRENGTH_MEDIUM);
   }
-  else if ($assurance_level === 'HIGH') {
+  elseif ($assurance_level === 'HIGH' || $assurance_level === 'TOP') {
     return variable_get('ecas_assurance_level_strength_high', ECAS_ASSURANCE_LEVELS_STRENGTH_HIGH);
   }
 
@@ -826,7 +826,6 @@ function ecas_warning_page($reason) {
     );
     $message = array('value' => $message);
   }
-
   $theme_variables['warning_text'] = _ecas_filter_variable_text($message);
 
   return theme('ecas_profile_warning_page', $theme_variables);

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -539,6 +539,19 @@ function ecas_login_check() {
     );
   }
 
+  $strengths_sent = _ecas_get_strengths();
+  if(!empty($strengths_sent) && $strengths_sent !== $ecas_attributes['cas:strengths']['cas:strength']) {
+    _ecas_warning_goto(
+      ECAS_WARNING_REASON_INVALID_STRENGTH,
+      NULL,
+      'Login process failed for "%ecas_name" because "%strength" is not an accepted authentication method.',
+      array(
+        '%ecas_name' => $ecas_name,
+        '%strength' => $ecas_attributes['cas:strengths']['cas:strength'],
+      )
+    );
+  }
+
   $ecas_social_login = $ecas_attributes['cas:employeeType'];
   $ecas_user_language = ecas_get_ecas_user_language($ecas_attributes);
 
@@ -673,6 +686,22 @@ function ecas_login_check() {
 }
 
 /**
+ * Get the strengths according to the assurance level.
+ **/
+function _ecas_get_strengths() {
+  $assurance_level = variable_get('ecas_assurance_level', constant('ECAS_DEFAULT_ASSURANCE_LEVEL'));
+
+  if ($assurance_level === 'MEDIUM') {
+    return variable_get('ecas_assurance_level_strength_medium', ECAS_ASSURANCE_LEVELS_STRENGTH_MEDIUM);
+  }
+  else if ($assurance_level === 'HIGH') {
+    return variable_get('ecas_assurance_level_strength_high', ECAS_ASSURANCE_LEVELS_STRENGTH_HIGH);
+  }
+
+  return NULL;
+}
+
+/**
  * Check to see if we need to display the logout menu.
  *
  * @return bool
@@ -747,7 +776,7 @@ function ecas_block_info() {
  *   The themed warning page display.
  */
 function ecas_warning_page($reason) {
-  $theme_variables = array('warning_title' => t("Your site's account cannot be created"));
+  $theme_variables = array('warning_title' => t("Your site's account cannot be activated"));
 
   switch ($reason) {
     case ECAS_WARNING_REASON_SOCIAL:
@@ -776,11 +805,13 @@ function ecas_warning_page($reason) {
       $message_key = ECAS_WARNING_MESSAGE_INCOMPLETE_USER;
       break;
 
+    case ECAS_WARNING_REASON_INVALID_STRENGTH:
+      $message_key = ECAS_WARNING_MESSAGE_INVALID_STRENGTH;
+      break;
+
     default:
       $theme_variables['warning_text'] = t("The reason is unknown. Please contact the site's administrator.");
-
       return theme('ecas_profile_warning_page', $theme_variables);
-
   }
 
   $message = variable_get($message_key, _ecas_get_default_warning_message($message_key));
@@ -795,6 +826,7 @@ function ecas_warning_page($reason) {
     );
     $message = array('value' => $message);
   }
+
   $theme_variables['warning_text'] = _ecas_filter_variable_text($message);
 
   return theme('ecas_profile_warning_page', $theme_variables);
@@ -1347,6 +1379,12 @@ EOF;
       $value = <<< EOF
       We do not receive all required data of your EU Login. That prevent us to create your account.<br /> 
       Please complete your EU-Login account or contact <a href="https://ecas.ec.europa.eu/cas/contact.html">EU-Login support</a>.
+EOF;
+      break;
+
+    case ECAS_WARNING_MESSAGE_INVALID_STRENGTH:
+      $value = <<< EOF
+      Authentication in EU Login was done with a method that is not accepted.
 EOF;
       break;
 

--- a/profiles/common/modules/custom/ecas/libraries/FPFIS_Common/constants/constants.php
+++ b/profiles/common/modules/custom/ecas/libraries/FPFIS_Common/constants/constants.php
@@ -9,9 +9,9 @@ if ( !defined('FPFIS_COMMON_LIBRARIES_PATH') ) define('FPFIS_COMMON_LIBRARIES_PA
 ECAS conf
 */
 if ( !defined('FPFIS_ECAS_PATH') ) define('FPFIS_ECAS_PATH', FPFIS_COMMON_LIBRARIES_PATH . '/phpcas/CAS.php');
-if ( !defined('FPFIS_ECAS_URL') ) define('FPFIS_ECAS_URL', 'ecas.cc.cec.eu.int');
+if ( !defined('FPFIS_ECAS_URL') ) define('FPFIS_ECAS_URL', 'webgate.ec.europa.eu');
 if ( !defined('FPFIS_ECAS_URI') ) define('FPFIS_ECAS_URI', '/cas');
-if ( !defined('FPFIS_ECAS_PORT') ) define('FPFIS_ECAS_PORT', 7002);
+if ( !defined('FPFIS_ECAS_PORT') ) define('FPFIS_ECAS_PORT', 443);
 
 /*
 LDAP conf

--- a/profiles/common/modules/custom/ecas/libraries/FPFIS_Common/constants/constants.php
+++ b/profiles/common/modules/custom/ecas/libraries/FPFIS_Common/constants/constants.php
@@ -9,9 +9,9 @@ if ( !defined('FPFIS_COMMON_LIBRARIES_PATH') ) define('FPFIS_COMMON_LIBRARIES_PA
 ECAS conf
 */
 if ( !defined('FPFIS_ECAS_PATH') ) define('FPFIS_ECAS_PATH', FPFIS_COMMON_LIBRARIES_PATH . '/phpcas/CAS.php');
-if ( !defined('FPFIS_ECAS_URL') ) define('FPFIS_ECAS_URL', 'webgate.ec.europa.eu');
+if ( !defined('FPFIS_ECAS_URL') ) define('FPFIS_ECAS_URL', 'ecas.cc.cec.eu.int');
 if ( !defined('FPFIS_ECAS_URI') ) define('FPFIS_ECAS_URI', '/cas');
-if ( !defined('FPFIS_ECAS_PORT') ) define('FPFIS_ECAS_PORT', 443);
+if ( !defined('FPFIS_ECAS_PORT') ) define('FPFIS_ECAS_PORT', 7002);
 
 /*
 LDAP conf

--- a/profiles/common/modules/custom/ecas/libraries/phpcas/CAS/Client.php
+++ b/profiles/common/modules/custom/ecas/libraries/phpcas/CAS/Client.php
@@ -342,6 +342,12 @@ class CAS_Client
             $this->_server['login_url'] .= urlencode($this->getURL());
         }
         $url = $this->_server['login_url'];
+
+        // Add necessary parameters.
+        $strengths_send = _ecas_get_strengths();
+        if (!empty($strengths_send)) {
+            $url = $this->_buildQueryUrl($url, 'acceptStrengths=' . $strengths_send);
+        }
         if ($renew) {
             // It is recommended that when the "renew" parameter is set, its
             // value be "true"


### PR DESCRIPTION
## NEPT-2828

### Description

Send accepted strengths to EU Login when doing the authentication, in accordance with "EU Login Assurance Level for this application" setting.

### Change log

- Added: variables 'ecas_assurance_level_strength_medium', 'ecas_assurance_level_strength_high'
- Changed: Send "acceptStrength" parameter in request to EU Login.

### Commands

Setting "EU Login Assurance Level for this application" wich is stored in variable "ecas_assurance_level" can be updated to MEDIUM.