### PR TITLE
NEPT-2879: Remove the problematic constant CCE_BASIC_CONFIG_CEM_ROLE_NAME

### DIFF
--- a/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.constants.inc
@@ -51,11 +51,6 @@ define('ECAS_LOGIN_EXLUDE_PAGES', 0);
 define('ECAS_LOGIN_INCLUDE_PAGES', 1);
 
 /**
-  * ECAS group for CEM team users.
-  */
-define('ECAS_CEM_ECAS_GROUP', 'COMM_CEM');
-
-/**
   * Name of the ecas login message variable.
   */
 define('ECAS_LOGIN_MESSAGE', 'ecas_login_message');

--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -451,7 +451,7 @@ function ecas_ecas_sync_user_info($user, array $user_info, array &$edit, array $
     $user_cas_groups = (array) $user_info['cas:groups']['cas:group'];
   }
   $administrator_role = user_role_load_by_name("administrator");
-  $cem_role = user_role_load_by_name(CCE_BASIC_CONFIG_CEM_ROLE_NAME);
+  $cem_role = user_role_load_by_name("cem");
   $user_roles = (isset($user->roles)) ? $user->roles : array();
   // When a user logs using ecas, if they have the cem role on the site, we
   // remove cem and administrator roles from their profiles and keep the rest.
@@ -461,7 +461,7 @@ function ecas_ecas_sync_user_info($user, array $user_info, array &$edit, array $
       unset($user_roles[$administrator_role->rid]);
     }
   }
-  if (in_array(ECAS_CEM_ECAS_GROUP, $user_cas_groups)) {
+  if (in_array("COMM_CEM", $user_cas_groups)) {
     $user_roles[$cem_role->rid] = $cem_role->name;
     $user_roles[$administrator_role->rid] = $administrator_role->name;
     watchdog(


### PR DESCRIPTION
## NEPT-2879

### Description

2.5. backport of the PR #2967 

### Change log

- Changed: "profiles/common/modules/custom/ecas/includes/ecas.constants.inc", remove the "ECAS_CEM_ECAS_GROUP" constant declaration.
- Changed: "profiles/common/modules/custom/ecas/includes/ecas.inc", remove the call to the constants "CCE_BASIC_CONFIG_CEM_ROLE_NAME" and "ECAS_CEM_ECAS_GROUP".
Commands

No command execution required

Checklist

- [x ] Check if there are hook_updates and they are documented
- [x ] Add right labels to indicate in the devops ticket the commands to run
- [x ] Remove symlinks if it's a module removal
