### PR TITLE
Nept 2964

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -958,7 +958,9 @@ projects[wysiwyg][version] = "2.9"
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2185
 projects[wysiwyg][patch][2410565] = https://www.drupal.org/files/issues/2022-01-06/wysiwyg-heights.2410565.9.patch
 ; PHP 7.3 compliance.
-projects[wysiwyg][patch][] = https://www.drupal.org/files/issues/2022-02-01/wysiwyg-php7-compatibility-3261512_1.patch
+projects[wysiwyg][patch][3261512] = https://www.drupal.org/files/issues/2022-02-01/wysiwyg-php7-compatibility-3261512_1.patch
+; wysiwyg_deprecation_install_note notice fix.
+projects[wysiwyg][patch][3256637] = https://www.drupal.org/files/issues/2022-01-06/wysiwyg-markitup.3256637.4.patch
 
 projects[xml_field][subdir] = "contrib"
 projects[xml_field][version] = "2.3"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -953,15 +953,12 @@ projects[workbench_og][patch][] = patches/workbench_og_grants.patch
 
 ; Fix version on a commit, see issue NEPT-2247
 projects[wysiwyg][subdir] = "contrib"
-projects[wysiwyg][download][type] = "git"
-projects[wysiwyg][download][url] = "http://git.drupal.org/project/wysiwyg.git"
-projects[wysiwyg][download][revision] = "18832abda6a2a6df93b72a6edb8b980d1e948605"
+projects[wysiwyg][version] = "2.9"
 ; CKEditor height does not reflect the rows attribute
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2185
-projects[wysiwyg][patch][2410565] = https://www.drupal.org/files/issues/wysiwyg-heights.2410565.5.patch
-; Error highlight missing on wysiwyg
-; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2199
-projects[wysiwyg][patch][] = https://www.drupal.org/files/issues/wysiwyg-highlighting-required-field-error-2685519-2.patch
+projects[wysiwyg][patch][2410565] = https://www.drupal.org/files/issues/2022-01-06/wysiwyg-heights.2410565.9.patch
+; PHP 7.3 compliance.
+projects[wysiwyg][patch][] = https://www.drupal.org/files/issues/2022-02-01/wysiwyg-php7-compatibility-3261512_1.patch
 
 projects[xml_field][subdir] = "contrib"
 projects[xml_field][version] = "2.3"

--- a/tests/src/Context/CookieConsentKitContext.php
+++ b/tests/src/Context/CookieConsentKitContext.php
@@ -56,8 +56,9 @@ class CookieConsentKitContext extends RawMinkContext {
 
     /** @var \Behat\Mink\Element\NodeElement $element */
     foreach ($this->getSession()->getPage()->findAll('xpath', $xpath) as $element) {
+      // @codingStandardsIgnoreStart.
       $data = json_decode($element->getText());
-
+      // @codingStandardsIgnoreEnd
       if (!empty($data) && !empty($data->utility) && $data->utility === 'cck') {
         $cck[] = $data;
       }

--- a/tests/src/Context/RulesContext.php
+++ b/tests/src/Context/RulesContext.php
@@ -26,7 +26,9 @@ class RulesContext extends RawDrupalContext {
    */
   public function importRule(PyStringNode $string) {
     $raw = $string->getRaw();
+    // @codingStandardsIgnoreStart.
     $decoded = json_decode($raw, TRUE);
+    // @codingStandardsIgnoreEnd
     $error = '';
     $rule = rules_import(json_encode($decoded), $error);
     if ($rule === FALSE) {


### PR DESCRIPTION
## NEPT-2964

### Description

Since 2.8 an issue has been introduced in deprecation notice function. This issue even though not really important, fails behat testings.

```
Drupal\nexteuropa\Context\MinkContext::visit()
    │
    ╳  1 PHP errors were logged to the watchdog
    ╳  Feature: 'Change tracking features' on '/test/platform/tests/features/feature_set/nexteuropa_trackedchanges_set.feature' line 28
    ╳  Step: 'I go to "admin/config/content/wysiwyg/tracked_changes/table_status"'
    ╳  Errors:
    ╳  ----------
    ╳  Message: Notice: Trying to access array offset on value of type bool in wysiwyg_deprecation_install_note() (line 1491 of /test/platform/profiles/multisite_drupal_standard/modules/contrib/wysiwyg/wysiwyg.module).
    ╳  Location: http://web:8080/build/admin/config/content/wysiwyg/tracked_changes/table_status
    ╳  Referer: 
    ╳  Date/Time: 2022-02-09 19:56:36+01:00
    ╳  
    ╳  ----------
    ╳   (Exception)
    │
    └─ @AfterStep # FeatureContext::checkPhpErrors()
    Then the response should not contain "Tracked changes logs status"                                                 # Drupal\nexteuropa\Context\MinkContext::assertResponseNotContains()
```

### Change log

- Fixed: Notice message in wysiwyg_markitup_install_note

### Commands

./phing build-platform-dev

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
