### PR TITLE
NEPT-2847: NE Varnish new release

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -1191,4 +1191,4 @@ projects[nexteuropa_varnish][subdir] = "custom"
 projects[nexteuropa_varnish][type] = module
 projects[nexteuropa_varnish][download][type] = git
 projects[nexteuropa_varnish][download][url] = https://github.com/ec-europa/digit-ne-varnish.git
-projects[nexteuropa_varnish][download][tag] = v1.0.9
+projects[nexteuropa_varnish][download][tag] = v1.0.10


### PR DESCRIPTION
## NEPT-2847

### Description
New release of nexteuropa_varnish has permission marked as 'restricted'.

### Change log

- Changed: ne-varnish to latest version

### Commands


### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
