### PR TITLE
NEPT-2837: Release 2.5.148

### DIFF
--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -375,11 +375,11 @@ function ecas_sync_profile_core(&$user, array $user_info, array &$edit = array()
  *   info_ecas_update() hook.
  *
  * @deprecated
- *   Use the combination of ecas_sync_drupal_user_on_ecas_info() and
+ *   Use the combination of ecas_sync_drupal_user_with_ecas_info() and
  *   ecas_save_user() instead.
  */
 function ecas_sync_user_info(&$user, array $user_info, array $args) {
-  $account_edit = ecas_sync_drupal_user_on_ecas_info($user, $user_info, $args);
+  $account_edit = ecas_sync_drupal_user_with_ecas_info($user, $user_info, $args);
   ecas_save_user($user, $account_edit, $user_info, $args);
 }
 

--- a/profiles/common/modules/custom/ecas/libraries/phpcas/CAS/Client.php
+++ b/profiles/common/modules/custom/ecas/libraries/phpcas/CAS/Client.php
@@ -2346,8 +2346,8 @@ class CAS_Client
     private function _callback()
     {
         phpCAS::traceBegin();
-        if (preg_match('/PGTIOU-[\.\-\w]/', $_GET['pgtIou'])) {
-            if (preg_match('/[PT]GT-[\.\-\w]/', $_GET['pgtId'])) {
+        if (preg_match('/^PGTIOU-[\.\-\w]+$/', $_GET['pgtIou'])) {
+            if (preg_match('/^[PT]GT-[\.\-\w]+$/', $_GET['pgtId'])) {
                 $this->printHTMLHeader('phpCAS callback');
                 $pgt_iou = $_GET['pgtIou'];
                 $pgt = $_GET['pgtId'];
@@ -2563,7 +2563,7 @@ class CAS_Client
             $pgt_iou = trim(
                 $tree_response->getElementsByTagName("proxyGrantingTicket")->item(0)->nodeValue
             );
-            if (preg_match('/PGTIOU-[\.\-\w]/', $pgt_iou)) {
+            if (preg_match('/^PGTIOU-[\.\-\w]+$/', $pgt_iou)) {
                 $pgt = $this->_loadPGT($pgt_iou);
                 if ( $pgt == false ) {
                     phpCAS::trace('could not load PGT');

--- a/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.module
+++ b/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.module
@@ -46,6 +46,7 @@ function nexteuropa_piwik_permission() {
     'administer nexteuropa_piwik' => array(
       'title' => t('Administer Nexteuropa Piwik'),
       'description' => t('Perform maintenance tasks for Piwik.'),
+      'restrict access' => TRUE,
     ),
   );
 }

--- a/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
+++ b/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module
@@ -84,6 +84,7 @@ function nexteuropa_varnish_permission() {
     'administer frontend cache purge rules' => array(
       'title' => 'Administer frontend cache purge rules',
       'description' => '',
+      'restrict access' => TRUE,
     ),
   );
 }

--- a/profiles/common/modules/features/multisite_workbench_moderation_view/multisite_workbench_moderation_view.module
+++ b/profiles/common/modules/features/multisite_workbench_moderation_view/multisite_workbench_moderation_view.module
@@ -95,6 +95,7 @@ function multisite_workbench_moderation_view_permission() {
   $permissions['multisite_workbench_moderation_view_bulk_update'] = array(
     'title' => t('Moderate workbench in bulk'),
     'description' => t('Allow users to manage items from the workbench in bulk.'),
+    'restrict access' => TRUE,
   );
   return $permissions;
 }

--- a/profiles/common/modules/features/nexteuropa_dgt_connector/README.md
+++ b/profiles/common/modules/features/nexteuropa_dgt_connector/README.md
@@ -176,7 +176,7 @@ If you are working in collaboration with a contractor and he needs to test
 the DGT-Connector UI and the workflow locally, this can be done without the
 need to access the webservice by using the tmgmt_poetry_mock module.
 
- Contractors : see [the mock readme](tmgmt_poetry_mock/README.md) for more
+ Contractors : see [the mock readme](tmgmt_poetry/tmgmt_poetry_mock/README.md) for more
  information on testing with the mock.
 
 ## Testing in-house (for webmasters)

--- a/profiles/common/modules/features/nexteuropa_feature_set/multisite_drupal_features_set_standard/multisite_drupal_features_set_standard.module
+++ b/profiles/common/modules/features/nexteuropa_feature_set/multisite_drupal_features_set_standard/multisite_drupal_features_set_standard.module
@@ -23,6 +23,7 @@ function multisite_drupal_features_set_standard_permission() {
       $permissions['manage feature ' . $featureset] = array(
         'title' => t('Manage feature set @feature', array('@feature' => $featureset)),
         'description' => t('Enable and disable feature set @feature. Note that this functionality is similar and is a subset of the functionality allowed by administer modules so be aware that users with this permission will be able to enable, disable, and uninstall modules defined via the feature set module', array('@feature' => $featureset)),
+        'restrict access' => TRUE,
       );
     }
   }

--- a/profiles/common/modules/features/nexteuropa_webtools/nexteuropa_webtools.module
+++ b/profiles/common/modules/features/nexteuropa_webtools/nexteuropa_webtools.module
@@ -32,10 +32,12 @@ function nexteuropa_webtools_permission() {
     'administer webtools' => array(
       'title' => t('Administer webtools'),
       'description' => t('Administer nexteuropa_webbools feature.'),
+      'restrict access' => TRUE,
     ),
     'upload webtools custom js' => array(
       'title' => t('Upload webtools custom js'),
       'description' => t('Allows users to upload a custom js in webtools bean.'),
+      'restrict access' => TRUE,
     ),
   );
 }

--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = "core"
-projects[drupal][version] = "7.69"
+projects[drupal][version] = "7.70"
 
 ; AJAX callbacks not properly working with the language url suffix.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-4268

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -677,7 +677,9 @@ projects[scheduler][subdir] = "contrib"
 projects[scheduler][version] = 1.5
 
 projects[scheduler_workbench][subdir] = "contrib"
-projects[scheduler_workbench][version] = 1.3
+projects[scheduler_workbench][download][branch] = 7.x-1.x
+projects[scheduler_workbench][download][revision] = 46e8db33e54a0d873ff60956d4d2f90d27c4735d
+projects[scheduler_workbench][download][url] = https://git.drupal.org/project/scheduler_workbench.git
 ; Allow to schedule the publish date of a revision
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-1999
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2504
@@ -691,6 +693,9 @@ projects[scheduler_workbench][patch][] = https://www.drupal.org/files/issues/201
 ; the issue doesn't take into account the changes introduced on issue
 ; https://www.drupal.org/project/scheduler_workbench/issues/2048999, so we created a local patch for it.
 projects[scheduler_workbench][patch][] = patches/scheduler_workbench-allowed_status.patch
+; NEPT-2787: Remove already published nodes from scheduler list
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2787
+projects[scheduler_workbench][patch][] = https://www.drupal.org/files/issues/2020-04-29/persistent_nodes-3118719-6.patch
 
 projects[select_or_other][subdir] = "contrib"
 projects[select_or_other][version] = 2.24


### PR DESCRIPTION
## NEPT-2837

### Description

Release 2.5.148

### Change log

- Changed: **https://webgate.ec.europa.eu/fpfis/wikis/display/OPENEU/Release+notes+2.5.148**

### Commands

```drush updb```

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
