### PR TITLE
NEPT-2961: Fix php 7.4 notice.

### DIFF
--- a/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.callbacks.inc
+++ b/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.callbacks.inc
@@ -147,7 +147,7 @@ function nexteuropa_multilingual_language_negotiation_split_suffix($path, array 
   $languages_with_suffix = _nexteuropa_multilingual_get_languages_with_suffix($languages);
 
   $languages_suffix = array_keys($languages_with_suffix);
-  $pattern = '/' . $delimiter . '(' . implode($languages_suffix, '|') . ')(\/|$)/';
+  $pattern = '/' . $delimiter . '(' . implode('|', $languages_suffix) . ')(\/|$)/';
   // Search the language suffix with the delimiter in the path.
   if (!preg_match($pattern, $path)) {
     // No language suffix found.


### PR DESCRIPTION
## NEPT-2961

### Description

There is a deprecated syntax use in Nexteuropa multilingual that triggers a warning with php 7.4:

Deprecated function: implode(): Passing glue string after array is deprecated. Swap the parameters in nexteuropa_multilingual_language_negotiation_split_suffix() (line 150 of /home/ec2-user/environment/service-catalogue-dev/build/profiles/common/modules/features/nexteuropa_multilingual/nexteuropa_multilingual.callbacks.inc).

### Change log

- Changed: implode($array, $separator) to implode($separator, $array)

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
