### PR TITLE
Feature/nept 2987 php74 module compat

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -19,12 +19,7 @@ projects[administration_language_negotiation][subdir] = "contrib"
 projects[administration_language_negotiation][version] = "1.4"
 
 projects[advagg][subdir] = "contrib"
-projects[advagg][version] = "2.33"
-; NEPT-2790: Scan code for @codingStandardsIgnoreFile and fix
-; https://www.drupal.org/project/advagg/issues/3116299
-projects[advagg][patch][] = https://www.drupal.org/files/issues/2020-02-27/php7_compatibility-3116299-2.patch
-; https://github.com/ec-europa/platform-dev/pull/2869
-projects[advagg][patch][] = https://www.drupal.org/files/issues/2019-06-02/advagg_replace_continue_with_break-3058949-2.patch
+projects[advagg][version] = "2.35"
 
 projects[advanced_help][subdir] = "contrib"
 projects[advanced_help][version] = "1.6"

--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -490,9 +490,12 @@ projects[message][patch][2719823] = https://www.drupal.org/files/issues/message-
 ; https://citnet.tech.ec.europa.eu/CITnet/jira/browse/NEPT-1744
 projects[message][patch][2872964] = https://www.drupal.org/files/issues/2872964-message-cloneajax-2.patch
 
-
 projects[metatag][subdir] = "contrib"
 projects[metatag][version] = "1.28"
+; Prevents metatag_translate_metatags from returning error 500.
+; https://www.drupal.org/project/metatag/issues/3224758
+; https://citnet.tech.ec.europa.eu/CITnet/jira/browse/NEPT-2987
+projects[metatag][patch][3224758] = https://www.drupal.org/files/issues/2021-07-21/metatag-n3224758-2.patch
 
 projects[migrate][subdir] = contrib
 projects[migrate][download][branch] = 7.x-1.x


### PR DESCRIPTION
## NEPT-2987

### Description

Update advagg to the latest version (php 7.4 compatible) and fix an issue with metatag that returns an error 500.

### Change log

- Changed: advagg and metatag
