### PR TITLE
NEPT-2887: Patch for DTT sites only.

### DIFF
--- a/.opts.yml
+++ b/.opts.yml
@@ -1,0 +1,1 @@
+selenium_version: 3.141.5

--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -93,3 +93,8 @@ projects[drupal][patch][] = https://www.drupal.org/files/locale.module-array_uns
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2201
 ; https://www.drupal.org/project/drupal/issues/421586
 projects[drupal][patch][] = https://www.drupal.org/files/issues/2019-08-19/node-post-setting-with-test-421586-31.patch
+
+; Add missing primary key to taxonomy_index and fix duplicate.
+; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2845
+; See https://www.drupal.org/project/drupal/issues/610076
+projects[drupal][patch][] = https://www.drupal.org/files/issues/2020-06-18/drupal-n610076-86.patch


### PR DESCRIPTION
## NEPT-2887
### Description

Add private keys in 2.5 for DTT only

### Change log

- Added: Patch related to d.o 610076

### Commands

´´´drush updb´´´

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
