### PR TITLE
NEPT-2849: Update Drupal to 7.72

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = "core"
-projects[drupal][version] = "7.70"
+projects[drupal][version] = "7.72"
 
 ; AJAX callbacks not properly working with the language url suffix.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-4268

--- a/tests/features/news/news_standard.feature
+++ b/tests/features/news/news_standard.feature
@@ -1,4 +1,4 @@
-@api @javascript @maximizedwindow
+@api @javascript
 Feature: news standard and news core
   In order to publish news
   As different types of users


### PR DESCRIPTION
## NEPT-2849

### Description

Update Drupal to 7.72 regarding SA-CORE-2020-004


### Change log

- Changed: Drupal core version to

### Commands

[Insert commands here]

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
