### PR TITLE
NEPCB-78: Feature generation according Toolkit PHPCS rules.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_features/nexteuropa_formatters_features.info
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_features/nexteuropa_formatters_features.info
@@ -1,0 +1,9 @@
+name = NextEuropa Formatters - Features
+description = This modules provides features config according Nexteuropa PHPCS.
+package = NextEuropa
+core = 7.x
+
+dependencies[] = nexteuropa_formatters
+dependencies[] = features
+
+registry_autoload[] = PSR-4

--- a/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_features/nexteuropa_formatters_features.module
+++ b/profiles/common/modules/custom/nexteuropa_formatters/nexteuropa_formatters_features/nexteuropa_formatters_features.module
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * Module file.
+ */
+
+/**
+ * Implements hook_features_export_alter().
+ *
+ * Adding PHP Code Sniffer requirements.
+ */
+function nexteuropa_formatters_features_features_export_alter(&$export, $module_name) {
+  $export['multisite_version'] = '2.6';
+  $export['php'] = '7.3';
+}

--- a/profiles/common/modules/features/communities/communities.info
+++ b/profiles/common/modules/features/communities/communities.info
@@ -13,6 +13,7 @@ dependencies[] = og_access
 dependencies[] = og_context
 dependencies[] = workbench_og
 dependencies[] = nexteuropa_formatters
+dependencies[] = nexteuropa_formatters_features
 dependencies[] = nexteuropa_formatters_views
 dependencies[] = multisite_drupal_toolbox
 features[context][] = communities


### PR DESCRIPTION
## NEPCB-78

### Description

Add automatically the 'php' property to the .info file of generated feature, as required by PHPCS.

### Change log

- Added:
 Module 'nexteuropa_formatters_features'


### Commands

drush fe your_feature_name -y