### PR TITLE
NEPT-2838: Upgrade drupal core to 7.70

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = "core"
-projects[drupal][version] = "7.69"
+projects[drupal][version] = "7.70"
 
 ; AJAX callbacks not properly working with the language url suffix.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-4268


### PR DESCRIPTION
## NEPT-2838
### Description

Upgrade drupal core to 7.70

### Change log

- Security:  SA-CORE-2020-002 & SA-CORE-2020-003

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
