### PR TITLE
NEPT-2878: Fix inconsistency in old installs for the min version of Jquery

### DIFF
--- a/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
+++ b/profiles/common/modules/features/cce_basic_config/cce_basic_config.install
@@ -1941,3 +1941,14 @@ function cce_basic_config_update_7236() {
 function cce_basic_config_update_7237() {
   variable_set('user_failed_login_ip_limit', 5);
 }
+
+/**
+ * Use jquery 1.7 in admin UI if anyone has a lower version.
+ */
+function cce_basic_config_update_7238() {
+  $current_version = variable_get('jquery_update_jquery_admin_version');
+  $target_version = '1.7';
+  if (version_compare($target_version, $current_version, '>')) {
+    variable_set('jquery_update_jquery_admin_version', $target_version);
+  }
+}


### PR DESCRIPTION
## NEPT-2878

### Description

Fix inconsistency in old installs for the min version of Jquery

### Change log

- Added: hook_update to updame Jquery min version to min 1.7 if website has a lower version

### Commands

`drush updb`

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
