### PR TITLE
NEPT-000: Nexteuropa tracked changes avoid error.

### DIFF
--- a/profiles/common/modules/features/nexteuropa_trackedchanges/js/nexteuropa_trackedchanges_ckeditor.js
+++ b/profiles/common/modules/features/nexteuropa_trackedchanges/js/nexteuropa_trackedchanges_ckeditor.js
@@ -21,18 +21,20 @@
           }
         }
 
-        for (var i in CKEDITOR.instances) {
-          CKEDITOR.instances[i].on('configLoaded', function (event) {
-            filterTracked(event);
-          });
+        if (typeof CKEDITOR !== 'undefined') {
+          for (var i in CKEDITOR.instances) {
+            CKEDITOR.instances[i].on('configLoaded', function (event) {
+              filterTracked(event);
+            });
 
-          CKEDITOR.instances[i].on('change', function (event) {
-            filterTracked(event);
-          });
+            CKEDITOR.instances[i].on('change', function (event) {
+              filterTracked(event);
+            });
 
-          CKEDITOR.instances[i].on('afterCommandExec', function (event) {
-            filterTracked(event);
-          });
+            CKEDITOR.instances[i].on('afterCommandExec', function (event) {
+              filterTracked(event);
+            });
+          }
         }
       });
     }


### PR DESCRIPTION
## NEPT-000

### Description

When a content type do not have any wysiwyg field present, the nexteuropa_trackedchanges will throw a error when accessing a node edit form.

This is an example on the Info site for a content type that do not have a wysiwyg field.
![Screenshot 2021-05-04 at 09 44 40](https://user-images.githubusercontent.com/1574795/116974146-ed99ad00-acbd-11eb-8bbc-f2d97f829604.png)

The fix that I propose is just to check if variable `CKEDITOR` exists.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

[Insert commands here]

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal

### Notes

Please let me know if I should create a ticket for this.
Thank you