### PR TITLE
NEPT-2927: Initialise not null so that it's not null.

### DIFF
--- a/profiles/common/modules/custom/ecas/ecas_group_sync/ecas_group_sync.install
+++ b/profiles/common/modules/custom/ecas/ecas_group_sync/ecas_group_sync.install
@@ -80,6 +80,7 @@ function ecas_group_sync_update_7001() {
       'description' => 'Primary Key: Unique sync mapping ID.',
       'type' => 'int',
       'not null' => TRUE,
+      'initial' => '0',
     ));
   // https://api.drupal.org/api/drupal/includes%21database%21database.inc/function/db_change_field/7.x
   db_change_field($db_table, 'id', 'id', array(


### PR DESCRIPTION
## NEPT-2927

### Description

Fix error Null value not allowed: 1138 Invalid use of NULL value   

### Change log

- Changed: ecas_group_sync hook update to support primary keys


### Commands

[Insert commands here]

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
