### PR TITLE
nept-2859 -- Update password generation and README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ $ ./bin/phing build-europa-dev
 ```
 This Phing target is meant to be used only for the local development purposes.
 
+## Generic users.
+After install, generic users are created. Login using drush user-login command.
+```
+$  cd ./build
+$  drush uli
+```
+And setup a new password for these users.
+
 ## Running Behat tests
 
 The Behat test suite is located in the `tests/` folder. When the development

--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install.inc
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install.inc
@@ -440,7 +440,7 @@ function _cce_basic_config_post_install_users() {
   $account->is_new = TRUE;
   $account->status = TRUE;
   $account->name = 'user_administrator';
-  $account->pass = user_hash_password('pass');
+  $account->pass = user_password();
   $account->mail = 'administrator@' . $default_email_domain;
   $account->init = $account->mail;
   $role = user_role_load_by_name('administrator');
@@ -453,7 +453,7 @@ function _cce_basic_config_post_install_users() {
   $account1->is_new = TRUE;
   $account1->status = TRUE;
   $account1->name = 'user_contributor';
-  $account1->pass = user_hash_password('pass');
+  $account1->pass = user_password();
   $account1->mail = 'contributor@' . $default_email_domain;
   $account1->init = $account1->mail;
   $role1 = user_role_load_by_name('contributor');
@@ -466,7 +466,7 @@ function _cce_basic_config_post_install_users() {
   $account2->is_new = TRUE;
   $account2->status = TRUE;
   $account2->name = 'user_editor';
-  $account2->pass = user_hash_password('pass');
+  $account2->pass = user_password();
   $account2->mail = 'editor@' . $default_email_domain;
   $account2->init = $account2->mail;
   $role2 = user_role_load_by_name('editor');


### PR DESCRIPTION
## NEPT-2859

### Description

Update password generation on site install.

### Change log

- Changed: _cce_basic_config_post_install_users() and README.md.

### Commands

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
