### PR TITLE
NEPT-2936: Fixed displaying the language_selector_page block.

### DIFF
--- a/profiles/common/modules/custom/language_selector_page/language_selector_page.module
+++ b/profiles/common/modules/custom/language_selector_page/language_selector_page.module
@@ -70,7 +70,10 @@ function language_selector_page_block_content() {
 
       // Get currently served language.
       $served_code = entity_translation_get_existing_language('node', $node);
-      $translation_access = entity_translation_access('node', $node->translations->data[$served_code]);
+      $translation_access = FALSE;
+      if (isset($node->translations->data[$served_code])) {
+        $translation_access = entity_translation_access('node', $node->translations->data[$served_code]);
+      }
       $fallback_enabled = variable_get('locale_field_language_fallback', TRUE);
       // Get the fallback language if an entity translation is not accessible.
       if (!$translation_access && $fallback_enabled) {

--- a/profiles/common/modules/custom/language_selector_page/language_selector_page.module
+++ b/profiles/common/modules/custom/language_selector_page/language_selector_page.module
@@ -70,12 +70,23 @@ function language_selector_page_block_content() {
 
       // Get currently served language.
       $served_code = entity_translation_get_existing_language('node', $node);
+      $translation_access = entity_translation_access('node', $node->translations->data[$served_code]);
+      $fallback_enabled = variable_get('locale_field_language_fallback', TRUE);
+      // Get the fallback language if an entity translation is not accessible.
+      if (!$translation_access && $fallback_enabled) {
+        $fallback = drupal_multilingual() ? language_fallback_get_candidates() : array(LANGUAGE_NONE);
+        $served_code = array_shift($fallback);
+      }
       $served = $languages[1][$served_code];
 
-      // Display the switcher only if the current language is not available.
-      if (!in_array($language->language, array_keys($node->translations->data))) {
+      // Display the switcher if the entity translation is not available or is
+      // not accessible while fallback is allowed.
+      if (!in_array($language->language, array_keys($node->translations->data)) || (!$translation_access && $fallback_enabled)) {
         // Check available translations.
         foreach ($node->translations->data as $code => $lang) {
+          if (empty($lang['status'])) {
+            continue;
+          }
           if ($code == $language->language) {
             $is_available = TRUE;
           }


### PR DESCRIPTION
## NEPT-2936

### Description

Fixed displaying language_selector_page block when a translation is unpublished.

### Change log

- Changed: language_selector_page_block_content()

### Commands

No command execution is required.

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
