### PR TITLE
NEPT-2922: TMGMT OG - unable to accept translation

### DIFF
--- a/profiles/common/modules/custom/tmgmt_og/tmgmt_og.module
+++ b/profiles/common/modules/custom/tmgmt_og/tmgmt_og.module
@@ -115,6 +115,24 @@ function tmgmt_og_menu_alter(&$items) {
       $item['title'] = isset($item['title']) ? $item['title'] : '';
       $item['title arguments'] = isset($item['title arguments']) ? $item['title arguments'] : array($item['title']);
       $item['title callback'] = isset($item['title callback']) ? $item['title callback'] : 't';
+
+      // If it's menu default local task and has missing access callback we use
+      // the callback from the parent.
+      if (($item['type'] == MENU_DEFAULT_LOCAL_TASK) && !isset($item['access callback'])) {
+        $parent_path = explode('/', $path);
+        array_pop($parent_path);
+        $parent_path = implode('/', $parent_path);
+        $parent = isset($items[$parent_path]) ? $items[$parent_path] : FALSE;
+        if ($parent) {
+          if (isset($parent['access callback'])) {
+            $item['access callback'] = $items[$parent_path]['access callback'];
+          }
+          if (!isset($item['access arguments']) && isset($parent['access arguments'])) {
+            $item['access arguments'] = $items[$parent_path]['access arguments'];
+          }
+        }
+      }
+
       $item['access arguments'] = isset($item['access arguments']) ? $item['access arguments'] : array();
       $item['access callback'] = isset($item['access callback']) ? $item['access callback'] : 'user_access';
 

--- a/profiles/common/modules/custom/tmgmt_og/tmgmt_og.module
+++ b/profiles/common/modules/custom/tmgmt_og/tmgmt_og.module
@@ -118,7 +118,7 @@ function tmgmt_og_menu_alter(&$items) {
 
       // If it's menu default local task and has missing access callback we use
       // the callback from the parent.
-      if (($item['type'] == MENU_DEFAULT_LOCAL_TASK) && !isset($item['access callback'])) {
+      if (!empty($item['type']) && ($item['type'] == MENU_DEFAULT_LOCAL_TASK) && !isset($item['access callback'])) {
         $parent_path = explode('/', $path);
         array_pop($parent_path);
         $parent_path = implode('/', $parent_path);


### PR DESCRIPTION
## NEPT-2922

### Description

Fixed access callback for menu default local task item in tmgmt_og.

### Change log

- Fixed: tmgmt_og_menu_alter().

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
