### PR TITLE
NEPT-2992: Remove patch breaking user autocomplete.

### DIFF
--- a/resources/multisite_drupal_standard.make
+++ b/resources/multisite_drupal_standard.make
@@ -608,7 +608,6 @@ projects[realname][subdir] = "contrib"
 projects[realname][version] = "1.4"
 projects[realname][patch][] = https://www.drupal.org/files/issues/2021-01-20/realname-recursive_bug-1369824-7.x-1.4.patch
 projects[realname][patch][] = https://www.drupal.org/files/issues/2019-05-07/2225889-realname-correct-menu-10.patch
-projects[realname][patch][3263690] = https://www.drupal.org/files/issues/2022-02-10/realname-realname_autocomplete__trying_access_array_offset.patch
 
 projects[redirect][subdir] = "contrib"
 projects[redirect][download][branch] = 7.x-1.x


### PR DESCRIPTION
## NEPT-2992

### Description

Tryint to fix: 
Notice: Trying to access array offset on value of type null in realname_autocomplete() (line 430 of /test/platform/profiles/multisite_drupal_standard/modules/contrib/realname/realname.module).
We introduced an issue that prevent user autocomplete to work when using the realname module.

### Change log

- Removed: Realname patch.
