### PR TITLE
NEPT-2949: Views update to 3.25.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -828,7 +828,7 @@ projects[video][patch][] = patches/video-security-883.patch
 projects[video][patch][] = https://www.drupal.org/files/issues/2019-08-20/continue_in_switch-3042169-2.patch
 
 projects[views][subdir] = "contrib"
-projects[views][version] = 3.23
+projects[views][version] = 3.25
 ; Default argument not skipped in breadcrumbs
 ; https://www.drupal.org/node/1201160
 projects[views][patch][] = https://www.drupal.org/files/issues/views-contextual_filter_exception_breadcrumbs-1201160-17.patch
@@ -837,10 +837,6 @@ projects[views][patch][] = https://www.drupal.org/files/issues/views-contextual_
 ; https://www.drupal.org/project/views/issues/3012609
 ; https://www.drupal.org/project/views/issues/1809958
 projects[views][patch][] = https://www.drupal.org/files/issues/2019-07-09/issues-ajax-exposed-filters-blocks-1809958-74.patch
-; Issue 3076826: func_get_args(), no longer report the original value as passed to a parameter
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2641
-; https://www.drupal.org/project/views/issues/3076826
-projects[views][patch][] = https://www.drupal.org/files/issues/2019-08-23/views-php7-3076826-2.patch
 
 projects[views_ajax_history][subdir] = "contrib"
 projects[views_ajax_history][version] = "1.0"


### PR DESCRIPTION
## NEPT-2949

### Description

Update views to 3.25. Fixes php 7.4 notice messages.

### Change log

- Changed: views from 3.23 to 3.25
- Fixed: php 7.4 notice deprecated syntax messages

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
