### PR TITLE
NEPT-2880: Upgrade newsroom to latest version.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -559,7 +559,7 @@ projects[nagios][patch][] = https://www.drupal.org/files/issues/nagios-id-suppor
 
 projects[nexteuropa_newsroom][download][type] = git
 projects[nexteuropa_newsroom][download][url] = https://github.com/ec-europa/nexteuropa-newsroom-reference.git
-projects[nexteuropa_newsroom][download][tag] = v3.5.15
+projects[nexteuropa_newsroom][download][tag] = v3.5.17
 projects[nexteuropa_newsroom][subdir] = custom
 
 projects[og][subdir] = "contrib"


### PR DESCRIPTION
## NEPT-2880

### Description

Upgrade newsroom to version 3.5.17.

### Change log

- Changed: Newsroom version

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
