### PR TITLE
NEPT-2931: Release 2.6.15

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -45,11 +45,6 @@ projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal_add_js_sa
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-64
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-doc-theme-attributes-d7-569362-53.patch
 
-; Fix empty label on validation error message for multiple required textfield.
-; https://www.drupal.org/node/980144#comment-11695545
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-224
-projects[drupal][patch][] = https://www.drupal.org/files/issues/980144-98_0.patch
-
 ; Reverting to revisions prior to addition of field translations is broken.
 ; https://www.drupal.org/node/1992010
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-495

--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = "core"
-projects[drupal][version] = "7.80"
+projects[drupal][version] = "7.81"
 
 ; AJAX callbacks not properly working with the language url suffix.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-4268

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -188,6 +188,7 @@ projects[ds][version] = "2.16"
 
 projects[easy_breadcrumb][subdir] = "contrib"
 projects[easy_breadcrumb][version] = "2.17"
+projects[easy_breadcrumb][patch][] = https://www.drupal.org/files/issues/2020-12-18/easy_breadcrumb_query_array.patch
 
 projects[email][subdir] = "contrib"
 projects[email][version] = "1.3"


### PR DESCRIPTION
## NEPT-2931

### Description

Release 2.6.15

### Change log

- Changed: https://webgate.ec.europa.eu/fpfis/wikis/display/openeukb/Release+notes+2.6.15

### Commands

[Insert commands here]

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
