### PR TITLE
NEPT-2981: Poetry returns new content from request (behat fix).

### DIFF
--- a/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
+++ b/tests/features/tmgmt/tmgmt_dgt_connector_cart.feature
@@ -99,7 +99,7 @@ Feature: TMGMT Poetry Cart features
     And I fill in "Date" with a relative date of "+20" days
     And I press "Submit to translator"
     Then Poetry service received request should contain the following text:
-      | W1JFRiBDb21tZW50IFBhZ2UgMS |
+      | PD94bWwgdmVyc2lvbj0iMS4wIiB |
 
   @javascript @remove-menus
   Scenario: I can add menu and menu items to cart.


### PR DESCRIPTION
## NEPT-2981

### Description

Poetry returns a new content on successful request. The behat test need to be updated accordingly.

### Change log

- Changed: String assertion on tmgmt_dgt_connector_cart.feature
