### PR TITLE
NEPT-2964: Wysiwyg 2.9 update

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -953,15 +953,12 @@ projects[workbench_og][patch][] = patches/workbench_og_grants.patch
 
 ; Fix version on a commit, see issue NEPT-2247
 projects[wysiwyg][subdir] = "contrib"
-projects[wysiwyg][download][type] = "git"
-projects[wysiwyg][download][url] = "http://git.drupal.org/project/wysiwyg.git"
-projects[wysiwyg][download][revision] = "18832abda6a2a6df93b72a6edb8b980d1e948605"
+projects[wysiwyg][version] = "2.9"
 ; CKEditor height does not reflect the rows attribute
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2185
-projects[wysiwyg][patch][2410565] = https://www.drupal.org/files/issues/wysiwyg-heights.2410565.5.patch
-; Error highlight missing on wysiwyg
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2199
-projects[wysiwyg][patch][] = https://www.drupal.org/files/issues/wysiwyg-highlighting-required-field-error-2685519-2.patch
+projects[wysiwyg][patch][2410565] = https://www.drupal.org/files/issues/2022-01-06/wysiwyg-heights.2410565.9.patch
+; PHP 7.3 compliance.
+projects[wysiwyg][patch][] = https://www.drupal.org/files/issues/2022-02-01/wysiwyg-php7-compatibility-3261512_1.patch
 
 projects[xml_field][subdir] = "contrib"
 projects[xml_field][version] = "2.3"


### PR DESCRIPTION
## NEPT-2964

### Description

Update WYSIWYG module to 2.9 version.

### Change log

- Changed: WYSIWYG module to 2.9 with rerolled patches
- Removed: Error highlight missing on wysiwyg (not needed anymore) https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2199

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
