### PR TITLE
NEPT-2998 Add patch 2313517 on Durpal Core to fix error

### DIFF
--- a/resources/drupal-core.make
+++ b/resources/drupal-core.make
@@ -81,3 +81,6 @@ projects[drupal][patch][610076] = https://www.drupal.org/files/issues/2020-06-18
 ; Add missing primary key to forum.
 ; https://webgate.ec.europa.eu/CITnet/jira/browse/NEPT-2845
 projects[drupal][patch][1466458] = https://www.drupal.org/files/issues/2020-08-03/forum-duplicate_forum_nodes-1466458-35%20.patch
+
+; Fix Date pop up widget breaks exposed views form with Error : Cannot create references to/from string
+projects[drupal][patch][2313517] = https://www.drupal.org/files/issues/2021-12-22/cannot_create_references_tofrom_string_offsets_nor_overloaded_objects-2313517-62.patch


### PR DESCRIPTION
## NEPT-2998

### Description

Patch to fix Bug with Date pop up widget breaks exposed views form with Error : Cannot create references to/from string offsets

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

[Insert commands here]

### Checklist

- [ ] Check if there are hook_updates and they are documented
- [ ] Add right labels to indicate in the devops ticket the commands to run
- [ ] Remove symlinks if it's a module removal
