### PR TITLE
NEPT-2919: Remove uninstall of the contrib module from the feature.

### DIFF
--- a/profiles/common/modules/features/multisite_eu_cookie_compliance/multisite_eu_cookie_compliance.install
+++ b/profiles/common/modules/features/multisite_eu_cookie_compliance/multisite_eu_cookie_compliance.install
@@ -53,7 +53,6 @@ function multisite_eu_cookie_compliance_enable() {
  * Implements hook_disable().
  */
 function multisite_eu_cookie_compliance_disable() {
-  module_disable(array('eu_cookie_compliance'));
   drupal_set_message(t('EU Cookie Compliance feature is now disabled on your site.'));
 }
 


### PR DESCRIPTION
## NEPT-2919

### Description

Uninstall call in the feature generates infinite loop.

### Change log

- Removed: call do the module disable on the contrib module.

### Commands

[Insert commands here]

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
