### PR TITLE
NEPT-2613: Removing ftp protocol from ckeditor options.

### DIFF
--- a/profiles/common/modules/features/multisite_wysiwyg/ckeditor/link_alter.js
+++ b/profiles/common/modules/features/multisite_wysiwyg/ckeditor/link_alter.js
@@ -29,6 +29,16 @@
               }
           }
           targetTab.elements[0].children[0].items = optionsToKeep;
+          // NEPT-2613: Block FTP protocol from the wysiwyg filters.
+          // The blocking is also added on the server side using variable "filter_allowed_protocols".
+          var ftpIndex = false;
+          for (i = dialogDefinition.getContents('info').get('protocol')['items'].length - 1; i >= 0; i--) {
+            ftpIndex = dialogDefinition.getContents('info').get('protocol')['items'][i].indexOf("ftp://");
+
+            if (ftpIndex !== -1) {
+              dialogDefinition.getContents('info').get('protocol')['items'].splice(i, 1);
+            }
+          }
         }
     });
 })();


### PR DESCRIPTION
## NEPT-2613

### Description

Removing ftp protocol from ckeditor options.

### Change log

- Removed: ftp option in the ckeditor select list for links protocols


### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
