### PR TITLE
NEPT-2917: Replace drupal_json_decode to allow setting FALSE as second param for geofield.

### DIFF
--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -56,7 +56,7 @@
         <exclude-pattern>profiles/common/modules/custom/nexteuropa_dgt_connector/tmgmt_poetry/tmgmt_poetry.module</exclude-pattern>
         <exclude-pattern>profiles/common/modules/custom/nexteuropa_dgt_connector/tmgmt_poetry/inc/tmgmt_poetry.webservice.inc</exclude-pattern>
     </rule>
-
+    
     <!-- Tmgmt poetry tests not strictly follow Drupal class name conventions. -->
     <rule ref="Drupal.NamingConventions.ValidClassName">
         <exclude-pattern>profiles/common/modules/custom/nexteuropa_dgt_connector/tmgmt_poetry/tests/tmgmt_poetry.test</exclude-pattern>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -143,8 +143,4 @@
         <exclude-pattern>*/CHANGELOG.md</exclude-pattern>
         <exclude-pattern>*/CHANGELOG.txt</exclude-pattern>
     </rule>
-    <!-- NEPT-2917: ignore use of json_decode in nexteuropa_geofield -->
-    <rule ref="QualityAssurance.Functions.JsonDecode.FoundWithAlternative">
-        <exclude-pattern>profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module</exclude-pattern>
-    </rule>
 </ruleset>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -143,4 +143,8 @@
         <exclude-pattern>*/CHANGELOG.md</exclude-pattern>
         <exclude-pattern>*/CHANGELOG.txt</exclude-pattern>
     </rule>
+    <!-- NEPT-2917: ignore use of json_decode in nexteuropa_geofield -->
+    <rule ref="QualityAssurance.Functions.JsonDecode.FoundWithAlternative">
+        <exclude-pattern>profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module</exclude-pattern>
+    </rule>
 </ruleset>

--- a/profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module
+++ b/profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module
@@ -451,7 +451,7 @@ function _nexteuropa_geofield_geocode($form, $form_state) {
       $error = $geocode->error;
     }
     else {
-      $geocode_decoded = drupal_json_decode($geocode->data);
+      $geocode_decoded = json_decode($geocode->data);
 
       if ($geocode_decoded->geocodingRequestsCollection[0]->foundCount < 1) {
         $error = t('No address found.');

--- a/profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module
+++ b/profiles/common/modules/features/nexteuropa_geofield/nexteuropa_geofield.module
@@ -451,8 +451,9 @@ function _nexteuropa_geofield_geocode($form, $form_state) {
       $error = $geocode->error;
     }
     else {
-      $geocode_decoded = json_decode($geocode->data);
-
+      // @codingStandardsIgnoreStart.
+      $geocode_decoded = json_decode($geocode->data, FALSE);
+      // @codingStandardsIgnoreEnd
       if ($geocode_decoded->geocodingRequestsCollection[0]->foundCount < 1) {
         $error = t('No address found.');
       }


### PR DESCRIPTION
## NEPT-2917

### Description

nexteuropa_geofield no longer working after 2.6 CS fixes

### Change log

- Added:
- Changed: nexteuropa_geofield.module
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

[Insert commands here]

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
