### PR TITLE
NEPT-2953: php 7.4 deprecated syntax.

### DIFF
--- a/profiles/common/modules/custom/nexteuropa_token/src/HashTokenHandler.php
+++ b/profiles/common/modules/custom/nexteuropa_token/src/HashTokenHandler.php
@@ -197,7 +197,7 @@ class HashTokenHandler extends TokenAbstractHandler {
     $crumbs = $numeric;
     for ($i = 0; $i < count($charset); $i++) {
       $position = $crumbs % drupal_strlen($charset[$i]);
-      $hash .= $charset[$i]{$position};
+      $hash .= $charset[$i][$position];
       $crumbs = round($crumbs / drupal_strlen($charset[$i]));
     }
     return $hash;


### PR DESCRIPTION
## NEPT-2953

### Description

There is a deprecated syntax use in Nexteuropa token that triggers a warning with php 7.4:

`Deprecated: Array and string offset access syntax with curly braces is deprecated in /home/ec2-user/environment/chafea-dev/build/profiles/common/modules/custom/nexteuropa_token/src/HashTokenHandler.php on line 200`

### Change log

- Changed: Use of curly braces changed to brackets

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
