### PR TITLE
NEPT-2959: Update 'token' 1.7 => 1.8.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -777,10 +777,8 @@ projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2020-02-26/transl
 projects[tmgmt][patch][] = https://www.drupal.org/files/issues/2019-04-24/count_error_php_7_2-3050356-2.patch
 
 projects[token][subdir] = "contrib"
-projects[token][version] = "1.7"
-; #1058912: Prevent recursive tokens
-; https://www.drupal.org/node/1058912
-projects[token][patch][] = https://www.drupal.org/files/token-1058912-88-limit-token-depth.patch
+projects[token][version] = "1.8"
+projects[token][patch][1058912] = https://www.drupal.org/files/token-1058912-88-limit-token-depth.patch
 
 projects[token_filter][subdir] = "contrib"
 projects[token_filter][version] = 1.1


### PR DESCRIPTION
## NEPT-2959

### Description

After upgrading to PHP 7.4: 

Warning: strnatcmp() expects parameter 2 to be string, array given in token_asort_tokens() (line 579 of /home/ec2-user/environment/maritimeforum-dev/build/profiles/multisite_drupal_communities/modules/contrib/token/token.module).

### Change log

- Changed: Upgrade token module version