### PR TITLE
NEPT-2895: Do not switch on the 2AF enforcement by default

### DIFF
--- a/profiles/common/modules/custom/ecas/README.md
+++ b/profiles/common/modules/custom/ecas/README.md
@@ -135,6 +135,11 @@ roles
 - for the community multisite : it provides a mapping between DG and og roles in
 communities
 
+- release 2.6.x allows to improve security level of sites which allow logging in
+using 1AF. When the array 'ecas_whitelisted_user_roles' is present in the
+settings.php file, EU login will only allow 1AF for a user if all her/his roles
+are included. An empty array will force 2AF on all users.
+This variable should be set in the settings.php file of the site.
 
 Usage
 -----

--- a/profiles/common/modules/custom/ecas/includes/EcasDenyAuth.inc
+++ b/profiles/common/modules/custom/ecas/includes/EcasDenyAuth.inc
@@ -116,11 +116,13 @@ class EcasDenyAuth {
 
   /**
    * Private method checking if current user has only whitelisted roles.
+   *
+   * First checks if the functionality should be enabled.
    */
   private function userRolesAreWhitelisted() {
     $userRoles = $this->extend['user_roles'];
-    $whitelistedRoles = variable_get('ecas_whitelisted_user_roles', array());
-    $userIsWhitelisted = empty(array_diff($userRoles, $whitelistedRoles));
+    $whitelistedRoles = variable_get('ecas_whitelisted_user_roles', NULL);
+    $userIsWhitelisted = !isset($whitelistedRoles) ? TRUE : empty(array_diff($userRoles, $whitelistedRoles));
 
     return $userIsWhitelisted;
   }


### PR DESCRIPTION
## NEPT-2895

### Description

If the "ecas_whitelisted_user_roles" is not present, do not enforce the 2AF

### Change log

- Changed:  2AF is not enforced by default


### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
