### PR TITLE
NEPT-2944: Default login error message improvement.

### DIFF
--- a/profiles/common/modules/custom/ecas/includes/ecas.inc
+++ b/profiles/common/modules/custom/ecas/includes/ecas.inc
@@ -723,7 +723,7 @@ function ecas_block_info() {
  *   The themed warning page display.
  */
 function ecas_warning_page($reason) {
-  $theme_variables = array('warning_title' => t("Your site's account cannot be created"));
+  $theme_variables = array('warning_title' => t("EU LOGIN connection error – Retry in few minutes"));
 
   switch ($reason) {
     case ECAS_WARNING_REASON_SOCIAL:


### PR DESCRIPTION
## NEPT-2944

### Description

When CAS login fails and the error is not caught (unknown), the default title for the page was "we couldn't create the account", even though it could happen on a regular login attempt when the account already exists.
To prevent this misleading message, it has been updated to: "EU LOGIN connection error – Retry in few minutes".

### Change log

- Changed: default error page title.

### Commands

[Insert commands here]

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
