### PR TITLE
NEPT-2862 -- Impose EU Login 2 FA for non whitelisted users roles.

### DIFF
--- a/build.properties.dist
+++ b/build.properties.dist
@@ -47,7 +47,7 @@ drupal.htaccess.path = ${platform.build.dir}/.htaccess
 drupal.htaccess.append.text =
 
 # Configuration to append to the settings.php file of the build.
-drupal.settings.append.text = ${line.separator}$conf['multisite_toolbox_cs_whitelist'] = array('*.europa.eu', 'europa.eu');${line.separator}$conf['poetry_mock_base_url'] = "${mock.poetry.base_url}";${line.separator}$conf['ecas_whitelisted_user_roles'] = array('authenticated user');${line.separator}
+drupal.settings.append.text = ${line.separator}$conf['multisite_toolbox_cs_whitelist'] = array('*.europa.eu', 'europa.eu');${line.separator}$conf['poetry_mock_base_url'] = "${mock.poetry.base_url}";${line.separator}$conf['ecas_whitelisted_user_roles'] = array();${line.separator}
 
 
 # Platform configuration

--- a/build.properties.dist
+++ b/build.properties.dist
@@ -47,7 +47,7 @@ drupal.htaccess.path = ${platform.build.dir}/.htaccess
 drupal.htaccess.append.text =
 
 # Configuration to append to the settings.php file of the build.
-drupal.settings.append.text = ${line.separator}$conf['multisite_toolbox_cs_whitelist'] = array('*.europa.eu', 'europa.eu');${line.separator}$conf['poetry_mock_base_url'] = "${mock.poetry.base_url}";${line.separator}
+drupal.settings.append.text = ${line.separator}$conf['multisite_toolbox_cs_whitelist'] = array('*.europa.eu', 'europa.eu');${line.separator}$conf['poetry_mock_base_url'] = "${mock.poetry.base_url}";${line.separator}$conf['ecas_whitelisted_user_roles'] = array('authenticated user');${line.separator}
 
 
 # Platform configuration

--- a/profiles/common/modules/custom/ecas/ecas.module
+++ b/profiles/common/modules/custom/ecas/ecas.module
@@ -13,13 +13,17 @@
  * Both will be included from the FPFIS_COMMON_LIBRARIES_PATH.
  */
 
-// Include the constants sued in the different part of the module.
+// Include the constants used in the different parts of the module.
 $constants_ecas_module_include = drupal_get_path('module', 'ecas') . '/includes/ecas.constants.inc';
 include_once $constants_ecas_module_include;
 
 // Include the admin part of the module.
 $admin_ecas_module_include = drupal_get_path('module', 'ecas') . '/includes/ecas.admin.inc';
 include_once $admin_ecas_module_include;
+
+// Include the EcasDenieAuth class.
+$ecas_denie_auth = drupal_get_path('module', 'ecas') . '/includes/EcasDenieAuth.inc';
+include_once $ecas_denie_auth;
 
 $fpfis_common_include = constant('FPFIS_COMMON_LIBRARIES_PATH') . '/FPFIS_Common/fpfis_common.php';
 include_once $fpfis_common_include;

--- a/profiles/common/modules/custom/ecas/ecas.variable.inc
+++ b/profiles/common/modules/custom/ecas/ecas.variable.inc
@@ -79,6 +79,15 @@ function ecas_variable_info($options) {
     'localize' => TRUE,
   );
 
+  $variables[ECAS_WARNING_MESSAGE_TFA_REQUIRED] = array(
+    'type' => 'text_format',
+    'title' => t('Error message text in case of TFA is required but not used.', array(), $options),
+    'default' => _ecas_get_default_warning_message(ECAS_WARNING_MESSAGE_TFA_REQUIRED),
+    'description' => t('Text supplying information about the error caused by a one factor authentication from EU Login when the account requires a two factors authentication.'),
+    'group' => 'ecas',
+    'localize' => TRUE,
+  );
+
   return $variables;
 }
 

--- a/profiles/common/modules/custom/ecas/includes/EcasDenieAuth.inc
+++ b/profiles/common/modules/custom/ecas/includes/EcasDenieAuth.inc
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * @file
+ * Contains EcasDenieAuth.
+ */
+
+/**
+ * Contains logic to check and manage authentication denie.
+ */
+class EcasDenieAuth {
+
+  /**
+   * This variable stores current login process's status to check and manage.
+   *
+   * @var string
+   * @access private
+   */
+  private $status;
+
+  /**
+   * This variable stores user language object.
+   *
+   * @var object
+   * @access private
+   */
+  private $language;
+
+  /**
+   * This variable stores warning message arguments.
+   *
+   * @var array
+   * @access private
+   */
+  private $messageArgs;
+
+  /**
+   * This variable stores redirection attributes.
+   *
+   * @var array
+   * @access public
+   */
+  public $redirectionAttributes;
+
+  /**
+   * Construct EcasDenieAuth object.
+   */
+  public function __construct(array $props = array()) {
+    $this->language = isset($props['language']) ? $props['language'] : NULL;
+    $this->messageArgs = isset($props['message_args']) ? $props['message_args'] : array();
+
+    // Set redirection attributes.
+    $this->setRedirectionAttributes();
+  }
+
+  /**
+   * Main method proceeding to login status evaluation and user redirection.
+   *
+   * If the authentication has to be denied, session is destroyed
+   * and user is redirected to an informative page.
+   *
+   * @param string $status
+   *   The login status to check.
+   * @param bool $process
+   *   Indicates if authentication should be denied or not.
+   * @param array $extend
+   *   (Optional) If provided, authentication status evaluation can
+   *   be extended using provided values.
+   */
+  public function check($status, $process, array $extend = array()) {
+    $this->status = $status;
+    $this->process = $process;
+    $this->extend = $extend;
+
+    $denieAuth = $this->evaluateStatus();
+
+    if ($denieAuth) {
+
+      $this->redirect();
+    }
+  }
+
+  /**
+   * Private method which evaluate status.
+   *
+   * The evaluation can be extended with advanced check steps
+   * or only based on $process value.
+   */
+  private function evaluateStatus() {
+
+    $denieAuth = FALSE;
+
+    switch ($this->status) {
+
+      case 'authentication_strength':
+        $restrictAuth = variable_get('ecas_restrict_auth_strength', TRUE);
+
+        $denieAuth = (!$restrictAuth || $this->userRolesAreWhitelisted()) ? FALSE : !$this->loginStrengthIsCompliant();
+
+        break;
+
+      case 'eu_login_authentication':
+      case 'eu_login_account_attributes':
+      case 'e-mail_defined':
+      case 'e-mail_exists':
+      case 'social_login_role':
+      case 'account_status':
+
+        $denieAuth = $this->process;
+
+        break;
+
+    }
+
+    return $denieAuth;
+  }
+
+  /**
+   * Private method checking if current user has only whitelisted roles.
+   */
+  private function userRolesAreWhitelisted() {
+    $userRoles = $this->extend['user_roles'];
+    $whitelistedRoles = variable_get('ecas_whitelisted_user_roles', array('authenticated user'));
+    $userIsWhitelisted = empty(array_diff($userRoles, $whitelistedRoles));
+
+    return $userIsWhitelisted;
+  }
+
+  /**
+   * Private method checking EU Login authentication strength.
+   */
+  private function loginStrengthIsCompliant() {
+    $loginStrengths = count($this->extend['login_strengths']['cas:strength']);
+
+    return ($loginStrengths > 1) ? TRUE : FALSE;
+  }
+
+  /**
+   * Private method setting redirection attributes.
+   */
+  private function setRedirectionAttributes() {
+
+    $this->redirectionAttributes = array(
+      'eu_login_authentication' => array(
+        'page_argument' => ECAS_WARNING_REASON_UNKNOWN,
+        'message' => 'ECAS authentication failed for unexpected reasons.',
+      ),
+      'eu_login_account_attributes' => array(
+        'page_argument' => ECAS_WARNING_REASON_INCOMPLETE_USER,
+        'message' => 'Login process failed for "%ecas_name" because of an EU login user with missing required attributes.',
+      ),
+      'e-mail_defined' => array(
+        'page_argument' => ECAS_WARNING_REASON_NO_EMAIL,
+        'message' => 'Login denied for %ecas_name because it has no e-mail defined.',
+      ),
+      'e-mail_exists' => array(
+        'page_argument' => ECAS_WARNING_REASON_EXISTING_EMAIL,
+        'message' => 'Login denied for %ecas_name because the e-mail is already used by another account.',
+      ),
+      'social_login_role' => array(
+        'page_argument' => ECAS_WARNING_REASON_SOCIAL,
+        'message' => 'Login denied for %ecas_name because the account has more than authenticated role.',
+      ),
+      'account_status' => array(
+        'page_argument' => ECAS_WARNING_REASON_BLOCKED,
+        'message' => 'Login denied for %ecas_name because the account is not active yet.',
+      ),
+      'authentication_strength' => array(
+        'page_argument' => ECAS_WARNING_TFA_REQUIRED,
+        'message' => "Login denied for %ecas_name because his account requires a stronger EU Login authentication.",
+      ),
+    );
+  }
+
+  /**
+   * Triggers the redirection to the ecas warning page.
+   *
+   * @param array $data
+   *   (Optional) Array of variables used in case of this method
+   *   is called directly from outside class scope.
+   *
+   * @see drupal_goto()
+   */
+  public function redirect(array $data = array()) {
+
+    $message = (!isset($data['message'])) ? $this->redirectionAttributes[$this->status]['message'] : $data['message'];
+    $path_page_argument = (!isset($data['page_argument'])) ? $this->redirectionAttributes[$this->status]['page_argument'] : $data['page_argument'];
+    $language = (empty($this->language)) ? language_default() : $this->language;
+
+    if ($message != '') {
+      watchdog('user', $message, $this->messageArgs, WATCHDOG_ERROR);
+    }
+
+    $this->endSession();
+
+    // Ensure that the user is correctly redirected to warning page because
+    // if drupal_goto() detects an internal path in destination parameter, it
+    // will use it instead of the submitted parameters, see function code.
+    if (isset($_REQUEST['destination'])) {
+      unset($_REQUEST['destination']);
+    }
+    if (isset($_REQUEST['edit']['destination'])) {
+      unset($_REQUEST['edit']['destination']);
+    }
+
+    drupal_goto('eulogin_warning/' . $path_page_argument, array('language' => $language));
+  }
+
+  /**
+   * Public method ending session and set global variable $user to anonymous.
+   */
+  public static function endSession() {
+    global $user;
+
+    session_destroy();
+
+    $user = drupal_anonymous_user();
+  }
+
+  /**
+   * Public method allowing to refresh object properties.
+   */
+  public function set(array $props) {
+    $this->language = isset($props['language']) ? $props['language'] : $this->language;
+    $this->messageArgs = isset($props['message_args']) ? $props['message_args'] : $this->messageArgs;
+  }
+
+}

--- a/profiles/common/modules/custom/ecas/includes/EcasDenieAuth.inc
+++ b/profiles/common/modules/custom/ecas/includes/EcasDenieAuth.inc
@@ -93,9 +93,8 @@ class EcasDenieAuth {
     switch ($this->status) {
 
       case 'authentication_strength':
-        $restrictAuth = variable_get('ecas_restrict_auth_strength', TRUE);
 
-        $denieAuth = (!$restrictAuth || $this->userRolesAreWhitelisted()) ? FALSE : !$this->loginStrengthIsCompliant();
+        $denieAuth = ($this->userRolesAreWhitelisted()) ? FALSE : !$this->loginStrengthIsCompliant();
 
         break;
 

--- a/profiles/common/modules/custom/ecas/includes/EcasDenieAuth.inc
+++ b/profiles/common/modules/custom/ecas/includes/EcasDenieAuth.inc
@@ -120,7 +120,7 @@ class EcasDenieAuth {
    */
   private function userRolesAreWhitelisted() {
     $userRoles = $this->extend['user_roles'];
-    $whitelistedRoles = variable_get('ecas_whitelisted_user_roles', array('authenticated user'));
+    $whitelistedRoles = variable_get('ecas_whitelisted_user_roles', array());
     $userIsWhitelisted = empty(array_diff($userRoles, $whitelistedRoles));
 
     return $userIsWhitelisted;

--- a/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
@@ -91,6 +91,11 @@ define('ECAS_WARNING_MESSAGE_INCOMPLETE_USER', 'ecas_incomplete_user_message');
 define('ECAS_WARNING_MESSAGE_SOCIAL', 'social_role_not_allowed_message');
 
 /**
+  * Name of the ecas tfa required variable message variable.
+  */
+define('ECAS_WARNING_MESSAGE_TFA_REQUIRED', 'ecas_tfa_required');
+
+/**
   * Ids for the different reasons causing a ECAS login failures.
   */
 define('ECAS_WARNING_REASON_SOCIAL', 'social_role_not_allowed');
@@ -100,3 +105,4 @@ define('ECAS_WARNING_REASON_NOT_CREATED', 'not_created');
 define('ECAS_WARNING_REASON_BLOCKED', 'account_blocked');
 define('ECAS_WARNING_REASON_INCOMPLETE_USER', 'ecas_incomplete_user');
 define('ECAS_WARNING_REASON_UNKNOWN', 'unknown');
+define('ECAS_WARNING_TFA_REQUIRED', 'tfa_required');

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -1325,7 +1325,7 @@ EOF;
 
     case ECAS_WARNING_MESSAGE_TFA_REQUIRED:
       $value = <<< EOF
-      You just logged in using a one factor authentication method (I.e. Password) when your account requires a stronger authentication.
+      You just logged in using a one-factor authentication method (i.e. Password), when your account requires a stronger authentication.
       Please renew your authentication by choosing a more secure authentication method (e.g. Mobile Phone + SMS).
 EOF;
       break;

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -1326,7 +1326,7 @@ EOF;
     case ECAS_WARNING_MESSAGE_TFA_REQUIRED:
       $value = <<< EOF
       You just logged in using a one factor authentication method (I.e. Password) when your account requires a stronger authentication.
-      Please reiterate your authentication by choosing a more secured authentication method (I.e. Mobile Phone + SMS).
+      Please renew your authentication by choosing a more secure authentication method (e.g. Mobile Phone + SMS).
 EOF;
       break;
 

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -229,7 +229,8 @@ function ecas_login_page() {
 
   // If it is the user's first CAS login and initial login redirection is
   // enabled, go to the set page.
-  if (!empty($_SESSION['ecas_goto'])) {
+  if (!empty($_SESSION['ecas_goto'])
+    && !_ecas_is_warning_page($_SESSION['ecas_goto'])) {
     $destination = $_SESSION['ecas_goto'];
     unset($_SESSION['ecas_goto']);
   }
@@ -512,32 +513,25 @@ function ecas_login_check() {
     phpCAS::forceAuthentication();
   }
 
-  // Check the user is authenticated by ecas.
-  // if not, we stop here with a warning message page.
-  if (!phpCAS::isAuthenticated()) {
-    _ecas_warning_goto(
-      ECAS_WARNING_REASON_UNKNOWN,
-      NULL,
-      'ECAS authentication failed for unexpected reasons.'
-    );
-  }
+  // Instanciate EcasDenieAuth object.
+  $ecasDenieAuth = new EcasDenieAuth();
+
+  // Check if user has been authenticated by EU Login.
+  $ecasDenieAuth->check('eu_login_authentication', (!phpCAS::isAuthenticated()) ? TRUE : FALSE);
 
   // Get ecas user data.
   $ecas_name = phpCAS::getUser();
   $ecas_attributes = phpCAS::getAttributes();
 
-  // If no ecas attribute are available, we cannot achieve the user login.
-  // We stop the process and redirect the user to the warning page.
-  if (empty($ecas_attributes) || empty($ecas_name)) {
-    _ecas_warning_goto(
-      ECAS_WARNING_REASON_INCOMPLETE_USER,
-      NULL,
-      'Login process failed for "%ecas_name" because of an EU login user with missing required attributes.',
-      array(
-        '%ecas_name' => !empty($ecas_name) ? $ecas_name : 'Unknown user name',
-      )
-    );
-  }
+  // Update object props.
+  $ecasDenieAuth->set(array(
+    'message_args' => array(
+      '%ecas_name' => (!empty($ecas_name)) ? $ecas_name : 'Unknown user name',
+    ),
+  ));
+
+  // Check if ecas attributes are available.
+  $ecasDenieAuth->check('eu_login_account_attributes', (empty($ecas_attributes) || empty($ecas_name)) ? TRUE : FALSE);
 
   $ecas_social_login = $ecas_attributes['cas:employeeType'];
   $ecas_user_language = ecas_get_ecas_user_language($ecas_attributes);
@@ -588,61 +582,43 @@ function ecas_login_check() {
   // There is no save inside, that will be do after further validations.
   $account_edit = ecas_sync_drupal_user_with_ecas_info($account, $ecas_attributes, $ecas_sync_user_info_args);
 
+  // Update object props.
+  $ecasDenieAuth->set(
+    array(
+      'message_args' => array(
+        '%ecas_name' => $ecas_name,
+      ),
+      'language' => $ecas_user_language,
+    )
+  );
+
   // Before saving and as we gave a last chance to other modules to change the
   // user data, check the validity of the user that must be saved.
   // The ecas user must have a defined e-mail; otherwise the drupal
   // authentication is denied.
-  if (empty($account_edit['mail'])) {
-    _ecas_warning_goto(
-      ECAS_WARNING_REASON_NO_EMAIL,
-      $ecas_user_language,
-      'Login denied for %ecas_name because it has no e-mail defined.',
-      array(
-        '%ecas_name' => $ecas_name,
-      )
-    );
-  }
+  $ecasDenieAuth->check('e-mail_defined', (empty($account_edit['mail'])) ? TRUE : FALSE);
 
   // Check that the email is not used for another account; otherwise the drupal
   // authentication is denied.
-  if ($ecas_social_login == 'v' && ecas_is_email_already_used($account_edit['mail'], $account)) {
-    _ecas_warning_goto(
-      ECAS_WARNING_REASON_EXISTING_EMAIL,
-      $ecas_user_language,
-      'Login denied for %ecas_name because the e-mail is already used by another account.',
-      array(
-        '%ecas_name' => $ecas_name,
-      )
-    );
-  }
+  $ecasDenieAuth->check('e-mail_exists', ($ecas_social_login == 'v' && ecas_is_email_already_used($account_edit['mail'], $account)) ? TRUE : FALSE);
 
   // Check that social login user has authenticated role only.
   $authenticated_role = user_role_load_by_name('authenticated user');
 
-  if ($ecas_social_login == 'v' && (user_has_role($authenticated_role->rid, $account) && count($account->roles) > 1)) {
-    _ecas_warning_goto(
-      ECAS_WARNING_REASON_SOCIAL,
-      $ecas_user_language,
-      'Login denied for %ecas_name because the account has more then authenticated role.',
-      array(
-        '%ecas_name' => $ecas_name,
-      )
-    );
-  }
+  $ecasDenieAuth->check('social_login_role',
+    ($ecas_social_login == 'v' && (user_has_role($authenticated_role->rid, $account) && count($account->roles) > 1)) ? TRUE : FALSE);
 
   // Time to save the user.
   $saved_account = ecas_save_user($account, $account_edit, $ecas_attributes, $ecas_sync_user_info_args);
 
-  if (empty($saved_account->status)) {
-    _ecas_warning_goto(
-      ECAS_WARNING_REASON_BLOCKED,
-      $ecas_user_language,
-      'Login denied for %ecas_name because the account is not active yet.',
-      array(
-        '%ecas_name' => $ecas_name,
-      )
-    );
-  }
+  // Check account status.
+  $ecasDenieAuth->check('account_status', (empty($saved_account->status)) ? TRUE : FALSE);
+
+  // Check EU Login authentication strength.
+  $ecasDenieAuth->check('authentication_strength', FALSE, array(
+    'user_roles' => $saved_account->roles,
+    'login_strengths' => $ecas_attributes['cas:strengths'],
+  ));
 
   // Finalize the user login.
   $user = $saved_account;
@@ -774,6 +750,11 @@ function ecas_warning_page($reason) {
 
     case ECAS_WARNING_REASON_INCOMPLETE_USER:
       $message_key = ECAS_WARNING_MESSAGE_INCOMPLETE_USER;
+      break;
+
+    case ECAS_WARNING_TFA_REQUIRED:
+      $theme_variables['warning_title'] = t("Your site's account requirements are not met.");
+      $message_key = ECAS_WARNING_MESSAGE_TFA_REQUIRED;
       break;
 
     default:
@@ -1222,13 +1203,12 @@ function _ecas_force_login() {
 
 /**
  * End session and set global variable $user to anonymous.
+ *
+ * This function has been replaced by EcasDenieAuth::endSession() but
+ * better keep it in case of subsites call.
  */
 function _ecas_session_end() {
-  global $user;
-
-  session_destroy();
-
-  $user = drupal_anonymous_user();
+  EcasDenieAuth::endSession();
 }
 
 /**
@@ -1244,6 +1224,9 @@ function _ecas_get_site_frontpage_full_url() {
 /**
  * Triggers the redirection to the ecas warning page with the right parameters.
  *
+ * This function has been replaced by EcasDenieAuth::redirect() but better keep
+ * it in case of subsites call.
+ *
  * @param string $path_page_argument
  *   The warning page argument to use for the redirection.
  * @param object $language
@@ -1257,28 +1240,18 @@ function _ecas_get_site_frontpage_full_url() {
  *
  * @see drupal_goto()
  */
-function _ecas_warning_goto($path_page_argument, $language = NULL, $message = NULL, array $message_args = array()) {
-  if (!empty($message)) {
-    watchdog('user', $message, $message_args, WATCHDOG_ERROR);
-  }
+function _ecas_warning_goto($path_page_argument, $language = NULL, $message = '', array $message_args = array()) {
 
-  if (empty($language)) {
-    $language = language_default();
-  }
+  // Instanciate EcasDenieAuth object.
+  $ecasDenieAuth = new EcasDenieAuth(array(
+    'language' => $language,
+    'message_args' => $message_args,
+  ));
 
-  _ecas_session_end();
-
-  // Ensure that the user is correctly redirected to warning page because
-  // if drupal_goto() detects an internal path in destination parameter, it
-  // will use it instead of the submitted parameters, see function code.
-  if (isset($_REQUEST['destination'])) {
-    unset($_REQUEST['destination']);
-  }
-  if (isset($_REQUEST['edit']['destination'])) {
-    unset($_REQUEST['edit']['destination']);
-  }
-
-  drupal_goto('eulogin_warning/' . $path_page_argument, array('language' => $language));
+  $ecasDenieAuth->redirect(array(
+    'page_argument' => $path_page_argument,
+    'message' => $message,
+  ));
 }
 
 /**
@@ -1350,6 +1323,13 @@ EOF;
 EOF;
       break;
 
+    case ECAS_WARNING_MESSAGE_TFA_REQUIRED:
+      $value = <<< EOF
+      You just logged in using a one factor authentication method (I.e. Password) when your account requires a stronger authentication.
+      Please reiterate your authentication by choosing a more secured authentication method (I.e. Mobile Phone + SMS).
+EOF;
+      break;
+
     default:
       $value = "The reason is unknown. Please contact the site's administrator.";
       break;
@@ -1373,4 +1353,17 @@ EOF;
  */
 function _ecas_get_default_login_message() {
   return 'Logged in via EU Login as %ecas_username.';
+}
+
+/**
+ * Check if a path corresponds to a warning page.
+ *
+ * @param string $path
+ *   The path to check.
+ *
+ * @return bool
+ *   TRUE if $path corresponds to a warning page.
+ */
+function _ecas_is_warning_page($path) {
+  return strstr($path, 'eulogin_warning');
 }


### PR DESCRIPTION
## NEPT-2862

### Description

Impose EU Login 2 FA for non whitelisted users.

### Change log

- Added: settings.php variable storing whitelisted roles, EcasDenieAuth class that centralize login authentication checks process, new warning page informing user about his account requirements in case of login denial.

- Changed: ecas_login_page() when a user is correctly logged in do not redirect him to a warning page, _ecas_warning_goto() logic moved, _ecas_session_end() logic moved

### Commands

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
