### PR TITLE
NEPT-2872: Restore file that was erroneously removed in NEPT-2823.

### DIFF
--- a/profiles/common/modules/features/nexteuropa_webtools/nexteuropa_webtools.admin.inc
+++ b/profiles/common/modules/features/nexteuropa_webtools/nexteuropa_webtools.admin.inc
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Administration forms for the NextEuropa Webtools feature.
+ */
+
+/**
+ * Form construction for the NextEuropa Webtools settings form.
+ */
+function nexteuropa_webtools_settings_form() {
+  $form = array();
+
+  $form['nexteuropa_webtools_smartloader_prurl'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Smartloader Protocol-Relative URL'),
+    '#default_value' => variable_get('nexteuropa_webtools_smartloader_prurl', ''),
+    '#description' => t("The URL of the webtools smartloader script. e.g. '//example.com/load.js'"),
+    '#required' => TRUE,
+  );
+
+  return system_settings_form($form);
+}


### PR DESCRIPTION
## NEPT-2872

### Description

[Insert description here]

### Change log

- Added: Restore file that was erroneously removed in NEPT-2823.

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
