### PR TITLE
NEPT-2973: Media colorbox 7.4 compatibility.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -480,6 +480,7 @@ projects[media_youtube][patch][] = https://www.drupal.org/files/issues/2021-01-0
 
 projects[media_colorbox][subdir] = "contrib"
 projects[media_colorbox][version] = "1.0-rc4"
+projects[media_colorbox][patch][3155898] = https://www.drupal.org/files/issues/2020-06-30/php-7_4-3155898-1.patch
 
 projects[menu_attributes][subdir] = "contrib"
 projects[menu_attributes][version] = "1.0"


### PR DESCRIPTION
## NEPT-2973

### Description

Patch media colorbox for php 7.4 compatibility.

### Change log

- Changed: Update array curly bracket to bracket. 

### Checklist

- [x] Check if there are hook_updates and they are documented
- [x] Add right labels to indicate in the devops ticket the commands to run
- [x] Remove symlinks if it's a module removal
