### PR TITLE
NEPT-2933: Add permission to PIWIK Administrator.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.install
+++ b/profiles/common/modules/custom/nexteuropa_piwik/nexteuropa_piwik.install
@@ -89,6 +89,7 @@ function nexteuropa_piwik_enable() {
   // Define permissions for role.
   $piwik_admin_permissions = array(
     'administer nexteuropa_piwik' => TRUE,
+    'administer site configuration' => TRUE,
   );
   // Grant the permissions to PIWIK administrator role.
   user_role_change_permissions($piwik_admin_role->rid, $piwik_admin_permissions);
@@ -112,4 +113,13 @@ function nexteuropa_piwik_update_7101() {
     'nexteuropa_piwik_rule',
     _nexteuropa_piwik_get_schema_array()
   );
+}
+
+/**
+ * Add the Administer site configuration permission to the role.
+ */
+function nexteuropa_piwik_update_7102() {
+  $piwik_administrator = user_role_load_by_name('PIWIK administrator');
+  $rid = $piwik_administrator->rid;
+  user_role_grant_permissions($rid, array('administer site configuration'));
 }


### PR DESCRIPTION
## NEPT-2933

### Description

Add permission to configure to PIWIK Administrator

### Change log

- Security: Permission to configure Piwik

### Commands

```drush updb```

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
