### PR TITLE
NEPT-2947: Update Core to 7.83

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -2,7 +2,7 @@ api = 2
 core = 7.x
 
 projects[drupal][type] = "core"
-projects[drupal][version] = "7.82"
+projects[drupal][version] = "7.83"
 
 ; AJAX callbacks not properly working with the language url suffix.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-4268


### PR DESCRIPTION
## NEPT-2947

### Description

Update Core to 7.83

### Change log

- Changed: Drupal Core version

### Commands

[Insert commands here]

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
